### PR TITLE
feat: add InertialScroll helper for ImGui.Widgets

### DIFF
--- a/ImGui.Widgets/Scroll/InertialScroll.cs
+++ b/ImGui.Widgets/Scroll/InertialScroll.cs
@@ -1,0 +1,143 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Scroll;
+
+using System;
+
+/// <summary>
+/// One-dimensional scroll offset that coasts after release. Drives carousels, pickers, and
+/// long lists that should feel like native mobile scrollers rather than jumping to a stop
+/// when the pointer is lifted.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Usage during a frame: while the pointer is down, call <see cref="Drag"/> with the pan
+/// delta and frame <c>deltaTime</c>; on release call <see cref="Fling"/> with the recorded
+/// velocity (the <c>Velocity</c> field on a <c>GestureResult</c> is a fine source).
+/// Each frame thereafter call <see cref="Update"/> to advance the coast and decay the
+/// velocity exponentially. <see cref="IsActive"/> stays true until the motion settles —
+/// gate frame-rate boosts on that flag.
+/// </para>
+/// <para>
+/// Set <see cref="MinExtent"/> / <see cref="MaxExtent"/> to clamp to a content range; the
+/// default is unbounded. When the scroll hits a bound velocity is zeroed so the motion
+/// stops cleanly rather than rebounding.
+/// </para>
+/// </remarks>
+/// <param name="initialPosition">Starting scroll offset in pixels.</param>
+public sealed class InertialScroll(float initialPosition = 0.0f)
+{
+	/// <summary>Current scroll offset in pixels.</summary>
+	public float Position { get; private set; } = initialPosition;
+
+	/// <summary>Current velocity in pixels per second. Positive moves <see cref="Position"/> upward.</summary>
+	public float Velocity { get; private set; }
+
+	/// <summary>
+	/// Exponential velocity-decay rate per second. Higher values stop the coast sooner;
+	/// the default of 6.0 mirrors iOS-style "deceleration normal".
+	/// </summary>
+	public float Friction { get; init; } = 6.0f;
+
+	/// <summary>
+	/// Velocity magnitude below which the scroll is considered at rest. Update zeroes the
+	/// velocity once it falls under this threshold so <see cref="IsActive"/> can flip false.
+	/// </summary>
+	public float MinVelocity { get; init; } = 1.0f;
+
+	/// <summary>Lower bound for <see cref="Position"/>. Defaults to unbounded.</summary>
+	public float MinExtent { get; set; } = float.NegativeInfinity;
+
+	/// <summary>Upper bound for <see cref="Position"/>. Defaults to unbounded.</summary>
+	public float MaxExtent { get; set; } = float.PositiveInfinity;
+
+	/// <summary>True while the scroll is still coasting. Use this to keep the framerate elevated.</summary>
+	public bool IsActive => MathF.Abs(Velocity) > MinVelocity;
+
+	/// <summary>
+	/// Apply a pointer-driven displacement of <paramref name="delta"/> pixels this frame.
+	/// Tracks instantaneous velocity so a subsequent <see cref="Fling"/>-less release still
+	/// coasts using the last drag's speed.
+	/// </summary>
+	/// <param name="delta">Pixel offset to add to <see cref="Position"/>.</param>
+	/// <param name="deltaTime">Frame interval in seconds; used to derive instantaneous velocity.</param>
+	public void Drag(float delta, float deltaTime)
+	{
+		Position += delta;
+		if (deltaTime > 0.0f)
+		{
+			Velocity = delta / deltaTime;
+		}
+
+		ClampToBounds();
+	}
+
+	/// <summary>
+	/// Release the scroll with the supplied velocity. The next <see cref="Update"/> calls
+	/// will coast and decay until the motion settles or hits a bound.
+	/// </summary>
+	/// <param name="velocity">Initial coast velocity in pixels per second.</param>
+	public void Fling(float velocity) => Velocity = velocity;
+
+	/// <summary>
+	/// Advance the coast by <paramref name="deltaTime"/> seconds and return the new
+	/// <see cref="Position"/>. Returns immediately when the scroll is already at rest.
+	/// </summary>
+	public float Update(float deltaTime)
+	{
+		if (deltaTime <= 0.0f || !IsActive)
+		{
+			return Position;
+		}
+
+		// Exponential decay v(t) = v0 * exp(-friction * dt); integrate position
+		// using the average of pre- and post-decay velocity for second-order accuracy.
+		float decayed = Velocity * MathF.Exp(-Friction * deltaTime);
+		float averageVelocity = (Velocity + decayed) * 0.5f;
+		Position += averageVelocity * deltaTime;
+		Velocity = decayed;
+
+		if (Position <= MinExtent)
+		{
+			Position = MinExtent;
+			Velocity = 0.0f;
+		}
+		else if (Position >= MaxExtent)
+		{
+			Position = MaxExtent;
+			Velocity = 0.0f;
+		}
+		else if (MathF.Abs(Velocity) < MinVelocity)
+		{
+			Velocity = 0.0f;
+		}
+
+		return Position;
+	}
+
+	/// <summary>Halt the coast without changing <see cref="Position"/>. Useful when the pointer touches down again.</summary>
+	public void Stop() => Velocity = 0.0f;
+
+	/// <summary>Jump to <paramref name="position"/> (clamped to bounds) and clear velocity.</summary>
+	public void SnapTo(float position)
+	{
+		Position = Math.Clamp(position, MinExtent, MaxExtent);
+		Velocity = 0.0f;
+	}
+
+	private void ClampToBounds()
+	{
+		if (Position < MinExtent)
+		{
+			Position = MinExtent;
+			Velocity = 0.0f;
+		}
+		else if (Position > MaxExtent)
+		{
+			Position = MaxExtent;
+			Velocity = 0.0f;
+		}
+	}
+}

