### PR TITLE
feat: animation primitives (Easing, Tween, Spring) for mobile widgets

### DIFF
--- a/ImGui.Widgets/Animation/Easing.cs
+++ b/ImGui.Widgets/Animation/Easing.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Animation;
+
+using System;
+
+/// <summary>
+/// Easing functions normalized over <c>t &#x2208; [0, 1]</c> returning values in the same range
+/// (back / elastic / bounce variants can overshoot slightly). Pass any of these as the curve
+/// argument to <see cref="Tween"/>.
+/// </summary>
+public static class Easing
+{
+	/// <summary>No easing &#x2014; returns <paramref name="t"/> unchanged.</summary>
+	public static float Linear(float t) => t;
+
+	/// <summary>Slow start, accelerates quadratically.</summary>
+	public static float InQuad(float t) => t * t;
+
+	/// <summary>Fast start, decelerates quadratically. Good default for snappy UI fades.</summary>
+	public static float OutQuad(float t) => 1.0f - ((1.0f - t) * (1.0f - t));
+
+	/// <summary>Symmetric quadratic easing.</summary>
+	public static float InOutQuad(float t) => t < 0.5f
+		? 2.0f * t * t
+		: 1.0f - (MathF.Pow((-2.0f * t) + 2.0f, 2.0f) / 2.0f);
+
+	/// <summary>Slow start, accelerates cubically.</summary>
+	public static float InCubic(float t) => t * t * t;
+
+	/// <summary>Fast start, decelerates cubically. The mobile-UI default for entrances.</summary>
+	public static float OutCubic(float t) => 1.0f - MathF.Pow(1.0f - t, 3.0f);
+
+	/// <summary>Symmetric cubic easing.</summary>
+	public static float InOutCubic(float t) => t < 0.5f
+		? 4.0f * t * t * t
+		: 1.0f - (MathF.Pow((-2.0f * t) + 2.0f, 3.0f) / 2.0f);
+
+	/// <summary>Cubic with a small overshoot at the end &#x2014; "pops" into place.</summary>
+	public static float OutBack(float t)
+	{
+		const float c1 = 1.70158f;
+		const float c3 = c1 + 1.0f;
+		float u = t - 1.0f;
+		return 1.0f + (c3 * u * u * u) + (c1 * u * u);
+	}
+
+	/// <summary>Cubic that pulls back before launching forward.</summary>
+	public static float InBack(float t)
+	{
+		const float c1 = 1.70158f;
+		const float c3 = c1 + 1.0f;
+		return (c3 * t * t * t) - (c1 * t * t);
+	}
+}

