### PR TITLE
feat: gesture detection foundation for mobile widgets

### DIFF
--- a/ImGui.Widgets/Gestures/GestureDetector.cs
+++ b/ImGui.Widgets/Gestures/GestureDetector.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets;
+
+using System.Collections.Generic;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+using ktsu.ImGui.Widgets.Gestures;
+
+public static partial class ImGuiWidgets
+{
+	private static readonly Dictionary<uint, GestureMachine> GestureMachines = [];
+
+	/// <summary>
+	/// Claim a rectangular region with an invisible button and report mobile-style gestures
+	/// (tap, double-tap, long-press, swipe, pan) over it.
+	/// </summary>
+	/// <param name="label">Stable label used to push an ImGui ID for per-region state tracking.</param>
+	/// <param name="size">Region size in screen pixels.</param>
+	/// <param name="settings">Optional threshold overrides; defaults are mobile-friendly.</param>
+	/// <returns>Gestures that fired this frame plus continuous pointer state.</returns>
+	/// <remarks>
+	/// Mouse-only on desktop. The invisible button uses <see cref="ImGuiMouseButton.Left"/>.
+	/// State is keyed by <see cref="ImGui.GetID(string)"/> so the same label inside different
+	/// parent scopes yields distinct state.
+	/// </remarks>
+	public static GestureResult GestureDetector(string label, Vector2 size, GestureSettings? settings = null)
+	{
+		uint id = ImGui.GetID(label);
+		if (!GestureMachines.TryGetValue(id, out GestureMachine? machine))
+		{
+			machine = new GestureMachine(settings);
+			GestureMachines[id] = machine;
+		}
+
+		ImGui.InvisibleButton(label, size);
+
+		bool isActive = ImGui.IsItemActive();
+		Vector2 pos = ImGui.GetMousePos();
+		float deltaTime = ImGui.GetIO().DeltaTime;
+
+		return machine.Update(isActive, pos, deltaTime);
+	}
+
+	/// <summary>
+	/// Reset cached gesture state for a label. Call this when a screen unmounts or focus is lost
+	/// and you do not want a stale press to fire a tap on the next interaction.
+	/// </summary>
+	/// <param name="label">Label previously passed to <see cref="GestureDetector"/>.</param>
+	public static void ResetGestureDetector(string label)
+	{
+		uint id = ImGui.GetID(label);
+		if (GestureMachines.TryGetValue(id, out GestureMachine? machine))
+		{
+			machine.Reset();
+		}
+	}
+}

--- a/ImGui.Widgets/Gestures/GestureFlags.cs
+++ b/ImGui.Widgets/Gestures/GestureFlags.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Gestures;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Discrete gesture events that may fire on a given frame.
+/// Multiple flags can be set on the same frame (e.g. <see cref="Tap"/> + <see cref="PanEnd"/>
+/// is suppressed by the detector, but <see cref="PanEnd"/> + <see cref="SwipeRight"/> can co-occur).
+/// </summary>
+[Flags]
+[SuppressMessage(
+	"Naming",
+	"CA1711:Identifiers should not have incorrect suffix",
+	Justification = "The 'Flags' suffix is intentional and accurately describes a [Flags] enum used as a result bitmask; the alternatives (GestureKind/GestureType) would imply a single-value classification.")]
+public enum GestureFlags
+{
+	/// <summary>No gesture fired this frame.</summary>
+	None = 0,
+
+	/// <summary>Short press-and-release within tap distance and duration.</summary>
+	Tap = 1 << 0,
+
+	/// <summary>Second tap within the configured double-tap interval and radius.</summary>
+	DoubleTap = 1 << 1,
+
+	/// <summary>Pointer held in place past the long-press duration. Fires once per press.</summary>
+	LongPress = 1 << 2,
+
+	/// <summary>Release with a leftward velocity past the swipe threshold.</summary>
+	SwipeLeft = 1 << 3,
+
+	/// <summary>Release with a rightward velocity past the swipe threshold.</summary>
+	SwipeRight = 1 << 4,
+
+	/// <summary>Release with an upward velocity past the swipe threshold.</summary>
+	SwipeUp = 1 << 5,
+
+	/// <summary>Release with a downward velocity past the swipe threshold.</summary>
+	SwipeDown = 1 << 6,
+
+	/// <summary>First frame where movement exceeded the pan threshold.</summary>
+	PanStart = 1 << 7,
+
+	/// <summary>Pointer is being dragged. Set every frame from <see cref="PanStart"/> until release.</summary>
+	Pan = 1 << 8,
+
+	/// <summary>Pointer released after a pan. Set on the release frame.</summary>
+	PanEnd = 1 << 9,
+}

