### PR TITLE
feat: add mobile form-control widgets (Switch, SegmentedControl, Chip, Stepper, RangeSlider)

### DIFF
--- a/ImGui.Widgets/Chip.cs
+++ b/ImGui.Widgets/Chip.cs
@@ -1,0 +1,154 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Draws a compact, pill-shaped chip. Filled with the accent colour when <paramref name="selected"/>
+	/// is <see langword="true"/>, otherwise outlined. Useful for filter / choice tags.
+	/// </summary>
+	/// <param name="label">The chip caption; text after <c>##</c> is hidden but used for the ID.</param>
+	/// <param name="selected">Whether the chip is in its selected (filled) state.</param>
+	/// <returns><see langword="true"/> if the chip was clicked this frame; otherwise <see langword="false"/>.</returns>
+	public static bool Chip(string label, bool selected = false) => ChipImpl.Draw(label, selected, false, out _);
+
+	/// <summary>
+	/// Draws a closable chip with a trailing <c>×</c> button (an "input" chip).
+	/// </summary>
+	/// <param name="label">The chip caption; text after <c>##</c> is hidden but used for the ID.</param>
+	/// <param name="selected">Whether the chip is in its selected (filled) state.</param>
+	/// <param name="closeClicked">Set to <see langword="true"/> when the trailing close button was clicked this frame.</param>
+	/// <returns><see langword="true"/> if the chip body was clicked this frame; otherwise <see langword="false"/>.</returns>
+	public static bool Chip(string label, bool selected, out bool closeClicked) => ChipImpl.Draw(label, selected, true, out closeClicked);
+
+	/// <summary>
+	/// Draws a horizontal, wrapping group of single-select chips.
+	/// </summary>
+	/// <param name="label">A unique label used for the widget ID; not drawn.</param>
+	/// <param name="options">The chip captions.</param>
+	/// <param name="selectedIndex">The selected chip index. Updated in place when a chip is clicked.</param>
+	/// <param name="allowDeselect">When <see langword="true"/>, clicking the active chip clears the selection (sets it to -1).</param>
+	/// <returns><see langword="true"/> if the selection changed this frame; otherwise <see langword="false"/>.</returns>
+	public static bool ChipGroup(string label, IReadOnlyList<string> options, ref int selectedIndex, bool allowDeselect = false) =>
+		ChipImpl.DrawGroup(label, options, ref selectedIndex, allowDeselect);
+
+	internal static class ChipImpl
+	{
+		public static bool Draw(string label, bool selected, bool closable, out bool closeClicked)
+		{
+			closeClicked = false;
+			string visible = VisibleLabel(label);
+
+			ImGuiStylePtr style = ImGui.GetStyle();
+			float height = ImGui.GetFrameHeight();
+			float rounding = height * 0.5f;
+			float padX = style.FramePadding.X * 1.5f;
+
+			Vector2 textSize = ImGui.CalcTextSize(visible);
+			float closeSize = closable ? height * 0.55f : 0.0f;
+			float closeGap = closable ? style.ItemInnerSpacing.X : 0.0f;
+			float width = (padX * 2.0f) + textSize.X + closeGap + closeSize;
+
+			Vector2 origin = ImGui.GetCursorScreenPos();
+			ImGui.InvisibleButton(label, new Vector2(width, height));
+
+			bool hovered = ImGui.IsItemHovered();
+			bool bodyClicked = ImGui.IsItemClicked();
+
+			Span<Vector4> colors = style.Colors;
+			ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+
+			Vector2 max = new(origin.X + width, origin.Y + height);
+			if (selected)
+			{
+				Vector4 fill = hovered ? colors[(int)ImGuiCol.ButtonHovered] : colors[(int)ImGuiCol.ButtonActive];
+				drawList.AddRectFilled(origin, max, ImGui.GetColorU32(fill), rounding);
+			}
+			else
+			{
+				if (hovered)
+				{
+					drawList.AddRectFilled(origin, max, ImGui.GetColorU32(colors[(int)ImGuiCol.FrameBgHovered]), rounding);
+				}
+
+				drawList.AddRect(origin, max, ImGui.GetColorU32(colors[(int)ImGuiCol.Border]), rounding);
+			}
+
+			Vector2 textPos = new(origin.X + padX, origin.Y + ((height - textSize.Y) * 0.5f));
+			drawList.AddText(textPos, ImGui.GetColorU32(colors[(int)ImGuiCol.Text]), visible);
+
+			if (closable)
+			{
+				Vector2 closeCenter = new(max.X - padX - (closeSize * 0.5f), origin.Y + (height * 0.5f));
+				float r = closeSize * 0.5f;
+				Vector2 closeMin = new(closeCenter.X - r, closeCenter.Y - r);
+				Vector2 closeMax = new(closeCenter.X + r, closeCenter.Y + r);
+
+				// Hit-test the close glyph against the mouse without consuming the body button.
+				Vector2 mouse = ImGui.GetIO().MousePos;
+				bool overClose = mouse.X >= closeMin.X && mouse.X <= closeMax.X && mouse.Y >= closeMin.Y && mouse.Y <= closeMax.Y;
+				if (overClose && ImGui.IsItemClicked())
+				{
+					closeClicked = true;
+					bodyClicked = false;
+				}
+
+				uint glyphColor = ImGui.GetColorU32(overClose ? colors[(int)ImGuiCol.Text] : colors[(int)ImGuiCol.TextDisabled]);
+				float k = r * 0.5f;
+				drawList.AddLine(new Vector2(closeCenter.X - k, closeCenter.Y - k), new Vector2(closeCenter.X + k, closeCenter.Y + k), glyphColor, 1.5f);
+				drawList.AddLine(new Vector2(closeCenter.X - k, closeCenter.Y + k), new Vector2(closeCenter.X + k, closeCenter.Y - k), glyphColor, 1.5f);
+			}
+
+			return bodyClicked;
+		}
+
+		public static bool DrawGroup(string label, IReadOnlyList<string> options, ref int selectedIndex, bool allowDeselect)
+		{
+			Ensure.NotNull(options);
+
+			ImGui.PushID(label);
+			bool changed = false;
+			ImGuiStylePtr style = ImGui.GetStyle();
+			float rightEdge = ImGui.GetCursorScreenPos().X + ImGui.GetContentRegionAvail().X;
+
+			for (int i = 0; i < options.Count; i++)
+			{
+				if (Draw($"{options[i]}##chip{i}", i == selectedIndex, false, out _))
+				{
+					int next = allowDeselect && i == selectedIndex ? -1 : i;
+					if (next != selectedIndex)
+					{
+						selectedIndex = next;
+						changed = true;
+					}
+				}
+
+				// Keep the next chip on this line only if it fits before the content edge.
+				if (i + 1 < options.Count)
+				{
+					float lastRight = ImGui.GetItemRectMax().X;
+					float nextWidth = ImGui.CalcTextSize(VisibleLabel(options[i + 1])).X + (style.FramePadding.X * 3.0f);
+					if (lastRight + style.ItemSpacing.X + nextWidth < rightEdge)
+					{
+						ImGui.SameLine();
+					}
+				}
+			}
+
+			ImGui.PopID();
+			return changed;
+		}
+	}
+}

