### PR TITLE
feat: add OverlayHost z-ordered overlay manager for ImGui.Widgets

### DIFF
--- a/ImGui.Widgets/Overlays/OverlayHost.cs
+++ b/ImGui.Widgets/Overlays/OverlayHost.cs
@@ -1,0 +1,116 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Overlays;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Z-ordered registry for retained overlays — toasts, bottom sheets, action sheets, drawers, and
+/// the like — that must paint on top of the rest of a frame in a predictable order. Register an
+/// overlay once with <see cref="Show"/>; it persists across frames until <see cref="Dismiss"/> or
+/// <see cref="Clear"/> removes it. Call <see cref="Render"/> exactly once near the end of the
+/// user's frame to invoke every registered overlay's draw callback in ascending
+/// <see cref="OverlayLayer"/> order.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The host is intentionally free of any Dear ImGui calls: each overlay's draw callback owns its
+/// own windowing. That keeps the ordering logic unit-testable and lets higher-level widgets
+/// (<c>Toast</c>, <c>BottomSheet</c>, <c>NavigationDrawer</c>) layer their own presentation on
+/// top. Use <see cref="HasOverlays"/> to decide whether to keep the application's frame rate
+/// elevated while overlays are on screen.
+/// </para>
+/// <para>
+/// <see cref="Render"/> snapshots the current set before invoking any callback, so an overlay may
+/// safely <see cref="Show"/> or <see cref="Dismiss"/> overlays (including itself) from inside its
+/// own draw delegate. A dismissal mid-frame still leaves already-snapshotted overlays to paint
+/// this frame; newly shown overlays first appear on the next frame.
+/// </para>
+/// </remarks>
+public sealed class OverlayHost
+{
+	private sealed record OverlayEntry(OverlayLayer Layer, long Sequence, Action Draw);
+
+	private readonly Dictionary<string, OverlayEntry> _overlays = [];
+	private readonly List<OverlayEntry> _renderBuffer = [];
+	private long _sequenceCounter;
+
+	/// <summary>Number of overlays currently registered.</summary>
+	public int Count => _overlays.Count;
+
+	/// <summary>True while at least one overlay is registered. Gate frame-rate boosts on this flag.</summary>
+	public bool HasOverlays => _overlays.Count > 0;
+
+	/// <summary>
+	/// Register (or update) an overlay under <paramref name="key"/>. Re-showing an existing key
+	/// replaces its draw callback and layer while preserving the original registration order, so
+	/// calling <see cref="Show"/> every frame for the same key keeps a stable z-position rather
+	/// than thrashing it to the front.
+	/// </summary>
+	/// <param name="key">Stable identity for the overlay. Re-using a key updates in place.</param>
+	/// <param name="draw">Callback invoked by <see cref="Render"/>; owns its own ImGui windowing.</param>
+	/// <param name="layer">Z-order band. Overlays are drawn in ascending layer order.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="key"/> or <paramref name="draw"/> is null.</exception>
+	public void Show(string key, Action draw, OverlayLayer layer = OverlayLayer.Toast)
+	{
+		Ensure.NotNull(key);
+		Ensure.NotNull(draw);
+
+		_overlays[key] = _overlays.TryGetValue(key, out OverlayEntry? existing)
+			? existing with { Layer = layer, Draw = draw }
+			: new OverlayEntry(layer, _sequenceCounter++, draw);
+	}
+
+	/// <summary>Remove the overlay registered under <paramref name="key"/>.</summary>
+	/// <param name="key">Key previously passed to <see cref="Show"/>.</param>
+	/// <returns>True if an overlay was removed; false if none was registered under that key.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+	public bool Dismiss(string key)
+	{
+		Ensure.NotNull(key);
+		return _overlays.Remove(key);
+	}
+
+	/// <summary>Report whether an overlay is currently registered under <paramref name="key"/>.</summary>
+	/// <param name="key">Key previously passed to <see cref="Show"/>.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="key"/> is null.</exception>
+	public bool IsShown(string key)
+	{
+		Ensure.NotNull(key);
+		return _overlays.ContainsKey(key);
+	}
+
+	/// <summary>Remove every registered overlay.</summary>
+	public void Clear() => _overlays.Clear();
+
+	/// <summary>
+	/// Invoke every registered overlay's draw callback in ascending <see cref="OverlayLayer"/>
+	/// order, breaking ties by registration order. Call once near the end of the frame.
+	/// </summary>
+	public void Render()
+	{
+		if (_overlays.Count == 0)
+		{
+			return;
+		}
+
+		// Snapshot before drawing so callbacks may mutate the registry without disturbing this frame.
+		_renderBuffer.Clear();
+		_renderBuffer.AddRange(_overlays.Values);
+		_renderBuffer.Sort(static (a, b) =>
+		{
+			int byLayer = ((int)a.Layer).CompareTo((int)b.Layer);
+			return byLayer != 0 ? byLayer : a.Sequence.CompareTo(b.Sequence);
+		});
+
+		foreach (OverlayEntry entry in _renderBuffer)
+		{
+			entry.Draw();
+		}
+
+		_renderBuffer.Clear();
+	}
+}