--- a/tests/ImGui.Widgets.Tests/InertialScrollTests.cs
+++ b/tests/ImGui.Widgets.Tests/InertialScrollTests.cs
@@ -4,8 +4,6 @@
 
 namespace ktsu.ImGui.Widgets.Tests;
 
-using System;
-
 using ktsu.ImGui.Widgets.Scroll;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/tests/ImGui.Widgets.Tests/InertialScrollTests.cs
+++ b/tests/ImGui.Widgets.Tests/InertialScrollTests.cs
@@ -1,0 +1,231 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Tests;
+
+using System;
+
+using ktsu.ImGui.Widgets.Scroll;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class InertialScrollTests
+{
+	[TestMethod]
+	public void New_DefaultsAtRest()
+	{
+		InertialScroll s = new(initialPosition: 50.0f);
+
+		Assert.AreEqual(50.0f, s.Position, 1e-5f);
+		Assert.AreEqual(0.0f, s.Velocity, 1e-5f);
+		Assert.IsFalse(s.IsActive);
+	}
+
+	[TestMethod]
+	public void Drag_AdvancesPosition_AndRecordsInstantaneousVelocity()
+	{
+		InertialScroll s = new();
+
+		s.Drag(delta: 10.0f, deltaTime: 0.1f);
+
+		Assert.AreEqual(10.0f, s.Position, 1e-5f);
+		Assert.AreEqual(100.0f, s.Velocity, 1e-5f);
+	}
+
+	[TestMethod]
+	public void Drag_ZeroDeltaTime_DoesNotDivideByZero()
+	{
+		InertialScroll s = new();
+
+		s.Drag(delta: 5.0f, deltaTime: 0.0f);
+
+		Assert.AreEqual(5.0f, s.Position, 1e-5f);
+		// Velocity is left at its previous (zero) value rather than producing infinity.
+		Assert.AreEqual(0.0f, s.Velocity, 1e-5f);
+	}
+
+	[TestMethod]
+	public void Fling_AndUpdate_CoastsAndDecays()
+	{
+		InertialScroll s = new() { Friction = 4.0f, MinVelocity = 0.001f };
+		s.Fling(velocity: 200.0f);
+
+		float vBefore = s.Velocity;
+		s.Update(0.1f);
+
+		Assert.IsTrue(s.Position > 0.0f, "Coast should advance position.");
+		Assert.IsTrue(s.Velocity < vBefore, "Velocity should decay.");
+		Assert.IsTrue(s.IsActive, "Scroll should still be coasting after one short update.");
+	}
+
+	[TestMethod]
+	public void Update_NoFling_DoesNothing()
+	{
+		InertialScroll s = new(initialPosition: 10.0f);
+
+		s.Update(1.0f);
+
+		Assert.AreEqual(10.0f, s.Position, 1e-5f);
+		Assert.IsFalse(s.IsActive);
+	}
+
+	[TestMethod]
+	public void Update_NegativeDelta_DoesNothing()
+	{
+		InertialScroll s = new();
+		s.Fling(100.0f);
+		float p = s.Position;
+		float v = s.Velocity;
+
+		s.Update(-0.1f);
+
+		Assert.AreEqual(p, s.Position, 1e-5f);
+		Assert.AreEqual(v, s.Velocity, 1e-5f);
+	}
+
+	[TestMethod]
+	public void Update_RunsUntilRest()
+	{
+		InertialScroll s = new() { Friction = 8.0f, MinVelocity = 0.5f };
+		s.Fling(500.0f);
+
+		// 5 seconds is plenty for friction=8 to settle.
+		for (int i = 0; i < 300; i++)
+		{
+			s.Update(0.016f);
+		}
+
+		Assert.IsFalse(s.IsActive, $"Should be at rest. Velocity={s.Velocity}");
+		Assert.AreEqual(0.0f, s.Velocity, 1e-5f);
+	}
+
+	[TestMethod]
+	public void Update_ClampsAtMaxExtent_AndZerosVelocity()
+	{
+		InertialScroll s = new() { MaxExtent = 100.0f };
+		s.Fling(10_000.0f);
+
+		// One big step should drive past the bound.
+		s.Update(1.0f);
+
+		Assert.AreEqual(100.0f, s.Position, 1e-3f);
+		Assert.AreEqual(0.0f, s.Velocity, 1e-5f);
+		Assert.IsFalse(s.IsActive);
+	}
+
+	[TestMethod]
+	public void Update_ClampsAtMinExtent_AndZerosVelocity()
+	{
+		InertialScroll s = new() { MinExtent = -50.0f };
+		s.Fling(-10_000.0f);
+
+		s.Update(1.0f);
+
+		Assert.AreEqual(-50.0f, s.Position, 1e-3f);
+		Assert.AreEqual(0.0f, s.Velocity, 1e-5f);
+	}
+
+	[TestMethod]
+	public void Drag_ClampsToBounds()
+	{
+		InertialScroll s = new() { MaxExtent = 20.0f };
+
+		s.Drag(delta: 100.0f, deltaTime: 0.1f);
+
+		Assert.AreEqual(20.0f, s.Position, 1e-5f);
+		// Velocity zeroed because we hit the bound during the drag.
+		Assert.AreEqual(0.0f, s.Velocity, 1e-5f);
+	}
+
+	[TestMethod]
+	public void Stop_KeepsPosition_ClearsVelocity()
+	{
+		InertialScroll s = new();
+		s.Fling(500.0f);
+		s.Update(0.05f);
+		float p = s.Position;
+
+		s.Stop();
+
+		Assert.AreEqual(p, s.Position, 1e-5f);
+		Assert.AreEqual(0.0f, s.Velocity, 1e-5f);
+		Assert.IsFalse(s.IsActive);
+	}
+
+	[TestMethod]
+	public void SnapTo_ClampsAndClearsVelocity()
+	{
+		InertialScroll s = new() { MaxExtent = 100.0f };
+		s.Fling(50.0f);
+
+		s.SnapTo(250.0f);
+
+		Assert.AreEqual(100.0f, s.Position, 1e-5f);
+		Assert.AreEqual(0.0f, s.Velocity, 1e-5f);
+	}
+
+	[TestMethod]
+	public void Update_PositionIntegration_IsMonotonicWhileCoasting()
+	{
+		InertialScroll s = new() { Friction = 3.0f, MinVelocity = 0.1f };
+		s.Fling(300.0f);
+
+		float prev = s.Position;
+		for (int i = 0; i < 60 && s.IsActive; i++)
+		{
+			s.Update(0.016f);
+			Assert.IsTrue(s.Position >= prev - 1e-4f, $"Position regressed: prev={prev} curr={s.Position} on step {i}");
+			prev = s.Position;
+		}
+	}
+
+	[TestMethod]
+	public void Friction_Higher_StopsSooner()
+	{
+		InertialScroll slow = new() { Friction = 2.0f, MinVelocity = 0.5f };
+		InertialScroll fast = new() { Friction = 12.0f, MinVelocity = 0.5f };
+		slow.Fling(500.0f);
+		fast.Fling(500.0f);
+
+		int slowSteps = 0;
+		int fastSteps = 0;
+		for (int i = 0; i < 600; i++)
+		{
+			if (slow.IsActive) { slow.Update(0.016f); slowSteps++; }
+			if (fast.IsActive) { fast.Update(0.016f); fastSteps++; }
+			if (!slow.IsActive && !fast.IsActive)
+			{
+				break;
+			}
+		}
+
+		Assert.IsTrue(fastSteps < slowSteps, $"Higher friction should settle sooner. slow={slowSteps} fast={fastSteps}");
+	}
+
+	[TestMethod]
+	public void Drag_ThenFling_ResumesCoastingFromCurrentVelocity()
+	{
+		InertialScroll s = new() { Friction = 4.0f, MinVelocity = 0.1f };
+		s.Drag(20.0f, 0.1f);  // velocity = 200
+		float posAfterDrag = s.Position;
+
+		s.Fling(s.Velocity);
+		s.Update(0.1f);
+
+		Assert.IsTrue(s.Position > posAfterDrag, "Coast should advance position past the drag end.");
+	}
+
+	[TestMethod]
+	public void Update_LargeDeltaTime_StaysFinite()
+	{
+		InertialScroll s = new();
+		s.Fling(1_000.0f);
+
+		float result = s.Update(10.0f);
+
+		Assert.IsFalse(float.IsNaN(result));
+		Assert.IsFalse(float.IsInfinity(result));
+	}
+}