--- a/ImGui.Widgets/RangeSlider.cs
+++ b/ImGui.Widgets/RangeSlider.cs
@@ -1,0 +1,146 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Draws a dual-handle range slider for selecting a <paramref name="lower"/>/<paramref name="upper"/>
+	/// span within <paramref name="min"/>..<paramref name="max"/>. The handles cannot cross and are
+	/// kept at least <paramref name="minGap"/> apart.
+	/// </summary>
+	/// <param name="label">A unique label; text after <c>##</c> is hidden but used for the ID. Visible text is drawn to the right.</param>
+	/// <param name="lower">The lower bound of the selected range. Updated in place.</param>
+	/// <param name="upper">The upper bound of the selected range. Updated in place.</param>
+	/// <param name="min">The minimum selectable value.</param>
+	/// <param name="max">The maximum selectable value.</param>
+	/// <param name="minGap">The minimum distance kept between the two handles.</param>
+	/// <returns><see langword="true"/> if either value changed this frame; otherwise <see langword="false"/>.</returns>
+	public static bool RangeSlider(string label, ref float lower, ref float upper, float min, float max, float minGap = 0.0f) =>
+		RangeSliderImpl.Draw(label, ref lower, ref upper, min, max, minGap);
+
+	internal static class RangeSliderImpl
+	{
+		// Per-ID active handle: 0 = lower, 1 = upper, -1 = none.
+		private static readonly Dictionary<uint, int> ActiveHandle = [];
+
+		public static bool Draw(string label, ref float lower, ref float upper, float min, float max, float minGap)
+		{
+			if (min > max)
+			{
+				(min, max) = (max, min);
+			}
+
+			minGap = Math.Clamp(minGap, 0.0f, max - min);
+
+			uint id = ImGui.GetID(label);
+			float height = ImGui.GetFrameHeight();
+			float width = MathF.Max(ImGui.CalcItemWidth(), height * 3.0f);
+			float grabRadius = height * 0.35f;
+
+			Vector2 origin = ImGui.GetCursorScreenPos();
+			ImGui.InvisibleButton(label, new Vector2(width, height));
+
+			float trackMinX = origin.X + grabRadius;
+			float trackMaxX = origin.X + width - grabRadius;
+			float trackY = origin.Y + (height * 0.5f);
+			float span = MathF.Max(trackMaxX - trackMinX, 1.0f);
+
+			// Clamp inputs to a valid, non-crossing, gap-respecting state before interaction.
+			lower = Math.Clamp(lower, min, max);
+			upper = Math.Clamp(upper, min, max);
+			if (upper - lower < minGap)
+			{
+				upper = MathF.Min(max, lower + minGap);
+				lower = MathF.Min(lower, upper - minGap);
+			}
+
+			bool changed = false;
+
+			if (ImGui.IsItemActivated())
+			{
+				// Grab whichever handle is nearer the click.
+				float mouseX = ImGui.GetIO().MousePos.X;
+				float lowerX = trackMinX + (ValueToFraction(lower, min, max) * span);
+				float upperX = trackMinX + (ValueToFraction(upper, min, max) * span);
+				ActiveHandle[id] = MathF.Abs(mouseX - lowerX) <= MathF.Abs(mouseX - upperX) ? 0 : 1;
+			}
+
+			if (ImGui.IsItemActive())
+			{
+				int handle = ActiveHandle.GetValueOrDefault(id, -1);
+				float t = Math.Clamp((ImGui.GetIO().MousePos.X - trackMinX) / span, 0.0f, 1.0f);
+				float newValue = min + (t * (max - min));
+
+				if (handle == 0)
+				{
+					float clamped = Math.Clamp(newValue, min, upper - minGap);
+					if (clamped != lower)
+					{
+						lower = clamped;
+						changed = true;
+					}
+				}
+				else if (handle == 1)
+				{
+					float clamped = Math.Clamp(newValue, lower + minGap, max);
+					if (clamped != upper)
+					{
+						upper = clamped;
+						changed = true;
+					}
+				}
+			}
+			else
+			{
+				ActiveHandle.Remove(id);
+			}
+
+			// Draw track, filled selection, and handles.
+			ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+			Span<Vector4> colors = ImGui.GetStyle().Colors;
+			float trackThickness = MathF.Max(height * 0.18f, 2.0f);
+
+			drawList.AddLine(new Vector2(trackMinX, trackY), new Vector2(trackMaxX, trackY), ImGui.GetColorU32(colors[(int)ImGuiCol.FrameBg]), trackThickness);
+
+			float lowerX2 = trackMinX + (ValueToFraction(lower, min, max) * span);
+			float upperX2 = trackMinX + (ValueToFraction(upper, min, max) * span);
+			drawList.AddLine(new Vector2(lowerX2, trackY), new Vector2(upperX2, trackY), ImGui.GetColorU32(colors[(int)ImGuiCol.SliderGrab]), trackThickness);
+
+			bool hovered = ImGui.IsItemHovered() || ImGui.IsItemActive();
+			uint grabColor = ImGui.GetColorU32(hovered ? colors[(int)ImGuiCol.SliderGrabActive] : colors[(int)ImGuiCol.SliderGrab]);
+			drawList.AddCircleFilled(new Vector2(lowerX2, trackY), grabRadius, grabColor, 24);
+			drawList.AddCircleFilled(new Vector2(upperX2, trackY), grabRadius, grabColor, 24);
+
+			if ((ImGui.IsItemHovered() || ImGui.IsItemActive()))
+			{
+				ImGui.SetTooltip(string.Format(CultureInfo.CurrentCulture, "{0:0.###} – {1:0.###}", lower, upper));
+			}
+
+			string visible = VisibleLabel(label);
+			if (visible.Length > 0)
+			{
+				ImGui.SameLine();
+				ImGui.AlignTextToFramePadding();
+				ImGui.TextUnformatted(visible);
+			}
+
+			return changed;
+		}
+
+		private static float ValueToFraction(float value, float min, float max) =>
+			max <= min ? 0.0f : Math.Clamp((value - min) / (max - min), 0.0f, 1.0f);
+	}
+}

