### PR TITLE
Set System.Text.Json to 8.0.5

### DIFF
--- a/ImGuiApp/ImGuiApp.csproj
+++ b/ImGuiApp/ImGuiApp.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Silk.NET" Version="2.22.0" />
     <PackageReference Include="Silk.NET.Input.Extensions" Version="2.22.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ImGuiAppDemo/ImGuiAppDemo.csproj
+++ b/ImGuiAppDemo/ImGuiAppDemo.csproj
@@ -3,6 +3,9 @@
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\ImGuiApp\ImGuiApp.csproj" />


### PR DESCRIPTION
System.Text.Json is a transitive dependency from Silk.Net and it includes 8.0.0 which has a vulnerability warning, causing compile errors. Explicitly define a version of System.Text.Json within ImGuiApp to a higher version that does not include the vulnerability warning, at least until Silk.Net updates the dependency themselves.