--- a/ImGui.Widgets/Gestures/GestureMachine.cs
+++ b/ImGui.Widgets/Gestures/GestureMachine.cs
@@ -1,0 +1,204 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Gestures;
+
+using System;
+using System.Numerics;
+
+/// <summary>
+/// UI-agnostic gesture state machine. Feed it the current pointer-down state, pointer position,
+/// and frame delta time; it returns the discrete gestures that fired this frame plus continuous
+/// state (start position, velocity, duration).
+/// </summary>
+/// <remarks>
+/// Single-pointer only. Multi-touch and pinch gestures are deferred until a touch-capable
+/// backend lands. Suitable for both mouse-driven desktop and (future) single-finger touch input.
+/// </remarks>
+public sealed class GestureMachine(GestureSettings? settings = null)
+{
+	private Vector2 _startPos;
+	private Vector2 _currentPos;
+	private Vector2 _lastPos;
+	private Vector2 _velocity;
+	private float _pressDuration;
+	private bool _longPressFired;
+	private bool _panActive;
+	private float _timeSinceLastTap = float.MaxValue;
+	private Vector2 _lastTapPos;
+
+	/// <summary>Settings used by this machine.</summary>
+	public GestureSettings Settings { get; } = settings ?? new GestureSettings();
+
+	/// <summary>True while a press is active (pointer down since the last release).</summary>
+	public bool IsPressed { get; private set; }
+
+	/// <summary>
+	/// Advance the state machine by one frame.
+	/// </summary>
+	/// <param name="pressed">True if the pointer is currently down over the detector.</param>
+	/// <param name="pos">Current pointer position (any consistent coordinate space).</param>
+	/// <param name="deltaTime">Seconds since the previous call. Must be &gt;= 0.</param>
+	/// <returns>The gestures that fired this frame along with continuous state.</returns>
+	public GestureResult Update(bool pressed, Vector2 pos, float deltaTime)
+	{
+		if (deltaTime < 0.0f)
+		{
+			deltaTime = 0.0f;
+		}
+
+		GestureFlags fired = GestureFlags.None;
+
+		// Tick the double-tap window even when nothing is pressed.
+		if (_timeSinceLastTap < float.MaxValue)
+		{
+			_timeSinceLastTap += deltaTime;
+		}
+
+		bool justPressed = pressed && !IsPressed;
+		bool justReleased = !pressed && IsPressed;
+
+		if (justPressed)
+		{
+			_startPos = pos;
+			_currentPos = pos;
+			_lastPos = pos;
+			_velocity = Vector2.Zero;
+			_pressDuration = 0.0f;
+			_longPressFired = false;
+			_panActive = false;
+			IsPressed = true;
+		}
+		else if (IsPressed)
+		{
+			_pressDuration += deltaTime;
+
+			Vector2 frameDelta = pos - _lastPos;
+			Vector2 instantVelocity = deltaTime > 0.0f ? frameDelta / deltaTime : Vector2.Zero;
+
+			// Exponential smoothing: blend new sample toward stored velocity by the smoothing factor.
+			float smoothing = Math.Clamp(Settings.VelocitySmoothing, 0.0f, 1.0f);
+			_velocity = (_velocity * smoothing) + (instantVelocity * (1.0f - smoothing));
+
+			_currentPos = pos;
+			_lastPos = pos;
+
+			Vector2 totalDelta = _currentPos - _startPos;
+			float totalDistance = totalDelta.Length();
+
+			// Long-press fires once when the pointer has stayed roughly still past the threshold.
+			if (!_longPressFired
+				&& _pressDuration >= Settings.LongPressMinDuration
+				&& totalDistance <= Settings.TapMaxDistance)
+			{
+				fired |= GestureFlags.LongPress;
+				_longPressFired = true;
+			}
+
+			// Pan promotion: once we've moved past the threshold we're in a pan for the rest of this press.
+			if (!_panActive && totalDistance > Settings.PanMinDistance)
+			{
+				_panActive = true;
+				fired |= GestureFlags.PanStart;
+			}
+
+			if (_panActive)
+			{
+				fired |= GestureFlags.Pan;
+			}
+		}
+
+		if (justReleased)
+		{
+			Vector2 totalDelta = _currentPos - _startPos;
+			float totalDistance = totalDelta.Length();
+			bool wasPan = _panActive;
+			Vector2 releaseVelocity = _velocity;
+
+			if (wasPan)
+			{
+				fired |= GestureFlags.PanEnd;
+
+				GestureFlags swipe = ClassifySwipe(totalDelta, releaseVelocity);
+				fired |= swipe;
+			}
+			else if (!_longPressFired
+				&& _pressDuration <= Settings.TapMaxDuration
+				&& totalDistance <= Settings.TapMaxDistance)
+			{
+				bool isDoubleTap =
+					_timeSinceLastTap <= Settings.DoubleTapMaxInterval
+					&& Vector2.Distance(_startPos, _lastTapPos) <= Settings.DoubleTapMaxDistance;
+
+				if (isDoubleTap)
+				{
+					fired |= GestureFlags.DoubleTap;
+					// Reset so a third quick tap does NOT chain into another double-tap.
+					_timeSinceLastTap = float.MaxValue;
+				}
+				else
+				{
+					fired |= GestureFlags.Tap;
+					_timeSinceLastTap = 0.0f;
+					_lastTapPos = _startPos;
+				}
+			}
+
+			IsPressed = false;
+			_panActive = false;
+			_pressDuration = 0.0f;
+		}
+
+		return new GestureResult(
+			Gestures: fired,
+			IsPressed: IsPressed,
+			StartPos: IsPressed ? _startPos : (fired != GestureFlags.None ? _startPos : Vector2.Zero),
+			CurrentPos: _currentPos,
+			Delta: _currentPos - _startPos,
+			Velocity: _velocity,
+			PressDuration: IsPressed ? _pressDuration : 0.0f);
+	}
+
+	/// <summary>Drop all in-flight state. Use when the host element loses focus or unmounts.</summary>
+	public void Reset()
+	{
+		IsPressed = false;
+		_startPos = Vector2.Zero;
+		_currentPos = Vector2.Zero;
+		_lastPos = Vector2.Zero;
+		_velocity = Vector2.Zero;
+		_pressDuration = 0.0f;
+		_longPressFired = false;
+		_panActive = false;
+		_timeSinceLastTap = float.MaxValue;
+		_lastTapPos = Vector2.Zero;
+	}
+
+	private GestureFlags ClassifySwipe(Vector2 totalDelta, Vector2 releaseVelocity)
+	{
+		float absDx = MathF.Abs(totalDelta.X);
+		float absDy = MathF.Abs(totalDelta.Y);
+		float absVx = MathF.Abs(releaseVelocity.X);
+		float absVy = MathF.Abs(releaseVelocity.Y);
+
+		bool horizontalDominant = absDx >= absDy;
+
+		if (horizontalDominant)
+		{
+			if (absDx >= Settings.SwipeMinDistance && absVx >= Settings.SwipeMinVelocity)
+			{
+				return totalDelta.X < 0 ? GestureFlags.SwipeLeft : GestureFlags.SwipeRight;
+			}
+		}
+		else
+		{
+			if (absDy >= Settings.SwipeMinDistance && absVy >= Settings.SwipeMinVelocity)
+			{
+				return totalDelta.Y < 0 ? GestureFlags.SwipeUp : GestureFlags.SwipeDown;
+			}
+		}
+
+		return GestureFlags.None;
+	}
+}