--- a/ImGui.Widgets/RangeSlider.cs
+++ b/ImGui.Widgets/RangeSlider.cs
@@ -124,7 +124,7 @@ public static partial class ImGuiWidgets
 			drawList.AddCircleFilled(new Vector2(lowerX2, trackY), grabRadius, grabColor, 24);
 			drawList.AddCircleFilled(new Vector2(upperX2, trackY), grabRadius, grabColor, 24);
 
-			if ((ImGui.IsItemHovered() || ImGui.IsItemActive()))
+			if (ImGui.IsItemHovered() || ImGui.IsItemActive())
 			{
 				ImGui.SetTooltip(string.Format(CultureInfo.CurrentCulture, "{0:0.###} – {1:0.###}", lower, upper));
 			}

--- a/ImGui.Widgets/SegmentedControl.cs
+++ b/ImGui.Widgets/SegmentedControl.cs
@@ -1,0 +1,127 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Draws a pill-shaped segmented control: a row of mutually-exclusive options with a sliding,
+	/// animated highlight behind the selected segment (think iOS <c>UISegmentedControl</c>).
+	/// </summary>
+	/// <param name="label">A unique label used for the widget ID; not drawn.</param>
+	/// <param name="selectedIndex">The index of the active segment. Updated in place when a segment is clicked.</param>
+	/// <param name="segments">The segment captions, left to right.</param>
+	/// <returns><see langword="true"/> if the selection changed this frame; otherwise <see langword="false"/>.</returns>
+	public static bool SegmentedControl(string label, ref int selectedIndex, params string[] segments) =>
+		SegmentedControlImpl.Draw(label, ref selectedIndex, segments);
+
+	/// <summary>
+	/// Draws a pill-shaped segmented control from any read-only list of captions.
+	/// </summary>
+	/// <param name="label">A unique label used for the widget ID; not drawn.</param>
+	/// <param name="selectedIndex">The index of the active segment. Updated in place when a segment is clicked.</param>
+	/// <param name="segments">The segment captions, left to right.</param>
+	/// <returns><see langword="true"/> if the selection changed this frame; otherwise <see langword="false"/>.</returns>
+	public static bool SegmentedControl(string label, ref int selectedIndex, IReadOnlyList<string> segments) =>
+		SegmentedControlImpl.Draw(label, ref selectedIndex, segments);
+
+	internal static class SegmentedControlImpl
+	{
+		// Per-ID animated highlight position (segment-index space); persists across frames.
+		private static readonly Dictionary<uint, float> Highlight = [];
+
+		private const float AnimationDuration = 0.15f;
+
+		public static bool Draw(string label, ref int selectedIndex, IReadOnlyList<string> segments)
+		{
+			Ensure.NotNull(segments);
+			if (segments.Count == 0)
+			{
+				return false;
+			}
+
+			uint id = ImGui.GetID(label);
+			selectedIndex = Math.Clamp(selectedIndex, 0, segments.Count - 1);
+
+			ImGuiStylePtr style = ImGui.GetStyle();
+			float height = ImGui.GetFrameHeight();
+			float padX = style.FramePadding.X * 2.0f;
+
+			// Width: each segment sized to fit its text, all equal to the widest, with a sensible floor.
+			float segmentWidth = 0.0f;
+			for (int i = 0; i < segments.Count; i++)
+			{
+				segmentWidth = MathF.Max(segmentWidth, ImGui.CalcTextSize(segments[i]).X);
+			}
+
+			segmentWidth = MathF.Max(segmentWidth + padX, height * 1.5f);
+			float totalWidth = segmentWidth * segments.Count;
+			float rounding = height * 0.5f;
+
+			Vector2 origin = ImGui.GetCursorScreenPos();
+			ImGui.InvisibleButton(label, new Vector2(totalWidth, height));
+
+			bool changed = false;
+			if (ImGui.IsItemActive() && ImGui.IsItemHovered())
+			{
+				float localX = ImGui.GetIO().MousePos.X - origin.X;
+				int hit = Math.Clamp((int)(localX / segmentWidth), 0, segments.Count - 1);
+				if (hit != selectedIndex)
+				{
+					selectedIndex = hit;
+					changed = true;
+				}
+			}
+
+			// Slide the highlight toward the selected segment.
+			if (!Highlight.TryGetValue(id, out float pos))
+			{
+				pos = selectedIndex;
+			}
+
+			float step = ImGui.GetIO().DeltaTime / AnimationDuration * MathF.Max(1.0f, MathF.Abs(selectedIndex - pos));
+			pos = selectedIndex > pos ? MathF.Min(selectedIndex, pos + step) : MathF.Max(selectedIndex, pos - step);
+			Highlight[id] = pos;
+
+			ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+			Span<Vector4> colors = ImGui.GetStyle().Colors;
+
+			// Track background.
+			drawList.AddRectFilled(origin, new Vector2(origin.X + totalWidth, origin.Y + height), ImGui.GetColorU32(colors[(int)ImGuiCol.FrameBg]), rounding);
+
+			// Sliding selected-segment highlight.
+			float highlightX = origin.X + (pos * segmentWidth);
+			float pad = height * 0.08f;
+			drawList.AddRectFilled(
+				new Vector2(highlightX + pad, origin.Y + pad),
+				new Vector2(highlightX + segmentWidth - pad, origin.Y + height - pad),
+				ImGui.GetColorU32(colors[(int)ImGuiCol.ButtonActive]),
+				rounding);
+
+			// Captions.
+			for (int i = 0; i < segments.Count; i++)
+			{
+				Vector2 textSize = ImGui.CalcTextSize(segments[i]);
+				float cellX = origin.X + (i * segmentWidth);
+				Vector2 textPos = new(
+					cellX + ((segmentWidth - textSize.X) * 0.5f),
+					origin.Y + ((height - textSize.Y) * 0.5f));
+				uint textColor = ImGui.GetColorU32(i == selectedIndex ? colors[(int)ImGuiCol.Text] : colors[(int)ImGuiCol.TextDisabled]);
+				drawList.AddText(textPos, textColor, segments[i]);
+			}
+
+			return changed;
+		}
+	}
+}