--- a/tests/ImGui.Widgets.Tests/InertialScrollTests.cs
+++ b/tests/ImGui.Widgets.Tests/InertialScrollTests.cs
@@ -193,8 +193,18 @@ public sealed class InertialScrollTests
 		int fastSteps = 0;
 		for (int i = 0; i < 600; i++)
 		{
-			if (slow.IsActive) { slow.Update(0.016f); slowSteps++; }
-			if (fast.IsActive) { fast.Update(0.016f); fastSteps++; }
+			if (slow.IsActive)
+			{
+				slow.Update(0.016f);
+				slowSteps++;
+			}
+
+			if (fast.IsActive)
+			{
+				fast.Update(0.016f);
+				fastSteps++;
+			}
+
 			if (!slow.IsActive && !fast.IsActive)
 			{
 				break;


### PR DESCRIPTION
## Summary

Continues Phase 0 of the [mobile UI widgets plan](docs/plans/2026-05-28-mobile-ui-widgets.md) by adding the **InertialScroll** primitive listed alongside gestures and animation. Drives carousels, pickers, and any long list that should coast after pan release instead of snapping to a stop.

- `InertialScroll` (`ImGui.Widgets/Scroll/InertialScroll.cs`):
  - `Drag(delta, deltaTime)` — pointer-driven displacement; also records instantaneous velocity so a release without an explicit fling still coasts at the last drag speed.
  - `Fling(velocity)` — release with caller-supplied velocity.
  - `Update(deltaTime)` — per-frame coast with exponential velocity decay (`v = v0 · exp(-friction · dt)`); position integrated using the average of pre/post-decay velocity for second-order accuracy.
  - `MinExtent` / `MaxExtent` — optional bounds (default unbounded); hitting a bound zeroes velocity so the motion stops cleanly.
  - `IsActive` flips false once velocity falls under `MinVelocity`, so the app can release any framerate boost it requested while coasting.
  - `Stop()` / `SnapTo(position)` for non-physics interruptions.

## Test plan

- [x] 16 new MSTest cases in `tests/ImGui.Widgets.Tests/InertialScrollTests.cs`
- [x] Coverage: initial state, drag accumulation, zero-deltaTime divide guard, fling/coast/decay, monotonic-while-coasting integration, bound clamping at both extents, `Stop` / `SnapTo`, friction ordering (higher → settles sooner), large-deltaTime numerical stability
- [x] All 54 widget tests pass locally (38 existing + 16 new)

## Phase 0 progress

- [x] Gesture detector
- [x] Animation primitives (Tween / Spring / Easing)
- [x] **Inertial scroll helper** ← this PR
- [ ] Overlay / layer manager (next)

https://claude.ai/code/session_01RjRdPZykfagbYuku6MsanX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjRdPZykfagbYuku6MsanX)_