--- a/ImGui.Widgets/Gestures/GestureResult.cs
+++ b/ImGui.Widgets/Gestures/GestureResult.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Gestures;
+
+using System.Numerics;
+
+/// <summary>
+/// Snapshot of the gesture state for a single frame.
+/// </summary>
+/// <param name="Gestures">Discrete events that fired this frame.</param>
+/// <param name="IsPressed">True while the pointer is held over the detector.</param>
+/// <param name="StartPos">Screen position where the current press began (zero if no press is active and no gesture fired).</param>
+/// <param name="CurrentPos">Pointer position this frame.</param>
+/// <param name="Delta">Total movement from press start to the current frame.</param>
+/// <param name="Velocity">Smoothed pointer velocity in pixels per second.</param>
+/// <param name="PressDuration">Seconds elapsed since the current press began (zero when not pressed).</param>
+public readonly record struct GestureResult(
+	GestureFlags Gestures,
+	bool IsPressed,
+	Vector2 StartPos,
+	Vector2 CurrentPos,
+	Vector2 Delta,
+	Vector2 Velocity,
+	float PressDuration)
+{
+	/// <summary>True if any discrete gesture fired this frame.</summary>
+	public bool HasGesture => Gestures != GestureFlags.None;
+
+	/// <summary>Convenience accessor for <see cref="GestureFlags.Tap"/>.</summary>
+	public bool Tapped => (Gestures & GestureFlags.Tap) != 0;
+
+	/// <summary>Convenience accessor for <see cref="GestureFlags.DoubleTap"/>.</summary>
+	public bool DoubleTapped => (Gestures & GestureFlags.DoubleTap) != 0;
+
+	/// <summary>Convenience accessor for <see cref="GestureFlags.LongPress"/>.</summary>
+	public bool LongPressed => (Gestures & GestureFlags.LongPress) != 0;
+}