--- a/ImGui.Widgets/Stepper.cs
+++ b/ImGui.Widgets/Stepper.cs
@@ -1,0 +1,145 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Draws a <c>[-] value [+]</c> integer stepper with hold-to-repeat on the increment/decrement
+	/// buttons (after a short initial delay the value keeps changing while a button is held).
+	/// </summary>
+	/// <param name="label">A unique label used for the widget ID; text after <c>##</c> is hidden but used for the ID.</param>
+	/// <param name="value">The current value. Updated in place and clamped to <paramref name="min"/>/<paramref name="max"/>.</param>
+	/// <param name="step">The amount added or subtracted per activation.</param>
+	/// <param name="min">The inclusive lower bound.</param>
+	/// <param name="max">The inclusive upper bound.</param>
+	/// <returns><see langword="true"/> if the value changed this frame; otherwise <see langword="false"/>.</returns>
+	public static bool Stepper(string label, ref int value, int step = 1, int min = int.MinValue, int max = int.MaxValue) =>
+		StepperImpl.Draw(label, ref value, step, min, max);
+
+	internal static class StepperImpl
+	{
+		// Per-ID seconds a repeat button has been held; resets when released.
+		private static readonly Dictionary<uint, float> HoldTime = [];
+
+		private const float RepeatDelay = 0.4f;
+		private const float RepeatInterval = 0.06f;
+
+		public static bool Draw(string label, ref int value, int step, int min, int max)
+		{
+			if (min > max)
+			{
+				(min, max) = (max, min);
+			}
+
+			ImGui.PushID(label);
+			bool changed = false;
+
+			float height = ImGui.GetFrameHeight();
+			Vector2 buttonSize = new(height, height);
+
+			if (RepeatButton("-##dec", buttonSize))
+			{
+				int next = Math.Clamp(SafeAdd(value, -step), min, max);
+				if (next != value)
+				{
+					value = next;
+					changed = true;
+				}
+			}
+
+			ImGui.SameLine(0.0f, ImGui.GetStyle().ItemInnerSpacing.X);
+
+			string text = value.ToString(CultureInfo.CurrentCulture);
+			float valueWidth = MathF.Max(ImGui.CalcTextSize(text).X + (ImGui.GetStyle().FramePadding.X * 2.0f), height * 1.5f);
+			Vector2 valueOrigin = ImGui.GetCursorScreenPos();
+			ImGui.InvisibleButton("##value", new Vector2(valueWidth, height));
+
+			ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+			Span<Vector4> colors = ImGui.GetStyle().Colors;
+			drawList.AddRectFilled(valueOrigin, new Vector2(valueOrigin.X + valueWidth, valueOrigin.Y + height), ImGui.GetColorU32(colors[(int)ImGuiCol.FrameBg]), ImGui.GetStyle().FrameRounding);
+			Vector2 textSize = ImGui.CalcTextSize(text);
+			drawList.AddText(new Vector2(valueOrigin.X + ((valueWidth - textSize.X) * 0.5f), valueOrigin.Y + ((height - textSize.Y) * 0.5f)), ImGui.GetColorU32(colors[(int)ImGuiCol.Text]), text);
+
+			ImGui.SameLine(0.0f, ImGui.GetStyle().ItemInnerSpacing.X);
+
+			if (RepeatButton("+##inc", buttonSize))
+			{
+				int next = Math.Clamp(SafeAdd(value, step), min, max);
+				if (next != value)
+				{
+					value = next;
+					changed = true;
+				}
+			}
+
+			string visible = VisibleLabel(label);
+			if (visible.Length > 0)
+			{
+				ImGui.SameLine();
+				ImGui.AlignTextToFramePadding();
+				ImGui.TextUnformatted(visible);
+			}
+
+			ImGui.PopID();
+			return changed;
+		}
+
+		// A button that fires once on press, then repeatedly while held past the initial delay.
+		private static bool RepeatButton(string label, Vector2 size)
+		{
+			uint id = ImGui.GetID(label);
+			bool fired = ImGui.Button(label, size);
+
+			if (ImGui.IsItemActive())
+			{
+				float prev = HoldTime.GetValueOrDefault(id, 0.0f);
+				float now = prev + ImGui.GetIO().DeltaTime;
+				HoldTime[id] = now;
+				fired |= ShouldRepeat(prev, now, RepeatDelay, RepeatInterval);
+			}
+			else
+			{
+				HoldTime.Remove(id);
+			}
+
+			return fired;
+		}
+
+		/// <summary>
+		/// Pure hold-to-repeat decision: returns <see langword="true"/> when the hold crosses the
+		/// initial <paramref name="delay"/>, or each time it crosses an <paramref name="interval"/>
+		/// boundary thereafter, while advancing from <paramref name="prev"/> to <paramref name="now"/> seconds.
+		/// </summary>
+		internal static bool ShouldRepeat(float prev, float now, float delay, float interval)
+		{
+			if (prev < delay)
+			{
+				return now >= delay;
+			}
+
+			// Fire once per interval boundary crossed past the delay.
+			float a = (prev - delay) / interval;
+			float b = (now - delay) / interval;
+			return MathF.Floor(b) > MathF.Floor(a);
+		}
+
+		private static int SafeAdd(int value, int delta)
+		{
+			long result = (long)value + delta;
+			return result > int.MaxValue ? int.MaxValue : result < int.MinValue ? int.MinValue : (int)result;
+		}
+	}
+}

