### PR TITLE
Always call ImGui.End for ImGui.Begin

### DIFF
--- a/ImGuiApp/ImGuiApp.cs
+++ b/ImGuiApp/ImGuiApp.cs
@@ -473,8 +473,8 @@ public static partial class ImGuiApp
 		{
 			colors[(int)ImGuiCol.Border] = borderColor;
 			tickDelegate?.Invoke(dt);
-			ImGui.End();
 		}
+		ImGui.End();
 
 		if (showImGuiDemo)
 		{


### PR DESCRIPTION
The Dear ImGui documentation says that ImGui.End must ALWAYS be called for a matching ImGui.Begin, regardless of the return value. Begin and BeginChild are inconsistent with the rest of the Dear ImGui API and the appropriate End functions must ALWAYS be called.

After making this change I am no longer experiencing the crashing that I was previously. Even if this turns out to not fix the crashing, it is still a correct change to make.