--- a/ImGui.Widgets/Gestures/GestureSettings.cs
+++ b/ImGui.Widgets/Gestures/GestureSettings.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Gestures;
+
+/// <summary>
+/// Thresholds controlling how the gesture state machine classifies pointer input.
+/// Distances are in screen pixels; durations are in seconds; velocity in pixels per second.
+/// </summary>
+public sealed record GestureSettings
+{
+	/// <summary>Maximum total movement that still counts as a tap rather than a pan.</summary>
+	public float TapMaxDistance { get; init; } = 10.0f;
+
+	/// <summary>Maximum press duration that still counts as a tap.</summary>
+	public float TapMaxDuration { get; init; } = 0.3f;
+
+	/// <summary>Maximum interval between two taps for the second to count as a double-tap.</summary>
+	public float DoubleTapMaxInterval { get; init; } = 0.3f;
+
+	/// <summary>Maximum distance between two taps for the second to count as a double-tap.</summary>
+	public float DoubleTapMaxDistance { get; init; } = 25.0f;
+
+	/// <summary>Minimum press duration before a long-press fires.</summary>
+	public float LongPressMinDuration { get; init; } = 0.5f;
+
+	/// <summary>Minimum release velocity (px/sec) along the dominant axis for a swipe.</summary>
+	public float SwipeMinVelocity { get; init; } = 600.0f;
+
+	/// <summary>Minimum total travel along the dominant axis for a swipe.</summary>
+	public float SwipeMinDistance { get; init; } = 50.0f;
+
+	/// <summary>Movement past this distance promotes the gesture from "pending" to a pan.</summary>
+	public float PanMinDistance { get; init; } = 6.0f;
+
+	/// <summary>
+	/// Smoothing factor for exponential velocity averaging (0 = instantaneous, 1 = frozen).
+	/// Values around 0.6 give a stable reading while still reacting to flicks.
+	/// </summary>
+	public float VelocitySmoothing { get; init; } = 0.6f;
+}