--- a/ImGui.Widgets/Switch.cs
+++ b/ImGui.Widgets/Switch.cs
@@ -1,0 +1,105 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+using ktsu.ImGui.Widgets.Animation;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Draws an iOS-style toggle switch with an animated thumb. The track colour interpolates
+	/// between the frame background (off) and the check-mark accent (on) as the thumb slides.
+	/// </summary>
+	/// <param name="label">A unique label; text after <c>##</c> is hidden but used for the ID. Visible text is drawn to the right of the switch.</param>
+	/// <param name="value">The current on/off state. Toggled in place when the switch is clicked.</param>
+	/// <returns><see langword="true"/> if the value changed this frame; otherwise <see langword="false"/>.</returns>
+	public static bool Switch(string label, ref bool value) => SwitchImpl.Draw(label, ref value);
+
+	internal static class SwitchImpl
+	{
+		// Per-ID thumb animation progress in [0, 1]; persists across frames in immediate mode.
+		private static readonly Dictionary<uint, float> Progress = [];
+
+		// Seconds for the thumb to travel end to end.
+		private const float AnimationDuration = 0.12f;
+
+		public static bool Draw(string label, ref bool value)
+		{
+			uint id = ImGui.GetID(label);
+
+			float height = ImGui.GetFrameHeight();
+			float width = height * 1.75f;
+			float radius = height * 0.5f;
+
+			Vector2 origin = ImGui.GetCursorScreenPos();
+			ImGui.InvisibleButton(label, new Vector2(width, height));
+
+			bool changed = false;
+			if (ImGui.IsItemClicked())
+			{
+				value = !value;
+				changed = true;
+			}
+
+			// Advance the thumb toward its target, easing for a natural feel.
+			float target = value ? 1.0f : 0.0f;
+			if (!Progress.TryGetValue(id, out float t))
+			{
+				t = target;
+			}
+
+			float delta = ImGui.GetIO().DeltaTime / AnimationDuration;
+			t = target > t ? MathF.Min(target, t + delta) : MathF.Max(target, t - delta);
+			Progress[id] = t;
+
+			float eased = Easing.OutCubic(Math.Clamp(t, 0.0f, 1.0f));
+
+			ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+			Span<Vector4> colors = ImGui.GetStyle().Colors;
+			Vector4 offColor = colors[(int)ImGuiCol.FrameBg];
+			Vector4 onColor = colors[(int)ImGuiCol.CheckMark];
+			Vector4 trackColor = Lerp(offColor, onColor, eased);
+
+			bool hovered = ImGui.IsItemHovered();
+			if (hovered)
+			{
+				Vector4 hoverTint = colors[(int)ImGuiCol.FrameBgHovered];
+				trackColor = Lerp(trackColor, hoverTint, 0.25f);
+			}
+
+			drawList.AddRectFilled(origin, new Vector2(origin.X + width, origin.Y + height), ImGui.GetColorU32(trackColor), radius);
+
+			float pad = height * 0.1f;
+			float thumbRadius = radius - pad;
+			float minX = origin.X + radius;
+			float maxX = origin.X + width - radius;
+			float thumbX = minX + ((maxX - minX) * eased);
+			Vector2 thumbCenter = new(thumbX, origin.Y + radius);
+			drawList.AddCircleFilled(thumbCenter, thumbRadius, ImGui.GetColorU32(new Vector4(1.0f, 1.0f, 1.0f, 1.0f)), 32);
+
+			// Visible label to the right of the switch (text before ## only).
+			string visible = VisibleLabel(label);
+			if (visible.Length > 0)
+			{
+				ImGui.SameLine();
+				ImGui.AlignTextToFramePadding();
+				ImGui.TextUnformatted(visible);
+			}
+
+			return changed;
+		}
+
+		private static Vector4 Lerp(Vector4 a, Vector4 b, float t) => a + ((b - a) * Math.Clamp(t, 0.0f, 1.0f));
+	}
+}