--- a/ImGui.Widgets/Animation/Spring.cs
+++ b/ImGui.Widgets/Animation/Spring.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Animation;
+
+using System;
+
+/// <summary>
+/// Damped harmonic oscillator: a value chases a target with mass-spring physics.
+/// Frame-rate independent via fixed-substep semi-implicit Euler.
+/// </summary>
+/// <remarks>
+/// The motion is governed by <c>ẍ = -k(x - target) - c·v</c> where <c>k</c> is <see cref="Stiffness"/>
+/// and <c>c</c> is <see cref="Damping"/>. Critical damping at <c>c = 2·&#x221A;k</c>; under-damped values
+/// oscillate, over-damped values approach the target without overshoot but more slowly.
+/// </remarks>
+/// <param name="initial">Starting position; also the initial <see cref="Target"/>.</param>
+/// <param name="stiffness">Spring constant <c>k</c>. Higher = snappier.</param>
+/// <param name="damping">Damping coefficient <c>c</c>. Critical damping is <c>2 &#xB7; &#x221A;stiffness</c>.</param>
+public sealed class Spring(float initial = 0.0f, float stiffness = 170.0f, float damping = 26.0f)
+{
+	private const float SubStep = 1.0f / 240.0f;
+
+	/// <summary>Spring constant <c>k</c>. Higher = faster, stiffer pull toward the target.</summary>
+	public float Stiffness { get; set; } = stiffness;
+
+	/// <summary>Damping coefficient <c>c</c>. Critical damping is <c>2 &#xB7; &#x221A;Stiffness</c>.</summary>
+	public float Damping { get; set; } = damping;
+
+	/// <summary>Where the spring is trying to settle.</summary>
+	public float Target { get; set; } = initial;
+
+	/// <summary>Current position. Mutated each <see cref="Update"/>.</summary>
+	public float Value { get; private set; } = initial;
+
+	/// <summary>Current velocity. Mutated each <see cref="Update"/>.</summary>
+	public float Velocity { get; private set; }
+
+	/// <summary>
+	/// Distance-and-velocity threshold below which the spring is considered at rest and
+	/// <see cref="IsActive"/> flips false. The spring snaps to <see cref="Target"/> on rest.
+	/// </summary>
+	public float RestThreshold { get; init; } = 0.01f;
+
+	/// <summary>True while the spring is still settling. Use this to gate frame-rate boosts.</summary>
+	public bool IsActive => MathF.Abs(Value - Target) > RestThreshold
+		|| MathF.Abs(Velocity) > RestThreshold;
+
+	/// <summary>
+	/// Advance the spring by <paramref name="deltaTime"/> seconds and return the new value.
+	/// The simulation is sub-stepped internally so large dt does not destabilize the integrator.
+	/// </summary>
+	public float Update(float deltaTime)
+	{
+		if (deltaTime <= 0.0f)
+		{
+			return Value;
+		}
+
+		float remaining = deltaTime;
+		while (remaining > 0.0f)
+		{
+			float step = MathF.Min(remaining, SubStep);
+			remaining -= step;
+
+			float accel = (-Stiffness * (Value - Target)) - (Damping * Velocity);
+			// Semi-implicit Euler: integrate velocity first, then position with new velocity.
+			Velocity += accel * step;
+			Value += Velocity * step;
+		}
+
+		if (!IsActive)
+		{
+			Value = Target;
+			Velocity = 0.0f;
+		}
+
+		return Value;
+	}
+
+	/// <summary>
+	/// Jump immediately to <paramref name="value"/> and clear velocity. The spring is at rest afterward
+	/// until <see cref="Target"/> is changed.
+	/// </summary>
+	public void SnapTo(float value)
+	{
+		Value = value;
+		Target = value;
+		Velocity = 0.0f;
+	}
+
+	/// <summary>Set a new target without disturbing position or velocity. Equivalent to assigning <see cref="Target"/>.</summary>
+	public void SetTarget(float target) => Target = target;
+}