--- a/ImGui.sln
+++ b/ImGui.sln
@@ -37,6 +37,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ForceDirectedLayout.Native"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ForceDirectedLayout.Tests", "tests\ForceDirectedLayout.Tests\ForceDirectedLayout.Tests.csproj", "{D039461F-1A6A-420F-8C7C-F93B5C31D331}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImGui.Widgets.Tests", "tests\ImGui.Widgets.Tests\ImGui.Widgets.Tests.csproj", "{2FD2D844-481B-4A05-8B69-19D61DFAA878}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -227,6 +229,18 @@ Global
 		{D039461F-1A6A-420F-8C7C-F93B5C31D331}.Release|x64.Build.0 = Release|Any CPU
 		{D039461F-1A6A-420F-8C7C-F93B5C31D331}.Release|x86.ActiveCfg = Release|Any CPU
 		{D039461F-1A6A-420F-8C7C-F93B5C31D331}.Release|x86.Build.0 = Release|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Debug|x64.Build.0 = Debug|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Debug|x86.Build.0 = Debug|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Release|x64.ActiveCfg = Release|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Release|x64.Build.0 = Release|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Release|x86.ActiveCfg = Release|Any CPU
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -239,6 +253,7 @@ Global
 		{D1B3E399-F4E4-D537-46FE-2585AF4E9262} = {5F0E6F1C-44C1-42B7-ADF4-770ABB471B40}
 		{14A700C3-85E0-4782-81C8-FBDA250F1886} = {5F0E6F1C-44C1-42B7-ADF4-770ABB471B40}
 		{D039461F-1A6A-420F-8C7C-F93B5C31D331} = {5F0E6F1C-44C1-42B7-ADF4-770ABB471B40}
+		{2FD2D844-481B-4A05-8B69-19D61DFAA878} = {5F0E6F1C-44C1-42B7-ADF4-770ABB471B40}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {14515AC1-A74C-4CBB-98F2-9DA660E967EF}