--- a/ImGui.Widgets/WidgetLabel.cs
+++ b/ImGui.Widgets/WidgetLabel.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Returns the visible portion of an ImGui label: everything before the <c>##</c> ID delimiter.
+	/// Returns the whole string when no delimiter is present.
+	/// </summary>
+	internal static string VisibleLabel(string label)
+	{
+		int hash = label.IndexOf("##", StringComparison.Ordinal);
+		return hash >= 0 ? label[..hash] : label;
+	}
+}

--- a/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
+++ b/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
@@ -56,6 +56,16 @@ internal static class ImGuiWidgetsDemo
 	private static float value = 0.5f;
 	private static float tab2Value = 0.5f;
 
+	// Mobile form-control demo state
+	private static bool switchWifi = true;
+	private static bool switchBluetooth;
+	private static int segmentSelected;
+	private static int chipGroupSelected = 1;
+	private static readonly List<string> chipTags = ["All", "Unread", "Flagged", "Archived", "Drafts", "Sent", "Spam"];
+	private static int stepperQuantity = 3;
+	private static float rangeLower = 25.0f;
+	private static float rangeUpper = 75.0f;
+
 	// Radial Progress Bar demo state
 	private static float progressValue = 0.65f;
 	private static bool progressAnimating;
@@ -153,6 +163,7 @@ internal static class ImGuiWidgetsDemo
 		ImGui.TextUnformatted("ImGuiWidgets Library - Comprehensive Demo");
 		ImGui.Separator();
 