--- a/ImGui.Widgets/Animation/Tween.cs
+++ b/ImGui.Widgets/Animation/Tween.cs
@@ -1,0 +1,146 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Animation;
+
+using System;
+
+/// <summary>
+/// Time-based interpolation from <see cref="Start"/> to <see cref="End"/> over <see cref="Duration"/>
+/// seconds, shaped by an easing function. Frame-rate independent: caller supplies <c>deltaTime</c>.
+/// </summary>
+/// <remarks>
+/// Single-value (float) interpolation. Compose two Tweens for a Vector2, three for a Vector3, etc.
+/// Set <see cref="Repeat"/> for an unbounded loop or <see cref="PingPong"/> for a back-and-forth.
+/// </remarks>
+public sealed class Tween
+{
+	private readonly Func<float, float> _curve;
+
+	/// <summary>Initial value at <c>t = 0</c>.</summary>
+	public float Start { get; }
+
+	/// <summary>Final value at <c>t = Duration</c>.</summary>
+	public float End { get; }
+
+	/// <summary>Total length of one cycle in seconds. Zero or negative duration produces an instant snap.</summary>
+	public float Duration { get; }
+
+	/// <summary>When true the tween restarts from <see cref="Start"/> after reaching <see cref="End"/>.</summary>
+	public bool Repeat { get; init; }
+
+	/// <summary>When true the tween reverses direction at each endpoint instead of snapping back to <see cref="Start"/>.</summary>
+	public bool PingPong { get; init; }
+
+	/// <summary>Seconds elapsed in the current cycle.</summary>
+	public float Elapsed { get; private set; }
+
+	/// <summary>Current interpolated value, refreshed on each <see cref="Update"/>.</summary>
+	public float Value { get; private set; }
+
+	/// <summary>True while the tween still has work to do this frame (non-repeating tweens flip to false when complete).</summary>
+	public bool IsActive { get; private set; }
+
+	/// <summary>True for a non-repeating tween that has reached its end.</summary>
+	public bool IsComplete => !IsActive;
+
+	/// <summary>
+	/// Initializes a new tween. Pass an easing function from <see cref="Easing"/> (e.g.
+	/// <see cref="Easing.OutCubic"/>); defaults to <see cref="Easing.Linear"/> when null.
+	/// </summary>
+	public Tween(float start, float end, float duration, Func<float, float>? easing = null)
+	{
+		Start = start;
+		End = end;
+		Duration = duration;
+		_curve = easing ?? Easing.Linear;
+		Value = start;
+		IsActive = duration > 0.0f;
+		if (!IsActive)
+		{
+			Value = end;
+			Elapsed = MathF.Max(duration, 0.0f);
+		}
+	}
+
+	/// <summary>
+	/// Advance the tween by <paramref name="deltaTime"/> seconds and return the new value.
+	/// </summary>
+	public float Update(float deltaTime)
+	{
+		if (deltaTime < 0.0f)
+		{
+			deltaTime = 0.0f;
+		}
+
+		if (!IsActive && !Repeat && !PingPong)
+		{
+			return Value;
+		}
+
+		if (Duration <= 0.0f)
+		{
+			Value = End;
+			IsActive = false;
+			return Value;
+		}
+
+		Elapsed += deltaTime;
+
+		float cycle = Elapsed / Duration;
+		bool reverse = false;
+
+		if (Repeat || PingPong)
+		{
+			if (PingPong)
+			{
+				// Treat each Duration as a half-cycle; even halves go forward, odd halves backward.
+				int half = (int)MathF.Floor(cycle);
+				float frac = cycle - half;
+				reverse = (half % 2) == 1;
+				cycle = reverse ? 1.0f - frac : frac;
+			}
+			else
+			{
+				cycle -= MathF.Floor(cycle);
+			}
+		}
+		else if (cycle >= 1.0f)
+		{
+			Value = End;
+			IsActive = false;
+			Elapsed = Duration;
+			return Value;
+		}
+
+		float t = Math.Clamp(cycle, 0.0f, 1.0f);
+		float eased = _curve(t);
+		Value = Start + ((End - Start) * eased);
+		return Value;
+	}
+
+	/// <summary>Rewind to the starting value and reactivate the tween.</summary>
+	public void Restart()
+	{
+		Elapsed = 0.0f;
+		Value = Start;
+		IsActive = Duration > 0.0f;
+	}
+
+	/// <summary>Force the tween to its final value and mark it complete.</summary>
+	public void Complete()
+	{
+		Elapsed = Duration;
+		Value = End;
+		IsActive = false;
+	}
+
+	/// <summary>Seek to a specific elapsed time. Useful for scrub controls or initial-state restoration.</summary>
+	public void SeekTo(float elapsedSeconds)
+	{
+		Elapsed = MathF.Max(elapsedSeconds, 0.0f);
+		IsActive = true;
+		_ = Update(0.0f);
+	}
+}