--- a/tests/ImGui.Widgets.Tests/GestureMachineTests.cs
+++ b/tests/ImGui.Widgets.Tests/GestureMachineTests.cs
@@ -1,0 +1,234 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Tests;
+
+using System.Numerics;
+
+using ktsu.ImGui.Widgets.Gestures;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class GestureMachineTests
+{
+	private static GestureSettings DefaultSettings => new();
+
+	private static GestureMachine NewMachine(GestureSettings? settings = null) => new(settings ?? DefaultSettings);
+
+	[TestMethod]
+	public void Update_NotPressed_ReportsNoGesture()
+	{
+		GestureMachine machine = NewMachine();
+		GestureResult r = machine.Update(pressed: false, pos: Vector2.Zero, deltaTime: 0.016f);
+
+		Assert.AreEqual(GestureFlags.None, r.Gestures);
+		Assert.IsFalse(r.IsPressed);
+	}
+
+	[TestMethod]
+	public void Update_QuickPressRelease_EmitsTap()
+	{
+		GestureMachine machine = NewMachine();
+		Vector2 pos = new(100, 100);
+
+		GestureResult press = machine.Update(pressed: true, pos, deltaTime: 0.016f);
+		Assert.AreEqual(GestureFlags.None, press.Gestures);
+		Assert.IsTrue(press.IsPressed);
+
+		GestureResult release = machine.Update(pressed: false, pos, deltaTime: 0.016f);
+		Assert.AreEqual(GestureFlags.Tap, release.Gestures);
+		Assert.IsTrue(release.Tapped);
+		Assert.IsFalse(release.IsPressed);
+	}
+
+	[TestMethod]
+	public void Update_LongDuration_NoMovement_EmitsLongPress()
+	{
+		GestureSettings settings = DefaultSettings with { LongPressMinDuration = 0.5f };
+		GestureMachine machine = NewMachine(settings);
+		Vector2 pos = new(50, 50);
+
+		machine.Update(pressed: true, pos, deltaTime: 0.016f);
+
+		// Hold for 0.6s in 0.1s chunks. Long press should fire exactly once.
+		int longPressFireCount = 0;
+		for (int i = 0; i < 6; i++)
+		{
+			GestureResult r = machine.Update(pressed: true, pos, deltaTime: 0.1f);
+			if (r.LongPressed)
+			{
+				longPressFireCount++;
+			}
+		}
+
+		Assert.AreEqual(1, longPressFireCount, "LongPress must fire exactly once per press.");
+
+		// Releasing after long-press should NOT also emit Tap.
+		GestureResult release = machine.Update(pressed: false, pos, deltaTime: 0.016f);
+		Assert.IsFalse(release.Tapped, "Releasing after a long-press must not also count as a tap.");
+	}
+
+	[TestMethod]
+	public void Update_MoveBeyondPanThreshold_EmitsPanStartThenPan()
+	{
+		GestureSettings settings = DefaultSettings with { PanMinDistance = 5.0f };
+		GestureMachine machine = NewMachine(settings);
+
+		machine.Update(pressed: true, pos: new(0, 0), deltaTime: 0.016f);
+		GestureResult mid = machine.Update(pressed: true, pos: new(20, 0), deltaTime: 0.016f);
+
+		Assert.IsTrue((mid.Gestures & GestureFlags.PanStart) != 0, "PanStart should fire on the frame the threshold is crossed.");
+		Assert.IsTrue((mid.Gestures & GestureFlags.Pan) != 0, "Pan should also be flagged on the start frame.");
+
+		GestureResult next = machine.Update(pressed: true, pos: new(30, 0), deltaTime: 0.016f);
+		Assert.IsTrue((next.Gestures & GestureFlags.Pan) != 0);
+		Assert.IsTrue((next.Gestures & GestureFlags.PanStart) == 0, "PanStart should only fire once per press.");
+	}
+
+	[TestMethod]
+	public void Update_ReleaseAfterPan_EmitsPanEnd()
+	{
+		GestureMachine machine = NewMachine();
+		machine.Update(pressed: true, pos: new(0, 0), deltaTime: 0.016f);
+		machine.Update(pressed: true, pos: new(50, 0), deltaTime: 0.016f);
+
+		GestureResult release = machine.Update(pressed: false, pos: new(50, 0), deltaTime: 0.016f);
+		Assert.IsTrue((release.Gestures & GestureFlags.PanEnd) != 0);
+		Assert.IsFalse(release.Tapped, "Pan release should not also be a tap.");
+	}
+
+	[TestMethod]
+	public void Update_FastRightMovement_EmitsSwipeRight()
+	{
+		// Cover ~200px in 5 frames at 60Hz = 2400 px/s, well above 600 px/s threshold.
+		GestureMachine machine = NewMachine();
+		machine.Update(pressed: true, pos: new(0, 0), deltaTime: 0.016f);
+		for (int i = 1; i <= 5; i++)
+		{
+			machine.Update(pressed: true, pos: new(i * 40, 0), deltaTime: 0.016f);
+		}
+
+		GestureResult release = machine.Update(pressed: false, pos: new(200, 0), deltaTime: 0.016f);
+		Assert.IsTrue((release.Gestures & GestureFlags.SwipeRight) != 0, $"Fast horizontal drag should produce SwipeRight. Velocity={release.Velocity}");
+		Assert.IsTrue((release.Gestures & GestureFlags.PanEnd) != 0);
+	}
+
+	[TestMethod]
+	public void Update_FastUpMovement_EmitsSwipeUp()
+	{
+		GestureMachine machine = NewMachine();
+		machine.Update(pressed: true, pos: new(0, 0), deltaTime: 0.016f);
+		for (int i = 1; i <= 5; i++)
+		{
+			machine.Update(pressed: true, pos: new(0, -i * 40), deltaTime: 0.016f);
+		}
+
+		GestureResult release = machine.Update(pressed: false, pos: new(0, -200), deltaTime: 0.016f);
+		Assert.IsTrue((release.Gestures & GestureFlags.SwipeUp) != 0, $"Fast upward drag should produce SwipeUp. Velocity={release.Velocity}");
+	}
+
+	[TestMethod]
+	public void Update_SlowPanRelease_NoSwipe()
+	{
+		// 60px over 60 frames = 60 px/s, way below the 600 px/s swipe threshold.
+		GestureMachine machine = NewMachine();
+		machine.Update(pressed: true, pos: new(0, 0), deltaTime: 0.016f);
+		for (int i = 1; i <= 60; i++)
+		{
+			machine.Update(pressed: true, pos: new(i, 0), deltaTime: 0.016f);
+		}
+
+		GestureResult release = machine.Update(pressed: false, pos: new(60, 0), deltaTime: 0.016f);
+		Assert.IsTrue((release.Gestures & GestureFlags.PanEnd) != 0);
+		Assert.AreEqual(GestureFlags.None, release.Gestures & (GestureFlags.SwipeLeft | GestureFlags.SwipeRight | GestureFlags.SwipeUp | GestureFlags.SwipeDown));
+	}
+
+	[TestMethod]
+	public void Update_TwoQuickTapsAtSamePoint_EmitsDoubleTap()
+	{
+		GestureMachine machine = NewMachine();
+		Vector2 pos = new(40, 40);
+
+		// First tap.
+		machine.Update(pressed: true, pos, deltaTime: 0.016f);
+		GestureResult first = machine.Update(pressed: false, pos, deltaTime: 0.016f);
+		Assert.IsTrue(first.Tapped);
+
+		// Short gap before second tap.
+		machine.Update(pressed: false, pos, deltaTime: 0.1f);
+
+		// Second tap at the same point.
+		machine.Update(pressed: true, pos, deltaTime: 0.016f);
+		GestureResult second = machine.Update(pressed: false, pos, deltaTime: 0.016f);
+
+		Assert.IsTrue(second.DoubleTapped, "Second quick tap at the same point should produce DoubleTap.");
+		Assert.IsFalse(second.Tapped, "DoubleTap should not also emit a Tap on the same frame.");
+	}
+
+	[TestMethod]
+	public void Update_TwoTapsTooFarApart_NoDoubleTap()
+	{
+		GestureSettings settings = DefaultSettings with { DoubleTapMaxDistance = 10.0f };
+		GestureMachine machine = NewMachine(settings);
+
+		machine.Update(pressed: true, pos: new(0, 0), deltaTime: 0.016f);
+		machine.Update(pressed: false, pos: new(0, 0), deltaTime: 0.016f);
+
+		machine.Update(pressed: false, pos: new(100, 100), deltaTime: 0.05f);
+
+		machine.Update(pressed: true, pos: new(100, 100), deltaTime: 0.016f);
+		GestureResult second = machine.Update(pressed: false, pos: new(100, 100), deltaTime: 0.016f);
+
+		Assert.IsTrue(second.Tapped, "Second tap far from the first should be a fresh Tap, not DoubleTap.");
+		Assert.IsFalse(second.DoubleTapped);
+	}
+
+	[TestMethod]
+	public void Update_TwoTapsWithLongGap_NoDoubleTap()
+	{
+		GestureSettings settings = DefaultSettings with { DoubleTapMaxInterval = 0.3f };
+		GestureMachine machine = NewMachine(settings);
+
+		machine.Update(pressed: true, pos: new(5, 5), deltaTime: 0.016f);
+		machine.Update(pressed: false, pos: new(5, 5), deltaTime: 0.016f);
+
+		// Sleep longer than the double-tap interval.
+		machine.Update(pressed: false, pos: new(5, 5), deltaTime: 0.5f);
+
+		machine.Update(pressed: true, pos: new(5, 5), deltaTime: 0.016f);
+		GestureResult second = machine.Update(pressed: false, pos: new(5, 5), deltaTime: 0.016f);
+
+		Assert.IsTrue(second.Tapped);
+		Assert.IsFalse(second.DoubleTapped);
+	}
+
+	[TestMethod]
+	public void Reset_ClearsActivePress()
+	{
+		GestureMachine machine = NewMachine();
+		machine.Update(pressed: true, pos: new(10, 10), deltaTime: 0.016f);
+		Assert.IsTrue(machine.IsPressed);
+
+		machine.Reset();
+		Assert.IsFalse(machine.IsPressed);
+
+		// A subsequent release should NOT fire a tap because the press was cleared.
+		GestureResult release = machine.Update(pressed: false, pos: new(10, 10), deltaTime: 0.016f);
+		Assert.AreEqual(GestureFlags.None, release.Gestures);
+	}
+
+	[TestMethod]
+	public void Update_NegativeDeltaTime_IsClampedToZero()
+	{
+		GestureMachine machine = NewMachine();
+		// Negative delta should not crash or produce wild velocity.
+		machine.Update(pressed: true, pos: new(0, 0), deltaTime: -1.0f);
+		GestureResult r = machine.Update(pressed: true, pos: new(10, 0), deltaTime: -0.5f);
+
+		Assert.IsTrue(r.IsPressed);
+		// With clamped delta, velocity should be zero (deltaTime==0 branch).
+		Assert.AreEqual(Vector2.Zero, r.Velocity);
+	}
+}

