### PR TITLE
Implement font memory guards to prevent using too much texture memory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Hexa.NET.ImGui" Version="2.2.8.4" />
+    <PackageVersion Include="Hexa.NET.ImGui" Version="2.2.8.5" />
     <PackageVersion Include="ktsu.Invoker" Version="1.1.0" />
     <PackageVersion Include="ktsu.ScopedAction" Version="1.1.2" />
     <PackageVersion Include="ktsu.StrongPaths" Version="1.3.2" />
@@ -21,8 +21,8 @@
     <PackageVersion Include="Silk.NET.OpenGLES" Version="2.22.0" />
     <PackageVersion Include="Silk.NET.OpenXR" Version="2.22.0" />
     <PackageVersion Include="Silk.NET.Windowing.Sdl" Version="2.22.0" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.10" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.7" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.8" />
     <!-- Test Dependencies -->
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
@@ -33,8 +33,8 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.HotReload" Version="1.7.3" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Retry" Version="1.7.3" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.7.3" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.9.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.9.3" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.10.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.10.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <!-- SDK Dependencies -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Main Application Dependencies -->
-    <PackageVersion Include="coverlet.collector" Version="6.0.4">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageVersion>
     <PackageVersion Include="Hexa.NET.ImGui" Version="2.2.8.5" />
     <PackageVersion Include="ktsu.Invoker" Version="1.1.0" />
     <PackageVersion Include="ktsu.ScopedAction" Version="1.1.2" />
@@ -24,6 +20,10 @@
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageVersion Include="System.Text.Json" Version="9.0.8" />
     <!-- Test Dependencies -->
+    <PackageVersion Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />

--- a/ImGuiApp.Test/FontMemoryGuardTests.cs
+++ b/ImGuiApp.Test/FontMemoryGuardTests.cs
@@ -1,0 +1,450 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGuiApp.Test;
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Tests for FontMemoryGuard functionality including memory estimation, GPU detection,
+/// and Intel/AMD integrated GPU support.
+/// </summary>
+[TestClass]
+public class FontMemoryGuardTests
+{
+	[TestInitialize]
+	public void Setup()
+	{
+		ImGuiApp.Reset();
+		// Reset FontMemoryGuard configuration to defaults
+		FontMemoryGuard.CurrentConfig = new FontMemoryGuard.FontMemoryConfig();
+	}
+
+	#region FontMemoryEstimate Tests
+
+	[TestMethod]
+	public void FontMemoryEstimate_Equality_WorksCorrectly()
+	{
+		FontMemoryGuard.FontMemoryEstimate estimate1 = new()
+		{
+			EstimatedBytes = 1024,
+			EstimatedGlyphCount = 100,
+			ExceedsLimits = false,
+			RecommendedMaxSizes = 5,
+			ShouldDisableEmojis = false,
+			ShouldReduceUnicodeRanges = false
+		};
+
+		FontMemoryGuard.FontMemoryEstimate estimate2 = new()
+		{
+			EstimatedBytes = 1024,
+			EstimatedGlyphCount = 100,
+			ExceedsLimits = false,
+			RecommendedMaxSizes = 5,
+			ShouldDisableEmojis = false,
+			ShouldReduceUnicodeRanges = false
+		};
+
+		FontMemoryGuard.FontMemoryEstimate estimate3 = new()
+		{
+			EstimatedBytes = 2048,
+			EstimatedGlyphCount = 100,
+			ExceedsLimits = false,
+			RecommendedMaxSizes = 5,
+			ShouldDisableEmojis = false,
+			ShouldReduceUnicodeRanges = false
+		};
+
+		// Test equality
+		Assert.AreEqual(estimate1, estimate2);
+		Assert.AreNotEqual(estimate1, estimate3);
+
+		// Test operators
+		Assert.IsTrue(estimate1 == estimate2);
+		Assert.IsFalse(estimate1 == estimate3);
+		Assert.IsFalse(estimate1 != estimate2);
+		Assert.IsTrue(estimate1 != estimate3);
+
+		// Test Equals with object
+		Assert.IsTrue(estimate1.Equals((object)estimate2));
+		Assert.IsFalse(estimate1.Equals((object)estimate3));
+		Assert.IsFalse(estimate1.Equals(null));
+		Assert.IsFalse(estimate1.Equals("not an estimate"));
+	}
+
+	[TestMethod]
+	public void FontMemoryEstimate_GetHashCode_ConsistentForEqualObjects()
+	{
+		FontMemoryGuard.FontMemoryEstimate estimate1 = new()
+		{
+			EstimatedBytes = 1024,
+			EstimatedGlyphCount = 100,
+			ExceedsLimits = true,
+			RecommendedMaxSizes = 3,
+			ShouldDisableEmojis = true,
+			ShouldReduceUnicodeRanges = false
+		};
+
+		FontMemoryGuard.FontMemoryEstimate estimate2 = new()
+		{
+			EstimatedBytes = 1024,
+			EstimatedGlyphCount = 100,
+			ExceedsLimits = true,
+			RecommendedMaxSizes = 3,
+			ShouldDisableEmojis = true,
+			ShouldReduceUnicodeRanges = false
+		};
+
+		Assert.AreEqual(estimate1.GetHashCode(), estimate2.GetHashCode());
+	}
+
+	#endregion
+
+	#region EstimateMemoryUsage Tests
+
+	[TestMethod]
+	public void EstimateMemoryUsage_ValidParameters_ReturnsValidEstimate()
+	{
+		int[] fontSizes = [12, 14, 16, 18, 20];
+
+		FontMemoryGuard.FontMemoryEstimate estimate = FontMemoryGuard.EstimateMemoryUsage(
+			fontCount: 2,
+			fontSizes: fontSizes,
+			includeEmojis: true,
+			includeExtendedUnicode: true,
+			scaleFactor: 1.0f);
+
+		Assert.IsTrue(estimate.EstimatedBytes > 0);
+		Assert.IsTrue(estimate.EstimatedGlyphCount > 0);
+		Assert.IsTrue(estimate.RecommendedMaxSizes > 0);
+	}
+
+	[TestMethod]
+	public void EstimateMemoryUsage_HighScaleFactor_IncreasesMemoryEstimate()
+	{
+		int[] fontSizes = [14, 16, 18];
+
+		FontMemoryGuard.FontMemoryEstimate lowScaleEstimate = FontMemoryGuard.EstimateMemoryUsage(1, fontSizes, false, false, 1.0f);
+		FontMemoryGuard.FontMemoryEstimate highScaleEstimate = FontMemoryGuard.EstimateMemoryUsage(1, fontSizes, false, false, 2.0f);
+
+		Assert.IsTrue(highScaleEstimate.EstimatedBytes > lowScaleEstimate.EstimatedBytes);
+	}
+
+	[TestMethod]
+	public void EstimateMemoryUsage_WithEmojisAndUnicode_IncreasesGlyphCount()
+	{
+		int[] fontSizes = [14];
+
+		FontMemoryGuard.FontMemoryEstimate basicEstimate = FontMemoryGuard.EstimateMemoryUsage(1, fontSizes, false, false, 1.0f);
+		FontMemoryGuard.FontMemoryEstimate unicodeEstimate = FontMemoryGuard.EstimateMemoryUsage(1, fontSizes, false, true, 1.0f);
+		FontMemoryGuard.FontMemoryEstimate emojiEstimate = FontMemoryGuard.EstimateMemoryUsage(1, fontSizes, true, false, 1.0f);
+		FontMemoryGuard.FontMemoryEstimate fullEstimate = FontMemoryGuard.EstimateMemoryUsage(1, fontSizes, true, true, 1.0f);
+
+		Assert.IsTrue(unicodeEstimate.EstimatedGlyphCount > basicEstimate.EstimatedGlyphCount);
+		Assert.IsTrue(emojiEstimate.EstimatedGlyphCount > basicEstimate.EstimatedGlyphCount);
+		Assert.IsTrue(fullEstimate.EstimatedGlyphCount > unicodeEstimate.EstimatedGlyphCount);
+		Assert.IsTrue(fullEstimate.EstimatedGlyphCount > emojiEstimate.EstimatedGlyphCount);
+	}
+
+	[TestMethod]
+	public void EstimateMemoryUsage_NullFontSizes_ThrowsArgumentNullException()
+	{
+		Assert.ThrowsExactly<ArgumentNullException>(() =>
+			FontMemoryGuard.EstimateMemoryUsage(1, null!, false, false, 1.0f));
+	}
+
+	[TestMethod]
+	public void EstimateMemoryUsage_ExceedsLimits_SetsCorrectFlags()
+	{
+		// Set a very low memory limit to trigger limit exceeded
+		FontMemoryGuard.CurrentConfig.MaxAtlasMemoryBytes = 1024; // 1KB - very small
+
+		int[] largeFontSizes = [12, 14, 16, 18, 20, 24, 32, 48]; // Many sizes
+
+		FontMemoryGuard.FontMemoryEstimate estimate = FontMemoryGuard.EstimateMemoryUsage(
+			fontCount: 3, // Multiple fonts
+			fontSizes: largeFontSizes,
+			includeEmojis: true,
+			includeExtendedUnicode: true,
+			scaleFactor: 2.0f); // High DPI
+
+		Assert.IsTrue(estimate.ExceedsLimits, "Should exceed the very low memory limit");
+	}
+
+	#endregion
+
+	#region GetReducedFontSizes Tests
+
+	[TestMethod]
+	public void GetReducedFontSizes_FewerThanMax_ReturnsOriginal()
+	{
+		int[] originalSizes = [12, 14, 16];
+		int[] result = FontMemoryGuard.GetReducedFontSizes(originalSizes, 5, 14);
+
+		CollectionAssert.AreEqual(originalSizes, result);
+	}
+
+	[TestMethod]
+	public void GetReducedFontSizes_MoreThanMax_ReducesToMax()
+	{
+		int[] originalSizes = [10, 12, 14, 16, 18, 20, 24, 32, 48];
+		int[] result = FontMemoryGuard.GetReducedFontSizes(originalSizes, 3, 14);
+
+		Assert.AreEqual(3, result.Length);
+		Assert.IsTrue(result.Contains(14), "Should always include preferred size");
+	}
+
+	[TestMethod]
+	public void GetReducedFontSizes_PrioritizesPreferredSize()
+	{
+		int[] originalSizes = [10, 12, 14, 16, 18, 20, 24, 32, 48];
+		int[] result = FontMemoryGuard.GetReducedFontSizes(originalSizes, 4, 16);
+
+		Assert.IsTrue(result.Contains(16), "Should include preferred size 16");
+		Assert.AreEqual(4, result.Length);
+	}
+
+	[TestMethod]
+	public void GetReducedFontSizes_RespectsMinimumSizes()
+	{
+		FontMemoryGuard.CurrentConfig.MinFontSizesToLoad = 2;
+		int[] originalSizes = [12, 14, 16, 18, 20];
+		int[] result = FontMemoryGuard.GetReducedFontSizes(originalSizes, 1, 14); // Request only 1, but min is 2
+
+		Assert.IsTrue(result.Length >= 2, "Should respect minimum font sizes setting");
+	}
+
+	[TestMethod]
+	public void GetReducedFontSizes_NullOriginalSizes_ThrowsArgumentNullException()
+	{
+		Assert.ThrowsExactly<ArgumentNullException>(() =>
+			FontMemoryGuard.GetReducedFontSizes(null!, 3, 14));
+	}
+
+	[TestMethod]
+	public void GetReducedFontSizes_ResultIsSorted()
+	{
+		int[] originalSizes = [48, 12, 20, 14, 16]; // Unsorted input
+		int[] result = FontMemoryGuard.GetReducedFontSizes(originalSizes, 3, 14);
+
+		for (int i = 1; i < result.Length; i++)
+		{
+			Assert.IsTrue(result[i] > result[i - 1], "Result should be sorted in ascending order");
+		}
+	}
+
+	#endregion
+
+	#region DetermineFallbackStrategy Tests
+
+	[TestMethod]
+	public void DetermineFallbackStrategy_NoLimitsExceeded_ReturnsNone()
+	{
+		FontMemoryGuard.FontMemoryEstimate estimate = new()
+		{
+			ExceedsLimits = false,
+			EstimatedBytes = 1024
+		};
+
+		FontMemoryGuard.FallbackStrategy strategy = FontMemoryGuard.DetermineFallbackStrategy(estimate);
+		Assert.AreEqual(FontMemoryGuard.FallbackStrategy.None, strategy);
+	}
+
+	[TestMethod]
+	public void DetermineFallbackStrategy_SlightOverage_ReturnsReduceFontSizes()
+	{
+		FontMemoryGuard.CurrentConfig.MaxAtlasMemoryBytes = 1024;
+		FontMemoryGuard.FontMemoryEstimate estimate = new()
+		{
+			ExceedsLimits = true,
+			EstimatedBytes = 1200 // 1.17x over limit
+		};
+
+		FontMemoryGuard.FallbackStrategy strategy = FontMemoryGuard.DetermineFallbackStrategy(estimate);
+		Assert.AreEqual(FontMemoryGuard.FallbackStrategy.ReduceFontSizes, strategy);
+	}
+
+	[TestMethod]
+	public void DetermineFallbackStrategy_ModerateOverage_ReturnsDisableEmojis()
+	{
+		FontMemoryGuard.CurrentConfig.MaxAtlasMemoryBytes = 1024;
+		FontMemoryGuard.FontMemoryEstimate estimate = new()
+		{
+			ExceedsLimits = true,
+			EstimatedBytes = 1700 // 1.66x over limit
+		};
+
+		FontMemoryGuard.FallbackStrategy strategy = FontMemoryGuard.DetermineFallbackStrategy(estimate);
+		Assert.AreEqual(FontMemoryGuard.FallbackStrategy.DisableEmojis, strategy);
+	}
+
+	[TestMethod]
+	public void DetermineFallbackStrategy_HighOverage_ReturnsReduceUnicodeRanges()
+	{
+		FontMemoryGuard.CurrentConfig.MaxAtlasMemoryBytes = 1024;
+		FontMemoryGuard.FontMemoryEstimate estimate = new()
+		{
+			ExceedsLimits = true,
+			EstimatedBytes = 2500 // 2.44x over limit
+		};
+
+		FontMemoryGuard.FallbackStrategy strategy = FontMemoryGuard.DetermineFallbackStrategy(estimate);
+		Assert.AreEqual(FontMemoryGuard.FallbackStrategy.ReduceUnicodeRanges, strategy);
+	}
+
+	[TestMethod]
+	public void DetermineFallbackStrategy_ExtremeOverage_ReturnsMinimalFonts()
+	{
+		FontMemoryGuard.CurrentConfig.MaxAtlasMemoryBytes = 1024;
+		FontMemoryGuard.FontMemoryEstimate estimate = new()
+		{
+			ExceedsLimits = true,
+			EstimatedBytes = 5000 // 4.88x over limit
+		};
+
+		FontMemoryGuard.FallbackStrategy strategy = FontMemoryGuard.DetermineFallbackStrategy(estimate);
+		Assert.AreEqual(FontMemoryGuard.FallbackStrategy.MinimalFonts, strategy);
+	}
+
+	#endregion
+
+	#region GPU Detection Tests
+
+	[TestMethod]
+	public void TryDetectAndConfigureGpuMemory_NullGL_ReturnsFalse()
+	{
+		bool result = FontMemoryGuard.TryDetectAndConfigureGpuMemory(null!);
+		Assert.IsFalse(result);
+	}
+
+	[TestMethod]
+	public void TryDetectAndConfigureGpuMemory_DetectionDisabled_ReturnsFalse()
+	{
+		FontMemoryGuard.CurrentConfig.EnableGpuMemoryDetection = false;
+
+		// Since detection is disabled, the method should return false regardless of GL
+		bool result = FontMemoryGuard.TryDetectAndConfigureGpuMemory(null!);
+		Assert.IsFalse(result);
+	}
+
+	#endregion
+
+	#region GPU Heuristics Unit Tests (without actual GL calls)
+
+	[TestMethod]
+	public void FontMemoryGuard_IsIntegratedGpu_DetectsIntelCorrectly()
+	{
+		// Test Intel GPU detection patterns
+		Assert.IsTrue(FontMemoryGuard.IsIntegratedGpu("Intel(R) HD Graphics 530"));
+		Assert.IsTrue(FontMemoryGuard.IsIntegratedGpu("Intel(R) UHD Graphics 620"));
+		Assert.IsTrue(FontMemoryGuard.IsIntegratedGpu("Intel(R) Xe Graphics"));
+		Assert.IsTrue(FontMemoryGuard.IsIntegratedGpu("Intel(R) Iris(R) Xe Graphics"));
+
+		// Should not detect discrete GPUs as integrated
+		Assert.IsFalse(FontMemoryGuard.IsIntegratedGpu("NVIDIA GeForce RTX 3060"));
+		Assert.IsFalse(FontMemoryGuard.IsIntegratedGpu("AMD Radeon RX 6600 XT"));
+	}
+
+	[TestMethod]
+	public void FontMemoryGuard_IsIntegratedGpu_DetectsAmdApuCorrectly()
+	{
+		// Test AMD APU detection patterns
+		Assert.IsTrue(FontMemoryGuard.IsIntegratedGpu("AMD Radeon(TM) Vega 8 Graphics"));
+		Assert.IsTrue(FontMemoryGuard.IsIntegratedGpu("AMD Radeon(TM) 680M"));
+		Assert.IsTrue(FontMemoryGuard.IsIntegratedGpu("AMD Radeon(TM) R7 Graphics"));
+
+		// Should not detect discrete GPUs as integrated
+		Assert.IsFalse(FontMemoryGuard.IsIntegratedGpu("AMD Radeon RX 6600 XT"));
+		Assert.IsFalse(FontMemoryGuard.IsIntegratedGpu("AMD Radeon RX 7900 XTX"));
+	}
+
+	[TestMethod]
+	public void FontMemoryGuard_GetIntelGpuMemoryLimit_ReturnsCorrectLimits()
+	{
+		// Test Intel GPU generation-based memory limits
+		Assert.AreEqual(96 * 1024 * 1024, FontMemoryGuard.GetIntelGpuMemoryLimit("Intel(R) Xe Graphics"));
+		Assert.AreEqual(80 * 1024 * 1024, FontMemoryGuard.GetIntelGpuMemoryLimit("Intel(R) Iris(R) Xe Graphics"));
+		Assert.AreEqual(64 * 1024 * 1024, FontMemoryGuard.GetIntelGpuMemoryLimit("Intel(R) UHD Graphics 620"));
+		Assert.AreEqual(32 * 1024 * 1024, FontMemoryGuard.GetIntelGpuMemoryLimit("Intel(R) HD Graphics 530"));
+
+		// Default for unrecognized Intel GPUs
+		Assert.AreEqual(32 * 1024 * 1024, FontMemoryGuard.GetIntelGpuMemoryLimit("Intel(R) Unknown Graphics"));
+	}
+
+	[TestMethod]
+	public void FontMemoryGuard_GetAmdApuMemoryLimit_ReturnsCorrectLimits()
+	{
+		// Test AMD APU generation-based memory limits
+		Assert.AreEqual(128 * 1024 * 1024, FontMemoryGuard.GetAmdApuMemoryLimit("AMD Radeon(TM) 680M"));
+		Assert.AreEqual(96 * 1024 * 1024, FontMemoryGuard.GetAmdApuMemoryLimit("AMD Radeon(TM) Vega 8 Graphics"));
+		Assert.AreEqual(48 * 1024 * 1024, FontMemoryGuard.GetAmdApuMemoryLimit("AMD Radeon(TM) R7 Graphics"));
+
+		// Default for unrecognized AMD APUs
+		Assert.AreEqual(64 * 1024 * 1024, FontMemoryGuard.GetAmdApuMemoryLimit("AMD Radeon(TM) Unknown APU"));
+	}
+
+	#endregion
+
+	#region Configuration Tests
+
+	[TestMethod]
+	public void FontMemoryConfig_DefaultValues_AreReasonable()
+	{
+		FontMemoryGuard.FontMemoryConfig config = new();
+
+		Assert.AreEqual(FontMemoryGuard.DefaultMaxAtlasMemoryBytes, config.MaxAtlasMemoryBytes);
+		Assert.IsTrue(config.EnableGpuMemoryDetection);
+		Assert.AreEqual(0.1f, config.MaxGpuMemoryPercentage);
+		Assert.IsTrue(config.EnableFallbackStrategies);
+		Assert.AreEqual(3, config.MinFontSizesToLoad);
+		Assert.IsTrue(config.DisableEmojisOnLowMemory);
+		Assert.IsTrue(config.ReduceUnicodeRangesOnLowMemory);
+		Assert.IsTrue(config.EnableIntelGpuHeuristics);
+		Assert.IsTrue(config.EnableAmdApuHeuristics);
+	}
+
+	[TestMethod]
+	public void FontMemoryGuard_Constants_HaveExpectedValues()
+	{
+		Assert.AreEqual(64 * 1024 * 1024, FontMemoryGuard.DefaultMaxAtlasMemoryBytes);
+		Assert.AreEqual(8 * 1024 * 1024, FontMemoryGuard.MinAtlasMemoryBytes);
+		Assert.AreEqual(4096, FontMemoryGuard.MaxAtlasTextureDimension);
+		Assert.AreEqual(128, FontMemoryGuard.EstimatedBytesPerGlyph);
+	}
+
+	#endregion
+
+	#region Error Handling Tests
+
+	[TestMethod]
+	public void LogMemoryUsage_DoesNotThrow()
+	{
+		FontMemoryGuard.FontMemoryEstimate estimate = new()
+		{
+			EstimatedBytes = 1024,
+			EstimatedGlyphCount = 100,
+			ExceedsLimits = true
+		};
+
+		try
+		{
+			FontMemoryGuard.LogMemoryUsage(estimate, FontMemoryGuard.FallbackStrategy.ReduceFontSizes);
+		}
+		catch (ArgumentException ex)
+		{
+			Assert.Fail($"LogMemoryUsage should not throw ArgumentException, but got: {ex.Message}");
+		}
+		catch (InvalidOperationException ex)
+		{
+			Assert.Fail($"LogMemoryUsage should not throw InvalidOperationException, but got: {ex.Message}");
+		}
+		catch (System.ComponentModel.Win32Exception ex)
+		{
+			Assert.Fail($"LogMemoryUsage should not throw Win32Exception, but got: {ex.Message}");
+		}
+	}
+
+	#endregion
+}