--- a/tests/ImGui.Widgets.Tests/EasingTests.cs
+++ b/tests/ImGui.Widgets.Tests/EasingTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Tests;
+
+using ktsu.ImGui.Widgets.Animation;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class EasingTests
+{
+	[TestMethod]
+	public void All_Curves_HitZeroAndOneAtEndpoints()
+	{
+		System.Func<float, float>[] curves =
+		[
+			Easing.Linear,
+			Easing.InQuad, Easing.OutQuad, Easing.InOutQuad,
+			Easing.InCubic, Easing.OutCubic, Easing.InOutCubic,
+		];
+
+		foreach (System.Func<float, float> curve in curves)
+		{
+			Assert.AreEqual(0.0f, curve(0.0f), 1e-5f, "Curve must return 0 at t=0");
+			Assert.AreEqual(1.0f, curve(1.0f), 1e-5f, "Curve must return 1 at t=1");
+		}
+	}
+
+	[TestMethod]
+	public void Linear_IsIdentity()
+	{
+		Assert.AreEqual(0.25f, Easing.Linear(0.25f), 1e-5f);
+		Assert.AreEqual(0.5f, Easing.Linear(0.5f), 1e-5f);
+	}
+
+	[TestMethod]
+	public void OutCubic_FastInitialProgress()
+	{
+		// OutCubic at 0.25 → 1 - (0.75)^3 = 1 - 0.421875 = 0.578125
+		Assert.AreEqual(0.578125f, Easing.OutCubic(0.25f), 1e-5f);
+	}
+
+	[TestMethod]
+	public void InCubic_SlowInitialProgress()
+	{
+		// InCubic at 0.25 → 0.015625
+		Assert.AreEqual(0.015625f, Easing.InCubic(0.25f), 1e-5f);
+	}
+
+	[TestMethod]
+	public void OutBack_Overshoots()
+	{
+		// OutBack peaks above 1 before settling. At t ≈ 0.65 it should exceed 1.
+		float v = Easing.OutBack(0.65f);
+		Assert.IsTrue(v > 1.0f, $"OutBack should overshoot 1 mid-curve. Got {v}");
+	}
+
+	[TestMethod]
+	public void OutBack_LandsAtOne()
+	{
+		Assert.AreEqual(1.0f, Easing.OutBack(1.0f), 1e-5f);
+	}
+}

--- a/tests/ImGui.Widgets.Tests/SpringTests.cs
+++ b/tests/ImGui.Widgets.Tests/SpringTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Tests;
+
+using System;
+
+using ktsu.ImGui.Widgets.Animation;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class SpringTests
+{
+	[TestMethod]
+	public void New_RestsAtInitial()
+	{
+		Spring s = new(initial: 5.0f);
+
+		Assert.AreEqual(5.0f, s.Value, 1e-5f);
+		Assert.AreEqual(5.0f, s.Target, 1e-5f);
+		Assert.AreEqual(0.0f, s.Velocity, 1e-5f);
+		Assert.IsFalse(s.IsActive);
+	}
+
+	[TestMethod]
+	public void Update_NewTarget_BecomesActive()
+	{
+		Spring s = new(initial: 0.0f);
+		s.Target = 10.0f;
+
+		s.Update(0.016f);
+
+		Assert.IsTrue(s.IsActive);
+		Assert.IsTrue(s.Value > 0.0f, $"Spring should have moved toward target. Value={s.Value}");
+	}
+
+	[TestMethod]
+	public void Update_SettlesAtTarget_GivenEnoughTime()
+	{
+		Spring s = new(initial: 0.0f, stiffness: 170.0f, damping: 26.0f);
+		s.Target = 100.0f;
+
+		// Advance for two seconds in 16ms ticks; nearly-critically-damped should settle.
+		for (int i = 0; i < 125; i++)
+		{
+			s.Update(0.016f);
+		}
+
+		Assert.IsFalse(s.IsActive, $"Spring should be at rest. Value={s.Value}, Vel={s.Velocity}");
+		Assert.AreEqual(100.0f, s.Value, 1e-3f);
+	}
+
+	[TestMethod]
+	public void Update_LargeDelta_StaysStable()
+	{
+		// A single huge dt would blow up a naive explicit Euler; sub-stepping should keep it bounded.
+		Spring s = new(initial: 0.0f, stiffness: 500.0f, damping: 10.0f);
+		s.Target = 100.0f;
+
+		float result = s.Update(1.0f);
+
+		Assert.IsFalse(float.IsNaN(result));
+		Assert.IsFalse(float.IsInfinity(result));
+		Assert.IsTrue(MathF.Abs(result) < 1e4f, $"Spring exploded: {result}");
+	}
+
+	[TestMethod]
+	public void Update_NegativeDelta_DoesNothing()
+	{
+		Spring s = new(initial: 0.0f);
+		s.Target = 10.0f;
+		s.Update(0.016f);
+		float before = s.Value;
+
+		s.Update(-1.0f);
+
+		Assert.AreEqual(before, s.Value, 1e-5f);
+	}
+
+	[TestMethod]
+	public void SnapTo_ClearsVelocityAndRests()
+	{
+		Spring s = new(initial: 0.0f);
+		s.Target = 100.0f;
+		s.Update(0.016f);
+		Assert.IsTrue(s.IsActive);
+
+		s.SnapTo(50.0f);
+
+		Assert.AreEqual(50.0f, s.Value, 1e-5f);
+		Assert.AreEqual(50.0f, s.Target, 1e-5f);
+		Assert.AreEqual(0.0f, s.Velocity, 1e-5f);
+		Assert.IsFalse(s.IsActive);
+	}
+
+	[TestMethod]
+	public void Update_OverdampedSpring_DoesNotOvershoot()
+	{
+		// Heavily over-damped: damping > 2 sqrt(k) = 2 * sqrt(100) = 20
+		Spring s = new(initial: 0.0f, stiffness: 100.0f, damping: 100.0f);
+		s.Target = 10.0f;
+
+		float maxObserved = 0.0f;
+		for (int i = 0; i < 300; i++)
+		{
+			s.Update(0.016f);
+			maxObserved = MathF.Max(maxObserved, s.Value);
+		}
+
+		Assert.IsTrue(maxObserved <= 10.0f + 1e-3f, $"Over-damped spring should not overshoot. Max={maxObserved}");
+	}
+}