--- a/tests/ImGui.Widgets.Tests/ImGui.Widgets.Tests.csproj
+++ b/tests/ImGui.Widgets.Tests/ImGui.Widgets.Tests.csproj
@@ -1,0 +1,18 @@
+<Project>
+  <Sdk Name="MSTest.Sdk" />
+  <Sdk Name="ktsu.Sdk" />
+
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks></TargetFrameworks>
+    <RootNamespace>ktsu.ImGui.Widgets.Tests</RootNamespace>
+    <AssemblyName>$(RootNamespace)</AssemblyName>
+    <EnableSourceLink>false</EnableSourceLink>
+    <NoWarn>CA1051;CA1002;CA1062;CA1515;CA1707;CA1815;CA1819;CA1822;CA2227;CS8604;IDE0060;MSTEST0039</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ImGui.Widgets\ImGui.Widgets.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Lands Phase 0 of the [mobile UI widgets plan](docs/plans/2026-05-28-mobile-ui-widgets.md): a reusable gesture detector that downstream mobile widgets (`SwipeableListItem`, `PullToRefresh`, `Carousel`, `LongPressMenu`, `BottomSheet`) will all depend on.

- **`GestureMachine`** — UI-agnostic state machine. Feed it `(pressed, pos, deltaTime)` per frame; it returns the gestures that fired plus continuous state (start pos, velocity, duration).
- **`ImGuiWidgets.GestureDetector(label, size, settings?)`** — ImGui binding that claims a rectangular region with an invisible button and delegates to `GestureMachine`. Per-region state is keyed by `ImGui.GetID(label)`.
- **Gestures supported**: `Tap`, `DoubleTap`, `LongPress`, `SwipeLeft/Right/Up/Down`, `PanStart`/`Pan`/`PanEnd`. Tunable via `GestureSettings`.
- Mouse-only for now &mdash; multi-touch / pinch are deferred until a touch-capable backend lands (called out as an open question in the plan).

