### PR TITLE
refactor: introduce IRendererBackend seam for the iOS port (Task 1)

### DIFF
--- a/ImGui.App/IRendererBackend.cs
+++ b/ImGui.App/IRendererBackend.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.App;
+
+using System;
+using Hexa.NET.ImGui;
+
+/// <summary>
+/// Platform-agnostic seam for the GPU side of an ImGui frame. Each platform port
+/// provides an implementation: desktop uses <see cref="ktsu.ImGui.App.ImGuiController.ImGuiController"/>
+/// (OpenGL via Silk.NET); the future iOS port will provide a Metal-backed implementation.
+/// The interface deliberately covers only what differs between backends — atlas/user
+/// texture upload, texture release, and final draw-data submission. Per-frame state
+/// (input, NewFrame/EndFrame, font configuration) stays in the concrete backend until
+/// the broader split described in the iOS port plan is in place.
+/// </summary>
+internal interface IRendererBackend : IDisposable
+{
+	/// <summary>
+	/// Uploads an RGBA8 pixel buffer to the GPU and returns an opaque, pointer-sized handle.
+	/// On OpenGL the value is the GL texture name widened to <see cref="nint"/>; on Metal
+	/// it will be a retained <c>id&lt;MTLTexture&gt;</c>.
+	/// </summary>
+	/// <param name="rgba">Tightly packed RGBA8 pixel data (<paramref name="width"/> * <paramref name="height"/> * 4 bytes).</param>
+	/// <param name="width">Texture width in pixels.</param>
+	/// <param name="height">Texture height in pixels.</param>
+	/// <returns>An opaque handle suitable for use as an ImGui texture id.</returns>
+	public nint CreateTexture(ReadOnlySpan<byte> rgba, int width, int height);
+
+	/// <summary>
+	/// Releases a texture previously returned by <see cref="CreateTexture"/>.
+	/// </summary>
+	/// <param name="id">The handle returned by <see cref="CreateTexture"/>.</param>
+	public void DeleteTexture(nint id);
+
+	/// <summary>
+	/// Submits a fully-built ImGui draw-data tree to the GPU. The backend is responsible
+	/// for setting up its own pipeline / state and restoring any state it touches.
+	/// </summary>
+	/// <param name="drawData">The draw data returned by <c>ImGui.GetDrawData()</c> after <c>ImGui.Render()</c>.</param>
+	public void RenderDrawData(ImDrawDataPtr drawData);
+}

--- a/ImGui.App/ImGuiApp.cs
+++ b/ImGui.App/ImGuiApp.cs
@@ -23,7 +23,6 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using Color = System.Drawing.Color;
-using Texture = ImGuiController.Texture;
 
 /// <summary>
 /// Provides static methods and properties to manage the ImGui application.
@@ -1111,32 +1110,14 @@ public static partial class ImGuiApp
 	{
 		return Invoker.Invoke(() =>
 		{
-			if (gl is null)
+			if (controller is null)
 			{
-				throw new InvalidOperationException("OpenGL context is not initialized.");
+				throw new InvalidOperationException("Renderer backend is not initialized.");
 			}
 
-			// Upload texture to graphics system
-			gl.GetInteger(GLEnum.TextureBinding2D, out int previousTextureId);
-
-			nint textureHandle = Marshal.AllocHGlobal(bytes.Length);
-			try
-			{
-				Marshal.Copy(bytes, 0, textureHandle, bytes.Length);
-				Texture texture = new(gl, width, height, textureHandle, pxFormat: PixelFormat.Rgba);
-				texture.Bind();
-				texture.SetMagFilter(TextureMagFilter.Linear);
-				texture.SetMinFilter(TextureMinFilter.Linear);
-
-				// Restore state
-				gl.BindTexture(GLEnum.Texture2D, (uint)previousTextureId);
-
-				return texture.GlTexture;
-			}
-			finally
-			{
-				Marshal.FreeHGlobal(textureHandle);
-			}
+			// The pooled buffer may be larger than the texture; only the first w*h*4 bytes are pixel data.
+			int pixelByteCount = width * height * 4;
+			return (uint)controller.CreateTexture(bytes.AsSpan(0, pixelByteCount), width, height);
 		});
 	}
 
@@ -1149,12 +1130,12 @@ public static partial class ImGuiApp
 	{
 		Invoker.Invoke(() =>
 		{
-			if (gl is null)
+			if (controller is null)
 			{
-				throw new InvalidOperationException("OpenGL context is not initialized.");
+				throw new InvalidOperationException("Renderer backend is not initialized.");
 			}
 
-			gl.DeleteTexture(textureId);
+			controller.DeleteTexture((nint)textureId);
 			Textures.Where(x => x.Value.TextureId == textureId).ToList().ForEach(x => Textures.Remove(x.Key, out ImGuiAppTextureInfo? _));
 		});
 	}

--- a/ImGui.App/ImGuiController/ImGuiController.cs
+++ b/ImGui.App/ImGuiController/ImGuiController.cs
@@ -14,7 +14,7 @@ using Silk.NET.Maths;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
 