--- a/ImGui.Widgets/Overlays/OverlayLayer.cs
+++ b/ImGui.Widgets/Overlays/OverlayLayer.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Overlays;
+
+/// <summary>
+/// Named z-order bands for overlays hosted by an <see cref="OverlayHost"/>. Lower values are
+/// drawn first (further back); higher values are drawn last (closer to the user). Values are
+/// spaced out so callers can slot custom layers between the presets by casting an intermediate
+/// integer to <see cref="OverlayLayer"/>.
+/// </summary>
+public enum OverlayLayer
+{
+	/// <summary>Full-screen scrims and background dimmers that sit behind every other overlay.</summary>
+	Background = 0,
+
+	/// <summary>Edge-anchored navigation drawers.</summary>
+	Drawer = 1000,
+
+	/// <summary>Slide-up bottom sheets with snap points.</summary>
+	BottomSheet = 2000,
+
+	/// <summary>Bottom-anchored action sheets / button stacks.</summary>
+	ActionSheet = 3000,
+
+	/// <summary>Modal dialogs and alerts.</summary>
+	Dialog = 4000,
+
+	/// <summary>Transient toasts and snackbars.</summary>
+	Toast = 5000,
+
+	/// <summary>Tooltips and coach marks that must sit above everything else.</summary>
+	Tooltip = 6000,
+}

