### PR TITLE
Fix compile and runtime errors

### DIFF
--- a/ImGuiApp/ImGuiController/ImGuiController.cs
+++ b/ImGuiApp/ImGuiController/ImGuiController.cs
@@ -201,7 +201,7 @@ internal class ImGuiController : IDisposable
 		io.SetKeyEventNativeData(imGuiKey, (int)keycode, scancode);
 
 		var imguiModKey = TranslateImGuiKeyToImGuiModKey(imGuiKey);
-		if (imguiModKey != ImGuiKey.COUNT)
+		if (imguiModKey != ImGuiKey.NamedKey_END)
 		{
 			io.AddKeyEvent(imguiModKey, down);
 		}
@@ -491,7 +491,7 @@ internal class ImGuiController : IDisposable
 			ImGuiKey.RightAlt => ImGuiKey.ModAlt,
 			ImGuiKey.LeftSuper => ImGuiKey.ModSuper,
 			ImGuiKey.RightSuper => ImGuiKey.ModSuper,
-			_ => ImGuiKey.COUNT
+			_ => ImGuiKey.NamedKey_END
 		};
 	}
 

--- a/ImGuiAppDemo/ImGuiAppDemo.cs
+++ b/ImGuiAppDemo/ImGuiAppDemo.cs
@@ -59,7 +59,7 @@ internal static class ImGuiAppDemo
 			ImGui.PopFont();
 			ImGui.Text("This is a demo of ImGui.NET.");
 		}
-		ImGui.End();
+		ImGui.EndChild();
 	}
 
 	private static void OnMenu()

--- a/ImGuiAppDemo/ImGuiAppDemo.cs
+++ b/ImGuiAppDemo/ImGuiAppDemo.cs
@@ -3,7 +3,7 @@ namespace ktsu.ImGuiApp.Demo;
 using System.Runtime.InteropServices;
 using ImGuiNET;
 using ktsu.ImGuiApp;
-using ktsu.ImGuiApp.Demo.Properties;
+using ktsu.ImGuiAppDemo.Properties;
 
 internal static class ImGuiAppDemo
 {

--- a/ImGuiAppDemo/Properties/Resources.Designer.cs
+++ b/ImGuiAppDemo/Properties/Resources.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace ktsu.ImGuiApp.Demo.Properties {
+namespace ktsu.ImGuiAppDemo.Properties {
     using System;
     
     
@@ -39,7 +39,7 @@ namespace ktsu.ImGuiApp.Demo.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("ktsu.ImGuiApp.Demo.Properties.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("ktsu.ImGuiAppDemo.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;


### PR DESCRIPTION
https://github.com/ocornut/imgui/releases/tag/v1.91.5 

From the changelog:
Obsoleted ImGuiKey_COUNT (it was unusually error-prone/misleading since valid keys don't start at 0). Probably use ImGuiKey_NamedKey_BEGIN/ImGuiKey_NamedKey_END instead?

From the source code
ImGuiKey_COUNT = ImGuiKey_NamedKey_END,    // Obsoleted in 1.91.5 because it was extremely misleading (since named keys don't start at 0 anymore)