--- a/tests/ImGui.Widgets.Tests/SpringTests.cs
+++ b/tests/ImGui.Widgets.Tests/SpringTests.cs
@@ -27,8 +27,7 @@ public sealed class SpringTests
 	[TestMethod]
 	public void Update_NewTarget_BecomesActive()
 	{
-		Spring s = new(initial: 0.0f);
-		s.Target = 10.0f;
+		Spring s = new(initial: 0.0f) { Target = 10.0f };
 
 		s.Update(0.016f);
 
@@ -39,8 +38,7 @@ public sealed class SpringTests
 	[TestMethod]
 	public void Update_SettlesAtTarget_GivenEnoughTime()
 	{
-		Spring s = new(initial: 0.0f, stiffness: 170.0f, damping: 26.0f);
-		s.Target = 100.0f;
+		Spring s = new(initial: 0.0f, stiffness: 170.0f, damping: 26.0f) { Target = 100.0f };
 
 		// Advance for two seconds in 16ms ticks; nearly-critically-damped should settle.
 		for (int i = 0; i < 125; i++)
@@ -56,8 +54,7 @@ public sealed class SpringTests
 	public void Update_LargeDelta_StaysStable()
 	{
 		// A single huge dt would blow up a naive explicit Euler; sub-stepping should keep it bounded.
-		Spring s = new(initial: 0.0f, stiffness: 500.0f, damping: 10.0f);
-		s.Target = 100.0f;
+		Spring s = new(initial: 0.0f, stiffness: 500.0f, damping: 10.0f) { Target = 100.0f };
 
 		float result = s.Update(1.0f);
 
@@ -69,8 +66,7 @@ public sealed class SpringTests
 	[TestMethod]
 	public void Update_NegativeDelta_DoesNothing()
 	{
-		Spring s = new(initial: 0.0f);
-		s.Target = 10.0f;
+		Spring s = new(initial: 0.0f) { Target = 10.0f };
 		s.Update(0.016f);
 		float before = s.Value;
 
@@ -82,8 +78,7 @@ public sealed class SpringTests
 	[TestMethod]
 	public void SnapTo_ClearsVelocityAndRests()
 	{
-		Spring s = new(initial: 0.0f);
-		s.Target = 100.0f;
+		Spring s = new(initial: 0.0f) { Target = 100.0f };
 		s.Update(0.016f);
 		Assert.IsTrue(s.IsActive);
 
@@ -99,8 +94,7 @@ public sealed class SpringTests
 	public void Update_OverdampedSpring_DoesNotOvershoot()
 	{
 		// Heavily over-damped: damping > 2 sqrt(k) = 2 * sqrt(100) = 20
-		Spring s = new(initial: 0.0f, stiffness: 100.0f, damping: 100.0f);
-		s.Target = 10.0f;
+		Spring s = new(initial: 0.0f, stiffness: 100.0f, damping: 100.0f) { Target = 10.0f };
 
 		float maxObserved = 0.0f;
 		for (int i = 0; i < 300; i++)

--- a/tests/ImGui.Widgets.Tests/TweenTests.cs
+++ b/tests/ImGui.Widgets.Tests/TweenTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Tests;
+
+using ktsu.ImGui.Widgets.Animation;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class TweenTests
+{
+	[TestMethod]
+	public void New_LinearTween_StartsAtStartValue()
+	{
+		Tween t = new(0.0f, 100.0f, 1.0f);
+
+		Assert.AreEqual(0.0f, t.Value, 1e-5f);
+		Assert.IsTrue(t.IsActive);
+	}
+
+	[TestMethod]
+	public void Update_LinearTween_AtMidpointReturnsHalfway()
+	{
+		Tween t = new(0.0f, 100.0f, 1.0f);
+
+		float v = t.Update(0.5f);
+
+		Assert.AreEqual(50.0f, v, 1e-4f);
+		Assert.AreEqual(50.0f, t.Value, 1e-4f);
+		Assert.IsTrue(t.IsActive);
+	}
+
+	[TestMethod]
+	public void Update_LinearTween_PastDuration_Clamps()
+	{
+		Tween t = new(10.0f, 20.0f, 1.0f);
+
+		float v = t.Update(2.0f);
+
+		Assert.AreEqual(20.0f, v, 1e-5f);
+		Assert.IsFalse(t.IsActive);
+		Assert.IsTrue(t.IsComplete);
+	}
+
+	[TestMethod]
+	public void Update_LinearTween_ExactlyAtDuration_Completes()
+	{
+		Tween t = new(0.0f, 1.0f, 1.0f);
+		t.Update(1.0f);
+
+		Assert.AreEqual(1.0f, t.Value, 1e-5f);
+		Assert.IsFalse(t.IsActive);
+	}
+
+	[TestMethod]
+	public void New_ZeroDuration_SnapsToEndImmediately()
+	{
+		Tween t = new(0.0f, 5.0f, 0.0f);
+
+		Assert.AreEqual(5.0f, t.Value, 1e-5f);
+		Assert.IsFalse(t.IsActive);
+	}
+
+	[TestMethod]
+	public void Update_OutCubic_FastStartSlowEnd()
+	{
+		Tween t = new(0.0f, 100.0f, 1.0f, Easing.OutCubic);
+
+		// At t=0.5, OutCubic = 1 - (0.5)^3 = 1 - 0.125 = 0.875 → 87.5
+		t.Update(0.5f);
+		Assert.AreEqual(87.5f, t.Value, 1e-3f);
+	}
+
+	[TestMethod]
+	public void Update_NegativeDelta_DoesNotRewind()
+	{
+		Tween t = new(0.0f, 10.0f, 1.0f);
+		t.Update(0.4f);
+		float before = t.Value;
+		t.Update(-1.0f);
+
+		Assert.AreEqual(before, t.Value, 1e-5f);
+	}
+
+	[TestMethod]
+	public void Restart_ResetsToStart()
+	{
+		Tween t = new(0.0f, 10.0f, 1.0f);
+		t.Update(2.0f);
+		Assert.IsFalse(t.IsActive);
+
+		t.Restart();
+
+		Assert.AreEqual(0.0f, t.Value, 1e-5f);
+		Assert.IsTrue(t.IsActive);
+	}
+
+	[TestMethod]
+	public void Complete_JumpsToEnd()
+	{
+		Tween t = new(0.0f, 10.0f, 5.0f);
+		t.Complete();
+
+		Assert.AreEqual(10.0f, t.Value, 1e-5f);
+		Assert.IsFalse(t.IsActive);
+	}
+
+	[TestMethod]
+	public void Repeat_WrapsAroundAfterDuration()
+	{
+		Tween t = new(0.0f, 10.0f, 1.0f) { Repeat = true };
+
+		// After 1.5 cycles → fractional = 0.5 → value = 5
+		t.Update(1.5f);
+
+		Assert.AreEqual(5.0f, t.Value, 1e-4f);
+		Assert.IsTrue(t.IsActive, "Repeating tween should stay active indefinitely.");
+	}
+
+	[TestMethod]
+	public void PingPong_ReversesEachCycle()
+	{
+		Tween t = new(0.0f, 10.0f, 1.0f) { PingPong = true };
+
+		// 0.5s in → forward half → 5.0
+		t.Update(0.5f);
+		Assert.AreEqual(5.0f, t.Value, 1e-4f);
+
+		// total 1.5s → into second half, reversed at 0.5 → 5.0 again
+		t.Update(1.0f);
+		Assert.AreEqual(5.0f, t.Value, 1e-4f);
+
+		// total 2.0s → completed reverse half → back at 0
+		t.Update(0.5f);
+		Assert.AreEqual(0.0f, t.Value, 1e-4f);
+	}
+
+	[TestMethod]
+	public void SeekTo_JumpsToTimeOffset()
+	{
+		Tween t = new(0.0f, 100.0f, 2.0f);
+		t.SeekTo(1.0f);
+
+		Assert.AreEqual(50.0f, t.Value, 1e-4f);
+		Assert.IsTrue(t.IsActive);
+	}
+}


### PR DESCRIPTION
## Summary

Continues Phase 0 of the [mobile UI widgets plan](docs/plans/2026-05-28-mobile-ui-widgets.md) with frame-rate-independent animation primitives that downstream widgets (`SkeletonLoader`, `Switch`, `LongPressMenu`, `BottomSheet`, `PullToRefresh`) will all use.

- **`Easing`** &mdash; 8 standard curves: `Linear`, `In/Out/InOut` variants of `Quad` and `Cubic`, plus `InBack` / `OutBack` for overshoot "pops".
- **`Tween`** &mdash; explicit-duration float interpolation with a selectable easing function. Supports `Repeat` (loop) and `PingPong` (back-and-forth), plus `Restart` / `Complete` / `SeekTo` controls.
- **`Spring`** &mdash; damped harmonic oscillator (`ẍ = -k(x - target) - c·v`) with **semi-implicit Euler and a fixed 1/240s sub-step**, so large delta times can't destabilize the integrator.

Both `Tween` and `Spring` expose an `IsActive` flag that a follow-up PR will use to gate ImGuiApp's PID frame limiter ("bump framerate while animating").

## Design notes

- Pure logic, no ImGui dependency &mdash; same separation-of-concerns as `GestureMachine` from #184. Consumers compose two `Tween`s for a `Vector2`, three for a `Vector3`, etc.
- `Spring` defaults (`stiffness=170`, `damping=26`) give a nearly-critically-damped feel that feels right for typical mobile UI motion (snappy, no oscillation).
- All curves verified to hit `0` at `t=0` and `1` at `t=1` so they're swappable without rescaling.

## Test plan

- [x] `ImGui.Widgets` builds clean (verified locally on `net10.0`)
- [x] `EasingTests`: endpoint correctness for every curve, identity check on `Linear`, known-value checks on `In/OutCubic`, `OutBack` overshoot
- [x] `TweenTests`: midpoint, clamping past duration, exact-duration completion, zero-duration snap, `OutCubic` shape, negative-delta safety, `Restart` / `Complete` / `Repeat` / `PingPong` / `SeekTo`
- [x] `SpringTests`: at-rest initialization, target chase, settling within budget, large-delta stability (no NaN/Inf), negative-delta safety, `SnapTo`, over-damped no-overshoot
- [ ] CI on Windows compiles and runs the new tests

## Out of scope

Remaining Phase 0 items (`InertialScroll`, `OverlayHost`, and the frame-limiter wiring) will land in follow-up PRs.


---
_Generated by [Claude Code](https://claude.ai/code/session_016oxXTQpPRnfa5P6Cz56C1X)_