--- a/tests/ImGui.Widgets.Tests/OverlayHostTests.cs
+++ b/tests/ImGui.Widgets.Tests/OverlayHostTests.cs
@@ -1,0 +1,235 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets.Tests;
+
+using System;
+using System.Collections.Generic;
+
+using ktsu.ImGui.Widgets.Overlays;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class OverlayHostTests
+{
+	[TestMethod]
+	public void New_IsEmpty()
+	{
+		OverlayHost host = new();
+
+		Assert.AreEqual(0, host.Count);
+		Assert.IsFalse(host.HasOverlays);
+	}
+
+	[TestMethod]
+	public void Show_RegistersOverlay()
+	{
+		OverlayHost host = new();
+
+		host.Show("toast", () => { });
+
+		Assert.AreEqual(1, host.Count);
+		Assert.IsTrue(host.HasOverlays);
+		Assert.IsTrue(host.IsShown("toast"));
+	}
+
+	[TestMethod]
+	public void Show_SameKeyTwice_DoesNotDuplicate()
+	{
+		OverlayHost host = new();
+
+		host.Show("sheet", () => { });
+		host.Show("sheet", () => { });
+
+		Assert.AreEqual(1, host.Count);
+	}
+
+	[TestMethod]
+	public void Show_SameKey_UpdatesDrawCallback()
+	{
+		OverlayHost host = new();
+		List<string> drawn = [];
+
+		host.Show("k", () => drawn.Add("first"));
+		host.Show("k", () => drawn.Add("second"));
+		host.Render();
+
+		string[] expected = ["second"];
+		CollectionAssert.AreEqual(expected, drawn);
+	}
+
+	[TestMethod]
+	public void Dismiss_RemovesOverlay_AndReportsTrue()
+	{
+		OverlayHost host = new();
+		host.Show("toast", () => { });
+
+		bool removed = host.Dismiss("toast");
+
+		Assert.IsTrue(removed);
+		Assert.IsFalse(host.IsShown("toast"));
+		Assert.AreEqual(0, host.Count);
+	}
+
+	[TestMethod]
+	public void Dismiss_UnknownKey_ReportsFalse()
+	{
+		OverlayHost host = new();
+
+		Assert.IsFalse(host.Dismiss("nope"));
+	}
+
+	[TestMethod]
+	public void Clear_RemovesEverything()
+	{
+		OverlayHost host = new();
+		host.Show("a", () => { });
+		host.Show("b", () => { });
+
+		host.Clear();
+
+		Assert.AreEqual(0, host.Count);
+		Assert.IsFalse(host.HasOverlays);
+	}
+
+	[TestMethod]
+	public void Render_Empty_DoesNothing()
+	{
+		OverlayHost host = new();
+
+		// Must not throw with nothing registered.
+		host.Render();
+
+		Assert.AreEqual(0, host.Count);
+	}
+
+	[TestMethod]
+	public void Render_DrawsInAscendingLayerOrder()
+	{
+		OverlayHost host = new();
+		List<string> drawn = [];
+
+		// Register out of z-order on purpose.
+		host.Show("toast", () => drawn.Add("toast"), OverlayLayer.Toast);
+		host.Show("bg", () => drawn.Add("bg"), OverlayLayer.Background);
+		host.Show("dialog", () => drawn.Add("dialog"), OverlayLayer.Dialog);
+
+		host.Render();
+
+		string[] expected = ["bg", "dialog", "toast"];
+		CollectionAssert.AreEqual(expected, drawn);
+	}
+
+	[TestMethod]
+	public void Render_SameLayer_DrawsInRegistrationOrder()
+	{
+		OverlayHost host = new();
+		List<string> drawn = [];
+
+		host.Show("first", () => drawn.Add("first"), OverlayLayer.Toast);
+		host.Show("second", () => drawn.Add("second"), OverlayLayer.Toast);
+		host.Show("third", () => drawn.Add("third"), OverlayLayer.Toast);
+
+		host.Render();
+
+		string[] expected = ["first", "second", "third"];
+		CollectionAssert.AreEqual(expected, drawn);
+	}
+
+	[TestMethod]
+	public void Render_ReShowingKey_PreservesRegistrationOrder()
+	{
+		OverlayHost host = new();
+		List<string> drawn = [];
+
+		host.Show("a", () => { }, OverlayLayer.Toast);
+		host.Show("b", () => { }, OverlayLayer.Toast);
+
+		// Re-show "a" — it should keep its original (earlier) slot, not jump to the front.
+		host.Show("a", () => drawn.Add("a"), OverlayLayer.Toast);
+		host.Show("b", () => drawn.Add("b"), OverlayLayer.Toast);
+
+		host.Render();
+
+		string[] expected = ["a", "b"];
+		CollectionAssert.AreEqual(expected, drawn);
+	}
+
+	[TestMethod]
+	public void Render_DismissDuringDraw_IsSafe_AndAlreadySnapshottedStillDraw()
+	{
+		OverlayHost host = new();
+		List<string> drawn = [];
+
+		host.Show("a", () =>
+		{
+			drawn.Add("a");
+			// Dismiss a later overlay mid-render; it was already snapshotted so it still draws.
+			host.Dismiss("b");
+		}, OverlayLayer.Background);
+		host.Show("b", () => drawn.Add("b"), OverlayLayer.Toast);
+
+		host.Render();
+
+		string[] expected = ["a", "b"];
+		CollectionAssert.AreEqual(expected, drawn);
+		// The dismissal takes effect for the next frame.
+		Assert.IsFalse(host.IsShown("b"));
+	}
+
+	[TestMethod]
+	public void Render_ShowDuringDraw_DefersToNextFrame()
+	{
+		OverlayHost host = new();
+		List<string> drawn = [];
+
+		host.Show("a", () =>
+		{
+			drawn.Add("a");
+			host.Show("b", () => drawn.Add("b"), OverlayLayer.Toast);
+		}, OverlayLayer.Background);
+
+		host.Render();
+		string[] firstFrame = ["a"];
+		CollectionAssert.AreEqual(firstFrame, drawn);
+
+		drawn.Clear();
+		host.Render();
+		string[] secondFrame = ["a", "b"];
+		CollectionAssert.AreEqual(secondFrame, drawn);
+	}
+
+	[TestMethod]
+	public void Render_CanBeCalledRepeatedly_WithStableOrder()
+	{
+		OverlayHost host = new();
+		List<string> drawn = [];
+
+		host.Show("bg", () => drawn.Add("bg"), OverlayLayer.Background);
+		host.Show("toast", () => drawn.Add("toast"), OverlayLayer.Toast);
+
+		host.Render();
+		host.Render();
+
+		string[] expected = ["bg", "toast", "bg", "toast"];
+		CollectionAssert.AreEqual(expected, drawn);
+	}
+
+	[TestMethod]
+	public void Show_NullKey_Throws() =>
+		Assert.ThrowsExactly<ArgumentNullException>(() => new OverlayHost().Show(null!, () => { }));
+
+	[TestMethod]
+	public void Show_NullDraw_Throws() =>
+		Assert.ThrowsExactly<ArgumentNullException>(() => new OverlayHost().Show("k", null!));
+
+	[TestMethod]
+	public void Dismiss_NullKey_Throws() =>
+		Assert.ThrowsExactly<ArgumentNullException>(() => new OverlayHost().Dismiss(null!));
+
+	[TestMethod]
+	public void IsShown_NullKey_Throws() =>
+		Assert.ThrowsExactly<ArgumentNullException>(() => new OverlayHost().IsShown(null!));
+}