-internal sealed class ImGuiController : IDisposable
+internal sealed class ImGuiController : IDisposable, IRendererBackend
 {
 
 	internal GL? _gl;
@@ -248,9 +248,43 @@ internal sealed class ImGuiController : IDisposable
 		{
 			_frameBegun = false;
 			ImGui.Render();
-			RenderImDrawData(ImGui.GetDrawData());
+			RenderDrawData(ImGui.GetDrawData());
 		}
 	}
+
+	/// <inheritdoc />
+	[System.Diagnostics.CodeAnalysis.SuppressMessage(
+		"Reliability",
+		"CA2000:Dispose objects before losing scope",
+		Justification = "The Texture wrapper's resource is the GL texture; we hand its name back to ImGui, " +
+			"so disposing here would delete the very texture we're returning. Lifetime is owned by the caller.")]
+	public unsafe nint CreateTexture(ReadOnlySpan<byte> rgba, int width, int height)
+	{
+		if (_gl is null)
+		{
+			throw new InvalidOperationException("OpenGL context is not initialized.");
+		}
+
+		// Preserve whatever was bound — the caller may be mid-frame.
+		_gl.GetInteger(GLEnum.TextureBinding2D, out int previousTextureId);
+
+		uint glTexture;
+		fixed (byte* pixelPtr = rgba)
+		{
+			Texture texture = new(_gl, width, height, (IntPtr)pixelPtr, pxFormat: PixelFormat.Rgba);
+			texture.Bind();
+			texture.SetMagFilter(TextureMagFilter.Linear);
+			texture.SetMinFilter(TextureMinFilter.Linear);
+			glTexture = texture.GlTexture;
+		}
+
+		_gl.BindTexture(GLEnum.Texture2D, (uint)previousTextureId);
+		return (nint)glTexture;
+	}
+
+	/// <inheritdoc />
+	// _gl can be null if the context has already been torn down; callers expect a no-op then.
+	public void DeleteTexture(nint id) => _gl?.DeleteTexture((uint)id);
 
 	/// <summary>
 	/// Updates ImGui input and IO configuration state.
@@ -546,7 +580,8 @@ internal sealed class ImGuiController : IDisposable
 		_gl.VertexAttribPointer((uint)_attribLocationVtxColor, 4, GLEnum.UnsignedByte, true, (uint)sizeof(ImDrawVert), (void*)16);
 	}
 
-	internal unsafe void RenderImDrawData(ImDrawDataPtr drawDataPtr)
+	/// <inheritdoc />
+	public unsafe void RenderDrawData(ImDrawDataPtr drawDataPtr)
 	{
 		if (_gl is null)
 		{


### PR DESCRIPTION
## Summary

First chunk of the [iOS platform port plan](https://github.com/ktsu-dev/ImGuiApp/blob/main/docs/plans/2026-05-28-ios-platform-port.md) — **Task 1: Extract `IRendererBackend` on desktop, no behavioural change.**

Establishes the backend-agnostic seam that the future Metal renderer (Task 4) will plug into:

```csharp
internal interface IRendererBackend : IDisposable
{
    nint CreateTexture(ReadOnlySpan<byte> rgba, int width, int height);
    void DeleteTexture(nint id);
    void RenderDrawData(ImDrawDataPtr drawData);
}
```

- `ImGuiController` now implements `IRendererBackend`. Texture upload code that used to live in `ImGuiApp.UploadTextureRGBA` (open-coding `gl.*` calls + a temporary unmanaged buffer + a `Texture` wrapper) moves into `ImGuiController.CreateTexture(ReadOnlySpan<byte>, int, int)`, which pins the span directly.
- `ImGuiApp.UploadTextureRGBA` / `DeleteTexture(uint)` now route through the controller's new methods. Texture-dictionary bookkeeping stays in `ImGuiApp`.
- Renamed `ImGuiController.RenderImDrawData` → `RenderDrawData` to match the interface.
- iOS stub is untouched.

## Out of scope (deferred to later tasks per the plan)

- **Public API breakage:** `ImGuiAppTextureInfo.TextureId` stays `uint`. The `nint` widening called out in plan §7 is a deliberate later breaking-change PR — internal casting handles it here.
- Lifecycle methods (`Update`, `FontsConfigured`, `Dispose`) stay on the concrete controller, not on the interface — those bits will move when the desktop frame loop is split out (plan §4).
- iOS Mac-CI matrix job (plan Task 2).
- Metal backend itself (Task 4).

## Test plan

- [x] `dotnet build ImGui.App/ImGui.App.csproj -f net10.0` — clean.
- [x] `dotnet test tests/ImGui.App.Tests` — **271/271 pass**.
- [x] `dotnet test tests/NodeGraph.Tests` — **106/106 pass**.
- [x] `dotnet build examples/ImGuiAppDemo -f net10.0` — clean.
- [ ] Run all four example apps on Windows/macOS to confirm rendering / texture loading is visually unchanged (requires non-Linux developer; refactor is mechanical but should be eyeballed before merge).

Note: the Linux container reports IDE0055 formatting noise on a clean working tree because git checked out files as LF while `.editorconfig` enforces CRLF — this predates the PR and is unaffected by it (the file-level error counts for the two modified files match baseline once you account for the new file).


---
_Generated by [Claude Code](https://claude.ai/code/session_0146sYzqmuzj4rFqk8BZiVWW)_