## Design notes

- The state machine is pure, with no ImGui dependency, so it is unit-testable and the Phase 2 widgets that consume it stay decoupled from the input API.
- Long-press fires once per press and suppresses the trailing `Tap`. A pan release suppresses tap classification and emits `PanEnd` plus an optional `Swipe*` based on velocity and dominant-axis travel.
- Double-tap requires both the inter-tap interval **and** the inter-tap distance to be within configured bounds; a third quick tap does not chain into another double-tap.
- Velocity uses exponential smoothing so a stable read survives jitter, while flick-style releases still cross the swipe threshold.

## Test plan

- [x] `ImGui.Widgets` builds clean (verified locally on `net10.0`)
- [x] New `ImGui.Widgets.Tests` project added to the solution under `Tests`
- [x] Tests cover: tap, long-press (single-fire + tap suppression), pan start/continue, pan end, horizontal & vertical swipes, slow drag (no swipe), same-point double-tap, far-apart double-tap rejection, long-gap double-tap rejection, reset, negative delta clamping
- [ ] CI on Windows compiles both projects and runs the test suite

## Out of scope

Other Phase 0 items (`Tween`/`Spring`, `InertialScroll`, `OverlayHost`) will land in follow-up PRs as the plan suggests.


---
_Generated by [Claude Code](https://claude.ai/code/session_016oxXTQpPRnfa5P6Cz56C1X)_