+		ShowMobileFormControlsDemo();
 		ShowKnobDemo();
 		ShowRadialProgressBarDemo();
 		ShowColorIndicatorDemo();
@@ -458,6 +469,39 @@ internal static class ImGuiWidgetsDemo
 	}
 
 	// Individual widget demo methods
+	private static void ShowMobileFormControlsDemo()
+	{
+		if (ImGui.CollapsingHeader("Mobile - Form Controls"))
+		{
+			ImGui.TextUnformatted("Mobile-style form controls (Switch, SegmentedControl, Chip, Stepper, RangeSlider):");
+			ImGui.Separator();
+
+			ImGui.TextUnformatted("Switch (iOS-style toggle with animated thumb):");
+			ImGuiWidgets.Switch("Wi-Fi##switchWifi", ref switchWifi);
+			ImGuiWidgets.Switch("Bluetooth##switchBluetooth", ref switchBluetooth);
+
+			ImGui.Separator();
+			ImGui.TextUnformatted("Segmented control (sliding highlight):");
+			ImGuiWidgets.SegmentedControl("##viewMode", ref segmentSelected, "Day", "Week", "Month", "Year");
+			ImGui.TextUnformatted($"Selected segment index: {segmentSelected}");
+
+			ImGui.Separator();
+			ImGui.TextUnformatted("Chips (single-select, wrapping group):");
+			ImGuiWidgets.ChipGroup("##chipTags", chipTags, ref chipGroupSelected, allowDeselect: true);
+			ImGui.TextUnformatted(chipGroupSelected >= 0 ? $"Filter: {chipTags[chipGroupSelected]}" : "Filter: (none)");
+
+			ImGui.Separator();
+			ImGui.TextUnformatted("Stepper (hold +/- to repeat):");
+			ImGuiWidgets.Stepper("Quantity##stepperQuantity", ref stepperQuantity, step: 1, min: 0, max: 99);
+
+			ImGui.Separator();
+			ImGui.TextUnformatted("Range slider (dual handle, drag either grab):");
+			ImGui.SetNextItemWidth(260.0f);
+			ImGuiWidgets.RangeSlider("Price##rangePrice", ref rangeLower, ref rangeUpper, 0.0f, 100.0f, minGap: 5.0f);
+			ImGui.TextUnformatted($"Range: {rangeLower:F0} - {rangeUpper:F0}");
+		}
+	}
+
 	private static void ShowKnobDemo()
 	{
 		if (ImGui.CollapsingHeader("Knobs"))


### PR DESCRIPTION
## Summary

Continues the [mobile UI widgets plan](docs/plans/2026-05-28-mobile-ui-widgets.md). Phase 0 (gestures, animation primitives, inertial scroll, overlay host) already landed; this PR delivers the **Phase 1 "form controls" batch** — pure layout/draw widgets with no gesture dependency.

## New widgets (`ImGui.Widgets`)

| Widget | Notes |
|---|---|
| `Switch` | iOS-style toggle; `Tween`-eased (`OutCubic`) animated thumb. Track colour interpolates `FrameBg` → `CheckMark`. |
| `SegmentedControl` | Pill-shaped mutually-exclusive options with a sliding highlight. `params` and `IReadOnlyList` overloads. |
| `Chip` / `ChipGroup` | Filled/outlined pill chips, an optional trailing `×` close button (input chips), and a wrapping single-select group with optional deselect. |
| `Stepper` | `[-] value [+]` integer control with hold-to-repeat (pure `ShouldRepeat` timing helper) and overflow-safe clamping. |
| `RangeSlider` | Dual-handle range; non-crossing handles, configurable minimum gap, value tooltip, themed grabs. |

Also adds a shared internal `VisibleLabel` helper (strips the `##` ID delimiter) used by the new widgets.

## Cross-cutting concerns (per the plan)

- **Theming** — every widget reads colours from the active ImGui style; no hard-coded hex.
- **DPI** — sizes derive from `ImGui.GetFrameHeight()` so they scale with the app's global scale.
- **Immediate-mode state** — per-ID animation/hold state is kept in static dictionaries keyed by the ImGui ID, consistent with the Phase 0 helpers.

## Demo

Adds a **"Mobile - Form Controls"** section to `ImGuiWidgetsDemo` exercising all five widgets.

## Testing

- All 72 existing `ImGui.Widgets.Tests` pass.
- Phase 1 widgets are draw-only; per the plan they are verified visually via the demo. The one piece of pure logic (`Stepper.ShouldRepeat`) is factored out as a self-contained helper.

## Notes

The new files build clean under code-style enforcement (`IDE0055` etc.). The library compiles and tests pass; the demo/test *runtime* apphost couldn't be restored in the sandbox (`NU1101` for `Microsoft.NETCore.App.Host.ubuntu.24.04-x64`), so the demo was compile-validated rather than launched.

https://claude.ai/code/session_01LmWcjPaM7G88Cafu8uG7uN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmWcjPaM7G88Cafu8uG7uN)_