### PR DESCRIPTION
## Summary

Completes the **Phase 0** mobile-widget infrastructure from `docs/plans/2026-05-28-mobile-ui-widgets.md`. The four foundational pieces were: gesture detector, animation primitives, inertial scroll, and the overlay/layer manager — the first three already landed, and this PR adds the last one.

`OverlayHost` is a retained, z-ordered registry for overlays (toasts, bottom sheets, action sheets, drawers) that must paint on top of the rest of a frame in a predictable order. Register an overlay once with `Show`; it persists across frames until `Dismiss` or `Clear`. Call `Render()` once near the end of the frame to invoke every overlay's draw callback in ascending layer order.

## Design notes

- **No Dear ImGui calls in the host.** Each overlay's draw callback owns its own windowing, mirroring how `GestureMachine` and `InertialScroll` keep their logic separable from rendering. This keeps the ordering logic fully unit-testable and lets higher-level Phase 3 widgets (`Toast`, `BottomSheet`, `NavigationDrawer`) layer their presentation on top.
- **Safe mid-frame mutation.** `Render()` snapshots the registry before invoking callbacks, so an overlay may `Show`/`Dismiss` overlays — including itself — from inside its own draw delegate. Dismissals apply next frame; newly shown overlays first appear next frame.
- **Stable ordering.** Re-showing an existing key updates its callback/layer but preserves registration order, so calling `Show` every frame for the same key keeps a stable z-position. Ties within a layer break by registration order.
- **`OverlayLayer`** provides named, spaced z-order bands (`Background` … `Tooltip`) with room to slot custom layers between presets via an integer cast.
- `HasOverlays` is exposed so the app can keep the frame rate elevated while overlays are on screen.

## Tests

18 new unit tests in `OverlayHostTests` cover registration, dedup/update, dismissal, clear, layer + registration ordering, stable re-show, safe mid-frame Show/Dismiss, and null-arg guards. Full `ImGui.Widgets.Tests` suite: **72 passed, 0 failed**.

## Files

- `ImGui.Widgets/Overlays/OverlayHost.cs` (new)
- `ImGui.Widgets/Overlays/OverlayLayer.cs` (new)
- `tests/ImGui.Widgets.Tests/OverlayHostTests.cs` (new)

https://claude.ai/code/session_01PPGSNx3gFVrvXXGBzPCkGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPGSNx3gFVrvXXGBzPCkGR)_