--- a/ImGuiApp.Test/ImGuiApp.Test.csproj
+++ b/ImGuiApp.Test/ImGuiApp.Test.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="ktsu.Sdk.Test">
 
   <PropertyGroup>
+    <TargetFrameworks>net9.0;</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/ImGuiApp.Test/ImGuiAppTests.cs
+++ b/ImGuiApp.Test/ImGuiAppTests.cs
@@ -2,8 +2,6 @@
 // All rights reserved.
 // Licensed under the MIT license.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 [assembly: DoNotParallelize]
 
 namespace ktsu.ImGuiApp.Test;

--- a/ImGuiApp/FontMemoryGuard.cs
+++ b/ImGuiApp/FontMemoryGuard.cs
@@ -1,0 +1,762 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGuiApp;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hexa.NET.ImGui;
+using Silk.NET.OpenGL;
+
+/// <summary>
+/// Provides memory guards and limits for font loading to prevent excessive texture memory allocation
+/// on small GPUs or high-resolution displays.
+///
+/// <para><strong>Intel &amp; AMD Integrated GPU Support:</strong></para>
+/// <para>Special handling for integrated graphics which are the primary targets for memory constraints:</para>
+/// <list type="bullet">
+/// <item><strong>Intel Graphics:</strong> HD Graphics, UHD Graphics, Iris, Xe Graphics - Often don't expose memory query extensions</item>
+/// <item><strong>AMD APUs:</strong> Vega, RDNA integrated graphics - Share system RAM with limited bandwidth</item>
+/// <item><strong>Automatic Detection:</strong> Uses renderer string analysis when OpenGL memory extensions aren't available</item>
+/// <item><strong>Conservative Limits:</strong> 16-96MB font atlas limits for integrated GPUs vs 64-128MB for discrete</item>
+/// <item><strong>Generation-Aware:</strong> Newer integrated GPUs (Xe, RDNA2+) get higher limits than older ones</item>
+/// </list>
+///
+/// <para><strong>Why This Matters:</strong></para>
+/// <para>Integrated GPUs share system RAM and have limited memory bandwidth. A 4K display with full Unicode
+/// font support can easily create 200MB+ font atlases, which can cause:</para>
+/// <list type="bullet">
+/// <item>Application crashes due to GPU memory exhaustion</item>
+/// <item>Severe performance degradation from memory pressure</item>
+/// <item>System-wide slowdowns as integrated GPU competes with CPU for RAM bandwidth</item>
+/// </list>
+/// </summary>
+public static class FontMemoryGuard
+{
+	/// <summary>
+	/// Default maximum font atlas texture size in bytes (64MB).
+	/// This is conservative for integrated GPUs and high-DPI displays.
+	/// </summary>
+	public const long DefaultMaxAtlasMemoryBytes = 64 * 1024 * 1024; // 64MB
+
+	/// <summary>
+	/// Minimum font atlas texture size in bytes (8MB).
+	/// Below this threshold, basic functionality may be compromised.
+	/// </summary>
+	public const long MinAtlasMemoryBytes = 8 * 1024 * 1024; // 8MB
+
+	/// <summary>
+	/// Maximum font atlas texture dimension (e.g., 4096x4096).
+	/// Most GPUs support at least this size.
+	/// </summary>
+	public const int MaxAtlasTextureDimension = 4096;
+
+	/// <summary>
+	/// Estimated bytes per glyph for memory calculations.
+	/// This is a rough estimate based on typical font rasterization.
+	/// </summary>
+	public const int EstimatedBytesPerGlyph = 128;
+
+	/// <summary>
+	/// Configuration for font memory limits.
+	/// </summary>
+	public class FontMemoryConfig
+	{
+		/// <summary>
+		/// Maximum memory to allocate for font atlas textures in bytes.
+		/// </summary>
+		public long MaxAtlasMemoryBytes { get; set; } = DefaultMaxAtlasMemoryBytes;
+
+		/// <summary>
+		/// Whether to enable automatic GPU memory detection.
+		/// </summary>
+		public bool EnableGpuMemoryDetection { get; set; } = true;
+
+		/// <summary>
+		/// Maximum percentage of available GPU memory to use for font textures.
+		/// Note: Integrated GPUs automatically use lower percentages (3-5%) regardless of this setting.
+		/// </summary>
+		public float MaxGpuMemoryPercentage { get; set; } = 0.1f; // 10% for discrete GPUs
+
+		/// <summary>
+		/// Whether to enable special handling for Intel integrated GPUs.
+		/// Intel GPUs often don't expose memory query extensions, so we use heuristics.
+		/// </summary>
+		public bool EnableIntelGpuHeuristics { get; set; } = true;
+
+		/// <summary>
+		/// Whether to enable special handling for AMD integrated GPUs (APUs).
+		/// </summary>
+		public bool EnableAmdApuHeuristics { get; set; } = true;
+
+		/// <summary>
+		/// Whether to enable fallback strategies when memory limits are exceeded.
+		/// </summary>
+		public bool EnableFallbackStrategies { get; set; } = true;
+
+		/// <summary>
+		/// Minimum number of font sizes to load even under memory constraints.
+		/// </summary>
+		public int MinFontSizesToLoad { get; set; } = 3; // e.g., 12, 16, 20
+
+		/// <summary>
+		/// Whether to disable emoji fonts under memory constraints.
+		/// </summary>
+		public bool DisableEmojisOnLowMemory { get; set; } = true;
+
+		/// <summary>
+		/// Whether to reduce Unicode glyph ranges under memory constraints.
+		/// </summary>
+		public bool ReduceUnicodeRangesOnLowMemory { get; set; } = true;
+	}
+
+	/// <summary>
+	/// Result of font memory estimation.
+	/// </summary>
+	public struct FontMemoryEstimate : IEquatable<FontMemoryEstimate>
+	{
+		/// <summary>
+		/// Estimated memory usage in bytes.
+		/// </summary>
+		public long EstimatedBytes { get; set; }
+
+		/// <summary>
+		/// Number of glyphs estimated.
+		/// </summary>
+		public int EstimatedGlyphCount { get; set; }
+
+		/// <summary>
+		/// Whether the estimate exceeds memory limits.
+		/// </summary>
+		public bool ExceedsLimits { get; set; }
+
+		/// <summary>
+		/// Recommended maximum number of font sizes to load.
+		/// </summary>
+		public int RecommendedMaxSizes { get; set; }
+
+		/// <summary>
+		/// Whether emoji fonts should be disabled.
+		/// </summary>
+		public bool ShouldDisableEmojis { get; set; }
+
+		/// <summary>
+		/// Whether Unicode ranges should be reduced.
+		/// </summary>
+		public bool ShouldReduceUnicodeRanges { get; set; }
+
+		/// <summary>
+		/// Determines whether the specified object is equal to the current object.
+		/// </summary>
+		/// <param name="obj">The object to compare with the current object.</param>
+		/// <returns>true if the specified object is equal to the current object; otherwise, false.</returns>
+		public override readonly bool Equals(object? obj) => obj is FontMemoryEstimate estimate && Equals(estimate);
+
+		/// <summary>
+		/// Serves as the default hash function.
+		/// </summary>
+		/// <returns>A hash code for the current object.</returns>
+		public override readonly int GetHashCode() => HashCode.Combine(EstimatedBytes, EstimatedGlyphCount, ExceedsLimits, RecommendedMaxSizes, ShouldDisableEmojis, ShouldReduceUnicodeRanges);
+
+		/// <summary>
+		/// Indicates whether the current object is equal to another object of the same type.
+		/// </summary>
+		/// <param name="other">An object to compare with this object.</param>
+		/// <returns>true if the current object is equal to the other parameter; otherwise, false.</returns>
+		public readonly bool Equals(FontMemoryEstimate other) =>
+			EstimatedBytes == other.EstimatedBytes &&
+			EstimatedGlyphCount == other.EstimatedGlyphCount &&
+			ExceedsLimits == other.ExceedsLimits &&
+			RecommendedMaxSizes == other.RecommendedMaxSizes &&
+			ShouldDisableEmojis == other.ShouldDisableEmojis &&
+			ShouldReduceUnicodeRanges == other.ShouldReduceUnicodeRanges;
+
+		/// <summary>
+		/// Determines whether two specified instances of FontMemoryEstimate are equal.
+		/// </summary>
+		/// <param name="left">The first FontMemoryEstimate to compare.</param>
+		/// <param name="right">The second FontMemoryEstimate to compare.</param>
+		/// <returns>true if the two FontMemoryEstimate instances are equal; otherwise, false.</returns>
+		public static bool operator ==(FontMemoryEstimate left, FontMemoryEstimate right) => left.Equals(right);
+
+		/// <summary>
+		/// Determines whether two specified instances of FontMemoryEstimate are not equal.
+		/// </summary>
+		/// <param name="left">The first FontMemoryEstimate to compare.</param>
+		/// <param name="right">The second FontMemoryEstimate to compare.</param>
+		/// <returns>true if the two FontMemoryEstimate instances are not equal; otherwise, false.</returns>
+		public static bool operator !=(FontMemoryEstimate left, FontMemoryEstimate right) => !(left == right);
+	}
+
+	/// <summary>
+	/// Fallback strategy for font loading under memory constraints.
+	/// </summary>
+	public enum FallbackStrategy
+	{
+		/// <summary>
+		/// No fallback needed.
+		/// </summary>
+		None,
+
+		/// <summary>
+		/// Reduce number of font sizes.
+		/// </summary>
+		ReduceFontSizes,
+
+		/// <summary>
+		/// Disable emoji fonts.
+		/// </summary>
+		DisableEmojis,
+
+		/// <summary>
+		/// Reduce Unicode glyph ranges.
+		/// </summary>
+		ReduceUnicodeRanges,
+
+		/// <summary>
+		/// Aggressive fallback: minimal fonts only.
+		/// </summary>
+		MinimalFonts
+	}
+
+	/// <summary>
+	/// Gets the current font memory configuration.
+	/// </summary>
+	public static FontMemoryConfig CurrentConfig { get; set; } = new();
+
+	/// <summary>
+	/// Estimates the memory usage for font loading based on the provided parameters.
+	/// </summary>
+	/// <param name="fontCount">Number of font files to load.</param>
+	/// <param name="fontSizes">Array of font sizes to load.</param>
+	/// <param name="includeEmojis">Whether emoji fonts will be included.</param>
+	/// <param name="includeExtendedUnicode">Whether extended Unicode ranges will be included.</param>
+	/// <param name="scaleFactor">Current DPI scale factor.</param>
+	/// <returns>Font memory estimate.</returns>
+	public static FontMemoryEstimate EstimateMemoryUsage(
+		int fontCount,
+		int[] fontSizes,
+		bool includeEmojis,
+		bool includeExtendedUnicode,
+		float scaleFactor)
+	{
+		ArgumentNullException.ThrowIfNull(fontSizes);
+
+		// Estimate glyph count based on configuration
+		int baseGlyphCount = 128; // ASCII
+		if (includeExtendedUnicode)
+		{
+			baseGlyphCount += GetExtendedUnicodeGlyphCount();
+		}
+		if (includeEmojis)
+		{
+			baseGlyphCount += GetEmojiGlyphCount();
+		}
+
+		// Calculate total glyph count across all fonts and sizes
+		int totalGlyphCount = fontCount * fontSizes.Length * baseGlyphCount;
+
+		// Apply scale factor impact (higher DPI = larger textures)
+		float scaleImpact = scaleFactor * scaleFactor; // Quadratic impact on texture size
+		long estimatedBytes = (long)(totalGlyphCount * EstimatedBytesPerGlyph * scaleImpact);
+
+		// Determine if limits are exceeded and recommend fallbacks
+		bool exceedsLimits = estimatedBytes > CurrentConfig.MaxAtlasMemoryBytes;
+		int recommendedMaxSizes = CalculateRecommendedMaxSizes(estimatedBytes, fontCount, baseGlyphCount, scaleFactor);
+		bool shouldDisableEmojis = exceedsLimits && CurrentConfig.DisableEmojisOnLowMemory && includeEmojis;
+		bool shouldReduceUnicode = exceedsLimits && CurrentConfig.ReduceUnicodeRangesOnLowMemory && includeExtendedUnicode;
+
+		return new FontMemoryEstimate
+		{
+			EstimatedBytes = estimatedBytes,
+			EstimatedGlyphCount = totalGlyphCount,
+			ExceedsLimits = exceedsLimits,
+			RecommendedMaxSizes = recommendedMaxSizes,
+			ShouldDisableEmojis = shouldDisableEmojis,
+			ShouldReduceUnicodeRanges = shouldReduceUnicode
+		};
+	}
+
+	/// <summary>
+	/// Attempts to detect available GPU memory and update configuration accordingly.
+	/// Special handling for Intel and AMD integrated GPUs which are primary targets for memory constraints.
+	/// </summary>
+	/// <param name="gl">OpenGL context for querying GPU information.</param>
+	/// <returns>True if GPU memory was successfully detected and configuration updated.</returns>
+	public static unsafe bool TryDetectAndConfigureGpuMemory(GL gl)
+	{
+		if (!CurrentConfig.EnableGpuMemoryDetection || gl == null)
+		{
+			return false;
+		}
+
+		try
+		{
+			// Get GPU vendor and renderer information
+			string vendor = gl.GetStringS(GLEnum.Vendor) ?? "";
+			string renderer = gl.GetStringS(GLEnum.Renderer) ?? "";
+			bool isIntelGpu = vendor.Contains("Intel", StringComparison.OrdinalIgnoreCase);
+			bool isAmdGpu = vendor.Contains("AMD", StringComparison.OrdinalIgnoreCase) || vendor.Contains("ATI", StringComparison.OrdinalIgnoreCase);
+			bool isNvidiaGpu = vendor.Contains("NVIDIA", StringComparison.OrdinalIgnoreCase);
+			bool isIntegratedGpu = IsIntegratedGpu(renderer);
+
+			DebugLogger.Log($"FontMemoryGuard: Detected GPU - Vendor: {vendor}, Renderer: {renderer}");
+			DebugLogger.Log($"FontMemoryGuard: GPU Classification - Intel: {isIntelGpu}, AMD: {isAmdGpu}, NVIDIA: {isNvidiaGpu}, Integrated: {isIntegratedGpu}");
+
+			// Try to get GPU memory information using OpenGL extensions
+			bool memoryDetected = false;
+			long availableMemoryKB = 0;
+
+			// Try NVIDIA extension first (works on discrete NVIDIA GPUs)
+			// Note: NVIDIA memory extensions typically aren't available as TryGetExtension in Silk.NET
+			// We'll use direct OpenGL calls instead
+			if (isNvidiaGpu && gl.IsExtensionPresent("GL_NVX_gpu_memory_info"))
+			{
+				gl.GetInteger((GLEnum)0x9048, out int totalMemKB); // GL_GPU_MEMORY_TOTAL_AVAILABLE_MEMORY_NVX
+				gl.GetInteger((GLEnum)0x9049, out int currentMemKB); // GL_GPU_MEMORY_CURRENT_AVAILABLE_MEMORY_NVX
+				availableMemoryKB = currentMemKB;
+				memoryDetected = true;
+				DebugLogger.Log($"FontMemoryGuard: NVIDIA GPU memory: {totalMemKB}KB total, {currentMemKB}KB available");
+			}
+			// Try ATI extension (works on AMD discrete and some integrated GPUs)
+			else if (isAmdGpu && gl.IsExtensionPresent("GL_ATI_meminfo"))
+			{
+				Span<int> memInfo = stackalloc int[4];
+				gl.GetInteger((GLEnum)0x87FC, memInfo); // GL_TEXTURE_FREE_MEMORY_ATI
+				availableMemoryKB = memInfo[0];
+				memoryDetected = true;
+				DebugLogger.Log($"FontMemoryGuard: AMD GPU texture memory: {availableMemoryKB}KB available");
+			}
+
+			// Apply memory-based configuration if detected
+			if (memoryDetected && availableMemoryKB > 0)
+			{
+				long recommendedFontMemory = CalculateRecommendedMemoryFromDetection(availableMemoryKB, isIntegratedGpu);
+				CurrentConfig.MaxAtlasMemoryBytes = recommendedFontMemory;
+				DebugLogger.Log($"FontMemoryGuard: Set font memory limit to {recommendedFontMemory / (1024 * 1024)}MB based on GPU memory detection");
+				return true;
+			}
+
+			// Fallback to heuristic-based configuration for Intel and undetected GPUs
+			if (ApplyIntegratedGpuHeuristics(isIntelGpu, isAmdGpu, isIntegratedGpu, renderer))
+			{
+				return true;
+			}
+		}
+		catch (InvalidOperationException ex)
+		{
+			DebugLogger.Log($"FontMemoryGuard: GPU memory detection failed with InvalidOperationException: {ex.Message}");
+		}
+		catch (ArgumentException ex)
+		{
+			DebugLogger.Log($"FontMemoryGuard: GPU memory detection failed with ArgumentException: {ex.Message}");
+		}
+		catch (System.ComponentModel.Win32Exception ex)
+		{
+			DebugLogger.Log($"FontMemoryGuard: GPU memory detection failed with Win32Exception: {ex.Message}");
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Determines if a GPU is integrated based on renderer string analysis.
+	/// </summary>
+	/// <param name="renderer">GPU renderer string from OpenGL.</param>
+	/// <returns>True if the GPU appears to be integrated.</returns>
+	private static bool IsIntegratedGpu(string renderer)
+	{
+		if (string.IsNullOrEmpty(renderer))
+		{
+			return false;
+		}
+
+		string rendererLower = renderer.ToLowerInvariant();
+
+		// Intel integrated GPU patterns
+		string[] intelIntegratedPatterns = [
+			"intel", "hd graphics", "uhd graphics", "iris", "xe graphics"
+		];
+
+		// AMD integrated GPU patterns
+		string[] amdIntegratedPatterns = [
+			"radeon(tm) graphics", "vega", "rdna", "apu"
+		];
+
+		// General integrated GPU indicators
+		string[] integratedPatterns = [
+			"integrated", "onboard", "shared"
+		];
+
+		return intelIntegratedPatterns.Any(rendererLower.Contains) ||
+			   amdIntegratedPatterns.Any(rendererLower.Contains) ||
+			   integratedPatterns.Any(rendererLower.Contains);
+	}
+
+	/// <summary>
+	/// Applies memory configuration heuristics for integrated GPUs when direct memory detection fails.
+	/// This is especially important for Intel integrated GPUs which often don't expose memory extensions.
+	/// </summary>
+	/// <param name="isIntelGpu">Whether this is an Intel GPU.</param>
+	/// <param name="isAmdGpu">Whether this is an AMD GPU.</param>
+	/// <param name="isIntegratedGpu">Whether this appears to be integrated graphics.</param>
+	/// <param name="renderer">GPU renderer string for additional analysis.</param>
+	/// <returns>True if heuristics were applied and configuration updated.</returns>
+	private static bool ApplyIntegratedGpuHeuristics(bool isIntelGpu, bool isAmdGpu, bool isIntegratedGpu, string renderer)
+	{
+		if (!isIntegratedGpu && !isIntelGpu)
+		{
+			return false; // Only apply heuristics for suspected integrated GPUs
+		}
+
+		long recommendedMemory = DefaultMaxAtlasMemoryBytes; // Default 64MB
+
+		if (isIntelGpu)
+		{
+			// Intel integrated GPU memory recommendations
+			recommendedMemory = AnalyzeIntelGpuGeneration(renderer);
+			DebugLogger.Log($"FontMemoryGuard: Applied Intel integrated GPU heuristics: {recommendedMemory / (1024 * 1024)}MB limit");
+		}
+		else if (isAmdGpu && isIntegratedGpu)
+		{
+			// AMD integrated GPU (APU) memory recommendations
+			recommendedMemory = AnalyzeAmdApuGeneration(renderer);
+			DebugLogger.Log($"FontMemoryGuard: Applied AMD integrated GPU heuristics: {recommendedMemory / (1024 * 1024)}MB limit");
+		}
+		else if (isIntegratedGpu)
+		{
+			// Generic integrated GPU - be conservative
+			recommendedMemory = 32 * 1024 * 1024; // 32MB
+			DebugLogger.Log($"FontMemoryGuard: Applied generic integrated GPU heuristics: {recommendedMemory / (1024 * 1024)}MB limit");
+		}
+
+		CurrentConfig.MaxAtlasMemoryBytes = recommendedMemory;
+
+		// Enable more aggressive fallbacks for integrated GPUs
+		CurrentConfig.DisableEmojisOnLowMemory = true;
+		CurrentConfig.ReduceUnicodeRangesOnLowMemory = true;
+		CurrentConfig.MaxGpuMemoryPercentage = 0.05f; // Use only 5% for integrated GPUs
+
+		return true;
+	}
+
+	/// <summary>
+	/// Analyzes Intel GPU generation from renderer string to determine appropriate memory limits.
+	/// </summary>
+	/// <param name="renderer">GPU renderer string.</param>
+	/// <returns>Recommended memory limit in bytes.</returns>
+	private static long AnalyzeIntelGpuGeneration(string renderer)
+	{
+		if (string.IsNullOrEmpty(renderer))
+		{
+			return 32 * 1024 * 1024; // Conservative 32MB for unknown Intel GPU
+		}
+
+		string rendererLower = renderer.ToLowerInvariant();
+
+		// Modern Intel GPUs (12th gen+, Xe Graphics)
+		if (rendererLower.Contains("xe") || rendererLower.Contains("arc"))
+		{
+			return 96 * 1024 * 1024; // 96MB - Modern Intel has better memory bandwidth
+		}
+
+		// Recent Intel GPUs (UHD Graphics series)
+		if (rendererLower.Contains("uhd"))
+		{
+			return 64 * 1024 * 1024; // 64MB - Standard limit
+		}
+
+		// Older Intel GPUs (HD Graphics series)
+		if (rendererLower.Contains("hd graphics"))
+		{
+			// Extract generation number if possible
+			if (rendererLower.Contains("630") || rendererLower.Contains("620") || rendererLower.Contains("610"))
+			{
+				return 48 * 1024 * 1024; // 48MB - 7th/8th gen
+			}
+			else if (rendererLower.Contains("530") || rendererLower.Contains("520") || rendererLower.Contains("510"))
+			{
+				return 32 * 1024 * 1024; // 32MB - 6th gen and older
+			}
+			else
+			{
+				return 24 * 1024 * 1024; // 24MB - Very old Intel GPUs
+			}
+		}
+
+		// Iris graphics (higher end integrated)
+		if (rendererLower.Contains("iris"))
+		{
+			return 80 * 1024 * 1024; // 80MB - Iris has better performance
+		}
+
+		// Default for unknown Intel GPU
+		return 32 * 1024 * 1024; // 32MB conservative
+	}
+
+	/// <summary>
+	/// Analyzes AMD APU generation from renderer string to determine appropriate memory limits.
+	/// </summary>
+	/// <param name="renderer">GPU renderer string.</param>
+	/// <returns>Recommended memory limit in bytes.</returns>
+	private static long AnalyzeAmdApuGeneration(string renderer)
+	{
+		if (string.IsNullOrEmpty(renderer))
+		{
+			return 48 * 1024 * 1024; // Conservative 48MB for unknown AMD APU
+		}
+
+		string rendererLower = renderer.ToLowerInvariant();
+
+		// Modern RDNA2/3 APUs (6000+ series, Steam Deck)
+		if (rendererLower.Contains("rdna") || rendererLower.Contains("6600") || rendererLower.Contains("6800") || rendererLower.Contains("7600"))
+		{
+			return 128 * 1024 * 1024; // 128MB - Modern AMD APUs are quite capable
+		}
+
+		// Vega-based APUs (good performance)
+		if (rendererLower.Contains("vega"))
+		{
+			return 96 * 1024 * 1024; // 96MB - Vega integrated graphics are decent
+		}
+
+		// Older GCN-based APUs
+		if (rendererLower.Contains("radeon") && (rendererLower.Contains("r5") || rendererLower.Contains("r7")))
+		{
+			return 48 * 1024 * 1024; // 48MB - Older AMD APUs
+		}
+
+		// Default for unknown AMD APU
+		return 64 * 1024 * 1024; // 64MB standard
+	}
+
+	/// <summary>
+	/// Calculates recommended memory limit based on detected GPU memory and type.
+	/// </summary>
+	/// <param name="availableMemoryKB">Available memory in KB from GPU detection.</param>
+	/// <param name="isIntegratedGpu">Whether this is an integrated GPU.</param>
+	/// <returns>Recommended font memory limit in bytes.</returns>
+	private static long CalculateRecommendedMemoryFromDetection(long availableMemoryKB, bool isIntegratedGpu)
+	{
+		// Convert KB to bytes
+		long availableMemoryBytes = availableMemoryKB * 1024;
+
+		// Use different percentages for integrated vs discrete GPUs
+		float percentage = isIntegratedGpu ? 0.03f : CurrentConfig.MaxGpuMemoryPercentage; // 3% for integrated, configurable for discrete
+		long recommendedFontMemory = (long)(availableMemoryBytes * percentage);
+
+		// Apply bounds based on GPU type
+		long minMemory = isIntegratedGpu ? 16 * 1024 * 1024 : MinAtlasMemoryBytes; // 16MB min for integrated
+		long maxMemory = isIntegratedGpu ? 96 * 1024 * 1024 : DefaultMaxAtlasMemoryBytes * 2; // 96MB max for integrated
+
+		return Math.Clamp(recommendedFontMemory, minMemory, maxMemory);
+	}
+
+	/// <summary>
+	/// Determines the best fallback strategy based on memory constraints.
+	/// </summary>
+	/// <param name="estimate">Current memory estimate.</param>
+	/// <returns>Recommended fallback strategy.</returns>
+	public static FallbackStrategy DetermineFallbackStrategy(FontMemoryEstimate estimate)
+	{
+		if (!estimate.ExceedsLimits)
+		{
+			return FallbackStrategy.None;
+		}
+
+		// Calculate how much we're over the limit
+		double overageRatio = (double)estimate.EstimatedBytes / CurrentConfig.MaxAtlasMemoryBytes;
+
+		if (overageRatio > 4.0) // More than 4x over limit
+		{
+			return FallbackStrategy.MinimalFonts;
+		}
+		else if (overageRatio > 2.0) // More than 2x over limit
+		{
+			return FallbackStrategy.ReduceUnicodeRanges;
+		}
+		else if (overageRatio > 1.5) // More than 1.5x over limit
+		{
+			return FallbackStrategy.DisableEmojis;
+		}
+		else // Less than 1.5x over limit
+		{
+			return FallbackStrategy.ReduceFontSizes;
+		}
+	}
+
+	/// <summary>
+	/// Gets a reduced set of font sizes based on memory constraints.
+	/// </summary>
+	/// <param name="originalSizes">Original font sizes to load.</param>
+	/// <param name="maxSizes">Maximum number of sizes to include.</param>
+	/// <param name="preferredSize">Preferred size to always include (e.g., default font size).</param>
+	/// <returns>Reduced array of font sizes.</returns>
+	public static int[] GetReducedFontSizes(int[] originalSizes, int maxSizes, int preferredSize = 14)
+	{
+		ArgumentNullException.ThrowIfNull(originalSizes);
+
+		if (originalSizes.Length <= maxSizes)
+		{
+			return originalSizes;
+		}
+
+		maxSizes = Math.Max(CurrentConfig.MinFontSizesToLoad, maxSizes);
+		List<int> selectedSizes = [];
+
+		// Always include the preferred size
+		if (originalSizes.Contains(preferredSize))
+		{
+			selectedSizes.Add(preferredSize);
+		}
+
+		// Add other sizes, prioritizing medium sizes over very large or very small ones
+		IEnumerable<int> remainingSizes = originalSizes.Where(s => s != preferredSize)
+			.OrderBy(s => Math.Abs(s - preferredSize)) // Sort by distance from preferred size
+			.Take(maxSizes - selectedSizes.Count);
+
+		selectedSizes.AddRange(remainingSizes);
+
+		return [.. selectedSizes.OrderBy(s => s)];
+	}
+
+	/// <summary>
+	/// Gets reduced Unicode glyph ranges for memory-constrained scenarios.
+	/// </summary>
+	/// <param name="fontAtlasPtr">Font atlas for building ranges.</param>
+	/// <returns>Pointer to reduced glyph ranges.</returns>
+	public static unsafe uint* GetReducedUnicodeRanges(ImFontAtlasPtr fontAtlasPtr)
+	{
+		// Create a minimal set of ranges that still provides good functionality
+		ImFontGlyphRangesBuilderPtr builder = new(ImGui.ImFontGlyphRangesBuilder());
+
+		// Add default ranges (ASCII) - always needed
+		builder.AddRanges(fontAtlasPtr.GetGlyphRangesDefault());
+
+		// Add only the most essential extended ranges
+		AddEssentialLatinExtended(builder);
+		AddEssentialSymbols(builder);
+		AddEssentialNerdFontRanges(builder);
+
+		// Build and cache the ranges
+		ImVector<uint> reducedRanges = new();
+		builder.BuildRanges(ref reducedRanges);
+
+		return reducedRanges.Data;
+	}
+
+	/// <summary>
+	/// Logs memory usage information for debugging.
+	/// </summary>
+	/// <param name="estimate">Memory estimate to log.</param>
+	/// <param name="strategy">Applied fallback strategy.</param>
+	public static void LogMemoryUsage(FontMemoryEstimate estimate, FallbackStrategy strategy)
+	{
+		DebugLogger.Log($"FontMemoryGuard: Estimated font memory usage: {estimate.EstimatedBytes / (1024 * 1024)}MB");
+		DebugLogger.Log($"FontMemoryGuard: Memory limit: {CurrentConfig.MaxAtlasMemoryBytes / (1024 * 1024)}MB");
+		DebugLogger.Log($"FontMemoryGuard: Estimated glyph count: {estimate.EstimatedGlyphCount:N0}");
+
+		if (estimate.ExceedsLimits)
+		{
+			DebugLogger.Log($"FontMemoryGuard: Memory limit exceeded, applying fallback strategy: {strategy}");
+			if (estimate.ShouldDisableEmojis)
+			{
+				DebugLogger.Log("FontMemoryGuard: Disabling emoji fonts to reduce memory usage");
+			}
+			if (estimate.ShouldReduceUnicodeRanges)
+			{
+				DebugLogger.Log("FontMemoryGuard: Reducing Unicode ranges to reduce memory usage");
+			}
+			if (estimate.RecommendedMaxSizes > 0)
+			{
+				DebugLogger.Log($"FontMemoryGuard: Recommending maximum {estimate.RecommendedMaxSizes} font sizes");
+			}
+		}
+		else
+		{
+			DebugLogger.Log("FontMemoryGuard: Memory usage within limits, no restrictions applied");
+		}
+	}
+
+	#region Private Helper Methods
+
+	private static int GetExtendedUnicodeGlyphCount() =>
+		// Estimate glyph count for extended Unicode ranges
+		// This is based on the ranges defined in FontHelper.AddSymbolRanges and AddNerdFontRanges
+		2000; // Conservative estimate
+
+	private static int GetEmojiGlyphCount() =>
+		// Estimate glyph count for emoji ranges
+		// This is based on the ranges defined in FontHelper.AddEmojiRanges
+		3000; // Conservative estimate
+
+	private static int CalculateRecommendedMaxSizes(long estimatedBytes, int fontCount, int baseGlyphCount, float scaleFactor)
+	{
+		if (estimatedBytes <= CurrentConfig.MaxAtlasMemoryBytes)
+		{
+			return int.MaxValue; // No limit needed
+		}
+
+		// Calculate how many sizes we can fit within the memory limit
+		long bytesPerFontPerSize = (long)(baseGlyphCount * EstimatedBytesPerGlyph * scaleFactor * scaleFactor);
+		long availableBytesPerFont = CurrentConfig.MaxAtlasMemoryBytes / fontCount;
+		int maxSizesPerFont = (int)(availableBytesPerFont / bytesPerFontPerSize);
+
+		return Math.Max(CurrentConfig.MinFontSizesToLoad, maxSizesPerFont);
+	}
+
+	private static void AddEssentialLatinExtended(ImFontGlyphRangesBuilderPtr builder)
+	{
+		// Add only the most commonly used Latin Extended characters
+		// Latin Extended-A (U+0100–U+017F) - partial
+		for (uint c = 0x00C0; c <= 0x00FF; c++) // Latin-1 Supplement (most common)
+		{
+			builder.AddChar(c);
+		}
+		for (uint c = 0x0100; c <= 0x017F; c += 2) // Every other character in Latin Extended-A
+		{
+			builder.AddChar(c);
+		}
+	}
+
+	private static void AddEssentialSymbols(ImFontGlyphRangesBuilderPtr builder)
+	{
+		// Add only the most essential symbols
+		(uint start, uint end)[] essentialRanges = [
+			(0x2000, 0x206F), // General Punctuation
+			(0x20A0, 0x20CF), // Currency Symbols
+			(0x2190, 0x21FF), // Arrows
+			(0x2500, 0x257F), // Box Drawing
+		];
+
+		foreach ((uint start, uint end) in essentialRanges)
+		{
+			for (uint c = start; c <= end; c += 2) // Every other character to reduce count
+			{
+				builder.AddChar(c);
+			}
+		}
+	}
+
+	private static void AddEssentialNerdFontRanges(ImFontGlyphRangesBuilderPtr builder)
+	{
+		// Add only the most commonly used Nerd Font icons
+		(uint start, uint end)[] essentialNerdRanges = [
+			(0xE0A0, 0xE0A2), // Powerline symbols
+			(0xE0B0, 0xE0B3), // Powerline symbols
+			(0xF000, 0xF0FF), // First 256 Font Awesome icons (most common)
+		];
+
+		foreach ((uint start, uint end) in essentialNerdRanges)
+		{
+			for (uint c = start; c <= end; c++)
+			{
+				builder.AddChar(c);
+			}
+		}
+	}
+
+	#endregion
+}

--- a/ImGuiApp/ImGuiApp.csproj
+++ b/ImGuiApp/ImGuiApp.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="ktsu.Sdk.Lib">
 
   <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CA5392;</NoWarn>
   </PropertyGroup>

--- a/ImGuiApp/ImGuiAppConfig.cs
+++ b/ImGuiApp/ImGuiAppConfig.cs
@@ -98,6 +98,12 @@ public class ImGuiAppConfig
 	/// </summary>
 	public ImGuiAppPerformanceSettings PerformanceSettings { get; init; } = new();
 
+	/// <summary>
+	/// Gets or sets the font memory configuration for limiting texture memory allocation.
+	/// This helps prevent excessive memory usage on small GPUs or high-resolution displays.
+	/// </summary>
+	public FontMemoryGuard.FontMemoryConfig FontMemoryConfig { get; init; } = new();
+
 	internal Dictionary<string, byte[]> DefaultFonts { get; init; } = new Dictionary<string, byte[]>
 		{
 			{ "default", Resources.Resources.NerdFont}

--- a/ImGuiAppDemo/ImGuiAppDemo.csproj
+++ b/ImGuiAppDemo/ImGuiAppDemo.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="ktsu.Sdk.ImGuiApp">
   <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -4,12 +4,12 @@
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
-    "ktsu.Sdk": "1.48.0",
-    "ktsu.Sdk.Lib": "1.48.0",
-    "ktsu.Sdk.ConsoleApp": "1.48.0",
-    "ktsu.Sdk.Test": "1.48.0",
-    "ktsu.Sdk.ImGuiApp": "1.48.0",
-    "ktsu.Sdk.WinApp": "1.48.0",
-    "ktsu.Sdk.WinTest": "1.48.0"
+    "ktsu.Sdk": "1.56.0",
+    "ktsu.Sdk.Lib": "1.56.0",
+    "ktsu.Sdk.ConsoleApp": "1.56.0",
+    "ktsu.Sdk.Test": "1.56.0",
+    "ktsu.Sdk.ImGuiApp": "1.56.0",
+    "ktsu.Sdk.WinApp": "1.56.0",
+    "ktsu.Sdk.WinTest": "1.56.0"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a GPU-aware FontMemoryGuard with fallbacks and integrates it into font initialization, plus tests, config hooks, and build/dependency updates.
> 
> - **Core (ImGuiApp)**:
>   - Integrates `FontMemoryGuard` into `InitFonts()` with GPU detection, memory estimation, and fallback strategies (reduced sizes, disable emojis, reduced Unicode).
>   - Adds helpers: `ApplyFallbackConstraints`, `ShouldLoadEmojis`, `ShouldUseReducedUnicode`, `GetConstrainedGlyphRanges`, `LogFontAtlasInfo`.
>   - Logs atlas size/memory; uses constrained glyph ranges; minor logging adjustments.
> - **New Component**:
>   - `ImGuiApp/FontMemoryGuard.cs`: GPU memory detection (NVIDIA/AMD extensions, Intel/AMD APU heuristics), config (`FontMemoryConfig`), estimation (`FontMemoryEstimate`), strategies (`FallbackStrategy`), range reducers and utilities.
> - **Config**:
>   - `ImGuiAppConfig`: adds `FontMemoryConfig` to control font memory limits/behavior.
> - **Tests**:
>   - `ImGuiApp.Test/FontMemoryGuardTests.cs`: unit tests for estimation, fallbacks, heuristics, config, and logging.
>   - `ImGuiApp.Test/ImGuiAppTests.cs`: updates to support new APIs/usings.
> - **Build/Deps**:
>   - Target frameworks updated to `net9.0` (libs, tests, demo).
>   - Bumps deps: `Hexa.NET.ImGui`, `SixLabors.ImageSharp`, `System.Text.Json`, MSTest packages; updates `global.json` SDKs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dad3369a173457af56e7bbfc3a3891b069882d2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->