### PR TITLE
docs: correct package names and audit documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,10 @@ This is the **ktsu ImGui Suite**, a collection of .NET libraries for building De
 
 ### Libraries
 
-- **ImGui.App** (`ktsu.ImGuiApp`) - Application foundation with windowing, rendering, font/texture management, PID frame limiting, DPI awareness
-- **ImGui.Widgets** (`ktsu.ImGuiWidgets`) - Custom UI components: TabPanel, Knob, SearchBox, RadialProgressBar, Grid, DividerContainer, Combo, Tree, Icons, ColorIndicator, Text, Image, ScopedDisable, ScopedId
-- **ImGui.Popups** (`ktsu.ImGuiPopups`) - Modal dialogs: MessageOK, Prompt, InputString/Int/Float, FilesystemBrowser, SearchableList
-- **ImGui.Styler** (`ktsu.ImGuiStyler`) - Theming system with 50+ built-in themes, scoped styling, Button.Alignment, Text.Color semantic colors, Indent utilities, Alignment helpers, color palettes, and interactive theme browser
+- **ImGui.App** (`ktsu.ImGui.App`) - Application foundation with windowing, rendering, font/texture management, PID frame limiting, DPI awareness
+- **ImGui.Widgets** (`ktsu.ImGui.Widgets`) - Custom UI components: TabPanel, Knob, SearchBox, RadialProgressBar, Grid, DividerContainer, Combo, Tree, Icons, ColorIndicator, Text, Image, ScopedDisable, ScopedId
+- **ImGui.Popups** (`ktsu.ImGui.Popups`) - Modal dialogs: MessageOK, Prompt, InputString/Int/Float, FilesystemBrowser, SearchableList
+- **ImGui.Styler** (`ktsu.ImGui.Styler`) - Theming system with 50+ built-in themes, scoped styling, Button.Alignment, Text.Color semantic colors, Indent utilities, Alignment helpers, color palettes, and interactive theme browser
 - **NodeGraph** (`ktsu.NodeGraph`) - UI-agnostic attribute-based node graph metadata: `[Node]`, `[InputPin]`, `[OutputPin]`, `[NodeExecute]`, `[NodeBehavior]`, pin type utilities
 - **ImGuiNodeEditor** (`ktsu.ImGuiNodeEditor`) - ImNodes-based visual node editor with `NodeEditorEngine`, `AttributeBasedNodeFactory`, physics-based layout, `NodeEditorRenderer`, `NodeEditorInputHandler`
 

--- a/ImGui.App/README.md
+++ b/ImGui.App/README.md
@@ -1,10 +1,10 @@
-# ktsu.ImGuiApp
+# ktsu.ImGui.App
 
 > A .NET library that provides application scaffolding for Dear ImGui, using Silk.NET and Hexa.NET.ImGui.
 
-[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGuiApp.svg)](https://www.nuget.org/packages/ktsu.ImGuiApp/)
+[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGui.App.svg)](https://www.nuget.org/packages/ktsu.ImGui.App/)
 [![License](https://img.shields.io/github/license/ktsu-dev/ImGuiApp.svg)](LICENSE.md)
-[![NuGet Downloads](https://img.shields.io/nuget/dt/ktsu.ImGuiApp.svg)](https://www.nuget.org/packages/ktsu.ImGuiApp/)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/ktsu.ImGui.App.svg)](https://www.nuget.org/packages/ktsu.ImGui.App/)
 [![GitHub Stars](https://img.shields.io/github/stars/ktsu-dev/ImGuiApp?style=social)](https://github.com/ktsu-dev/ImGuiApp/stargazers)
 
 ## Introduction
@@ -27,33 +27,33 @@ ImGuiApp is a .NET library that provides application scaffolding for [Dear ImGui
 - **Lifecycle Callbacks**: Customizable delegate callbacks for application events
 - **Menu System**: Easy-to-use API for creating application menus
 - **Positioning Guards**: Offscreen positioning checks to keep windows visible
-- **Modern .NET**: Supports .NET 9 and newer
+- **Modern .NET**: Supports .NET 8, 9, and 10
 - **Active Development**: Open-source and actively maintained
 
 ## Getting Started
 
 ### Prerequisites
 
-- .NET 9.0 or later
+- .NET 8.0 or later
 
 ## Installation
 
 ### Package Manager Console
 
 ```powershell
-Install-Package ktsu.ImGuiApp
+Install-Package ktsu.ImGui.App
 ```
 
 ### .NET CLI
 
 ```bash
-dotnet add package ktsu.ImGuiApp
+dotnet add package ktsu.ImGui.App
 ```
 
 ### Package Reference
 
 ```xml
-<PackageReference Include="ktsu.ImGuiApp" Version="x.y.z" />
+<PackageReference Include="ktsu.ImGui.App" Version="x.y.z" />
 ```
 
 ## Usage Examples
@@ -63,7 +63,7 @@ dotnet add package ktsu.ImGuiApp
 Create a new class and call `ImGuiApp.Start()` with your application config:
 
 ```csharp
-using ktsu.ImGuiApp;
+using ktsu.ImGui.App;
 using Hexa.NET.ImGui;
 
 static class Program
@@ -272,7 +272,7 @@ The system automatically:
 ### Full Application with Multiple Windows
 
 ```csharp
-using ktsu.ImGuiApp;
+using ktsu.ImGui.App;
 using Hexa.NET.ImGui;
 using System.Numerics;
 

--- a/ImGui.Popups/README.md
+++ b/ImGui.Popups/README.md
@@ -1,6 +1,6 @@
-# ImGuiPopups
+# ktsu.ImGui.Popups
 
-[![Version](https://img.shields.io/badge/version-1.3.5-blue.svg)](VERSION.md)
+[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGui.Popups?logo=nuget)](https://nuget.org/packages/ktsu.ImGui.Popups)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE.md)
 
 A comprehensive library for custom popup windows and modal dialogs using ImGui.NET, providing a rich set of UI components for interactive applications.
@@ -36,23 +36,23 @@ A comprehensive library for custom popup windows and modal dialogs using ImGui.N
 
 ### Package Manager Console
 ```powershell
-Install-Package ktsu.ImGuiPopups
+Install-Package ktsu.ImGui.Popups
 ```
 
 ### .NET CLI
 ```bash
-dotnet add package ktsu.ImGuiPopups
+dotnet add package ktsu.ImGui.Popups
 ```
 
 ### PackageReference
 ```xml
-<PackageReference Include="ktsu.ImGuiPopups" Version="1.3.5" />
+<PackageReference Include="ktsu.ImGui.Popups" Version="x.y.z" />
 ```
 
 ## Quick Start
 
 ```csharp
-using ktsu.ImGuiPopups;
+using ktsu.ImGui.Popups;
 
 // Create popup instances (typically as class members)
 private static readonly ImGuiPopups.MessageOK messageOK = new();
@@ -141,25 +141,22 @@ Advanced file and directory browser:
 ```csharp
 var browser = new ImGuiPopups.FilesystemBrowser();
 
-// Open file
-browser.Open(
-    title: "Open File",
-    mode: FilesystemBrowserMode.Open,
-    target: FilesystemBrowserTarget.File,
-    startPath: Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-    onConfirm: path => OpenFile(path),
-    patterns: new[] { "*.txt", "*.md" } // Optional file filters
-);
+// Open a file (the optional glob filters which files are shown)
+browser.FileOpen("Open File", path => OpenFile(path), glob: "*.txt");
 
-// Save file
-browser.Open(
-    title: "Save File",
-    mode: FilesystemBrowserMode.Save,
-    target: FilesystemBrowserTarget.File,
-    startPath: currentDirectory,
-    onConfirm: path => SaveFile(path)
-);
+// Save a file
+browser.FileSave("Save File", path => SaveFile(path), glob: "*.txt");
+
+// Choose a directory
+browser.ChooseDirectory("Select Folder", dir => UseDirectory(dir));
+
+// Render the browser each frame in your ImGui loop
+browser.ShowIfOpen();
 ```
+
+> File callbacks receive an `AbsoluteFilePath` and directory callbacks an `AbsoluteDirectoryPath`
+> (from `ktsu.Semantics.Paths`). Each `FileOpen`/`FileSave`/`ChooseDirectory` overload also
+> accepts a `Vector2 customSize`.
 
 ### Custom Modal
 Create custom modal dialogs:
@@ -219,9 +216,9 @@ inputInt.Open("Enter Age", "Age (1-120):", 25, result => {
 The repository includes a comprehensive demo application showcasing all components:
 
 ```bash
-git clone https://github.com/ktsu-dev/ImGuiPopups.git
-cd ImGuiPopups
-dotnet run --project ImGuiPopupsDemo
+git clone https://github.com/ktsu-dev/ImGuiApp.git
+cd ImGuiApp
+dotnet run --project examples/ImGuiPopupsDemo
 ```
 
 ## Dependencies
@@ -230,7 +227,8 @@ dotnet run --project ImGuiPopupsDemo
 - [ktsu.Extensions](https://www.nuget.org/packages/ktsu.Extensions/) - Utility extensions
 - [ktsu.CaseConverter](https://www.nuget.org/packages/ktsu.CaseConverter/) - String case conversion
 - [ktsu.ScopedAction](https://www.nuget.org/packages/ktsu.ScopedAction/) - RAII-style actions
-- [ktsu.StrongPaths](https://www.nuget.org/packages/ktsu.StrongPaths/) - Type-safe path handling
+- [ktsu.Semantics.Paths](https://www.nuget.org/packages/ktsu.Semantics.Paths/) - Type-safe path handling
+- [ktsu.Semantics.Strings](https://www.nuget.org/packages/ktsu.Semantics.Strings/) - Type-safe string wrappers
 - [ktsu.TextFilter](https://www.nuget.org/packages/ktsu.TextFilter/) - Text filtering utilities
 - [Microsoft.Extensions.FileSystemGlobbing](https://www.nuget.org/packages/Microsoft.Extensions.FileSystemGlobbing/) - File pattern matching
 

--- a/ImGui.Styler/README.md
+++ b/ImGui.Styler/README.md
@@ -1,6 +1,6 @@
-# ImGuiStyler 🎨
+# ktsu.ImGui.Styler 🎨
 
-[![Version](https://img.shields.io/badge/version-1.3.10-blue.svg)](VERSION.md)
+[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGui.Styler?logo=nuget)](https://nuget.org/packages/ktsu.ImGui.Styler)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE.md)
 
 **A powerful, expressive styling library for ImGui.NET interfaces** that simplifies theme management, provides scoped styling utilities, and offers advanced color manipulation with accessibility features.
@@ -35,22 +35,22 @@
 Add ImGuiStyler to your project via NuGet:
 
 ```xml
-<PackageReference Include="ktsu.ImGuiStyler" Version="1.3.10" />
+<PackageReference Include="ktsu.ImGui.Styler" Version="x.y.z" />
 ```
 
 Or via Package Manager Console:
 ```powershell
-Install-Package ktsu.ImGuiStyler
+Install-Package ktsu.ImGui.Styler
 ```
 
 ## 🚀 Quick Start
 
 ```csharp
-using ktsu.ImGuiStyler;
+using ktsu.ImGui.Styler;
 using Hexa.NET.ImGui;
 
 // Apply a global theme
-Theme.Apply("TokyoNight");
+Theme.Apply("Tokyo Night");
 
 // Use scoped styling for specific elements
 using (new ScopedColor(ImGuiCol.Text, Color.FromHex("#ff6b6b")))
@@ -72,16 +72,15 @@ using (new Alignment.Center(ImGui.CalcTextSize("Centered!")))
 #### Applying Global Themes
 ```csharp
 // Apply any of the 50+ built-in themes
-Theme.Apply("Catppuccin.Mocha");
-Theme.Apply("Gruvbox.Dark");
+Theme.Apply("Catppuccin Mocha");
+Theme.Apply("Gruvbox Dark");
 Theme.Apply("Tokyo Night");
 
-// Get current theme information
+// Get the name of the currently applied theme
 string? currentTheme = Theme.CurrentThemeName;
-bool isCurrentThemeDark = Theme.IsCurrentThemeDark;
 
 // Reset to default ImGui theme
-Theme.Reset();
+Theme.ResetToDefault();
 ```
 
 #### Interactive Theme Browser
@@ -101,12 +100,16 @@ if (Theme.RenderThemeSelector())
 
 #### Scoped Theme Application
 ```csharp
-using (new ScopedTheme("Dracula"))
+// ScopedTheme takes an ISemanticTheme instance; resolve one by name from the registry
+ISemanticTheme dracula = Theme.FindTheme("Dracula")!.CreateInstance();
+ISemanticTheme nord = Theme.FindTheme("Nord")!.CreateInstance();
+
+using (new ScopedTheme(dracula))
 {
     ImGui.Text("This text uses Dracula theme");
     ImGui.Button("Themed button");
-    
-    using (new ScopedTheme("Nord"))
+
+    using (new ScopedTheme(nord))
     {
         ImGui.Text("Nested Nord theme");
     }
@@ -127,21 +130,26 @@ ImColor blueWithAlpha = Color.FromHex("#0066ffcc");
 ImColor green = Color.FromRGB(0, 255, 0);
 ImColor customColor = Color.FromRGBA(255, 128, 64, 200);
 
-// From HSV
-ImColor rainbow = Color.FromHSV(0.83f, 1.0f, 1.0f); // Purple
+// From HSL (hue, saturation, lightness)
+ImColor purple = Color.FromHSL(0.83f, 1.0f, 0.5f);
 ```
 
 #### Color Manipulation
+
+Color manipulation is provided as extension methods on `ImColor`:
+
 ```csharp
 ImColor baseColor = Color.FromHex("#3498db");
 
 // Adjust brightness
-ImColor lighter = Color.Lighten(baseColor, 0.3f);
-ImColor darker = Color.Darken(baseColor, 0.2f);
+ImColor lighter = baseColor.LightenBy(0.3f);
+ImColor darker = baseColor.DarkenBy(0.2f);
 
-// Accessibility-focused text colors
-ImColor optimalText = Color.GetOptimalTextColor(baseColor);
-ImColor contrastText = Color.GetContrastingTextColor(baseColor);
+// Accessibility-focused text color (best contrast over baseColor)
+ImColor optimalText = baseColor.CalculateOptimalContrastingColor();
+
+// WCAG contrast ratio between two colors
+float ratio = optimalText.GetContrastRatioOver(baseColor);
 ```
 
 #### Scoped Color Application
@@ -346,23 +354,29 @@ ImGuiStyler includes **50+ carefully crafted themes** across multiple families:
 ## 🛠️ API Reference
 
 ### Theme Class
-- `Theme.Apply(string themeName)` - Apply a global theme
+- `Theme.Apply(string themeName)` - Apply a global theme (returns `false` if not found)
 - `Theme.Apply(ISemanticTheme theme)` - Apply a semantic theme
-- `Theme.Reset()` - Reset to default ImGui theme
+- `Theme.ResetToDefault()` - Reset to default ImGui theme
 - `Theme.ShowThemeSelector(string title)` - Show theme browser modal
 - `Theme.RenderThemeSelector()` - Render theme browser (returns true if theme changed)
-- `Theme.AllThemes` - Get all available themes
+- `Theme.RenderMenu(string menuLabel)` - Render a theme selection menu
+- `Theme.FindTheme(string name)` - Look up a theme by name (returns `ThemeInfo?`)
+- `Theme.AllThemes` / `Theme.DarkThemes` / `Theme.LightThemes` - Available themes
 - `Theme.Families` - Get all theme families
 - `Theme.CurrentThemeName` - Get current theme name
-- `Theme.IsCurrentThemeDark` - Check if current theme is dark
 
 ### Color Class
 - `Color.FromHex(string hex)` - Create color from hex string
-- `Color.FromRGB(int r, int g, int b)` - Create color from RGB
-- `Color.FromRGBA(int r, int g, int b, int a)` - Create color from RGBA
-- `Color.GetOptimalTextColor(ImColor background)` - Get accessible text color
-- `Color.Lighten(ImColor color, float amount)` - Lighten color
-- `Color.Darken(ImColor color, float amount)` - Darken color
+- `Color.FromRGB(byte r, byte g, byte b)` - Create color from RGB
+- `Color.FromRGBA(byte r, byte g, byte b, byte a)` - Create color from RGBA
+- `Color.FromHSL(float h, float s, float l)` - Create color from HSL
+
+### Color Extension Methods (on `ImColor`)
+- `color.LightenBy(float amount)` - Lighten color
+- `color.DarkenBy(float amount)` - Darken color
+- `color.WithAlpha(float amount)` - Set alpha channel
+- `color.CalculateOptimalContrastingColor()` - Get accessible (max-contrast) text color
+- `color.GetContrastRatioOver(ImColor background)` - WCAG contrast ratio
 
 ### Alignment Classes
 - `new Alignment.Center(Vector2 contentSize)` - Center in available region
@@ -372,7 +386,7 @@ ImGuiStyler includes **50+ carefully crafted themes** across multiple families:
 - `new ScopedColor(ImGuiCol col, ImColor color)` - Scoped color application
 - `new ScopedTextColor(ImColor color)` - Scoped text color
 - `new ScopedStyleVar(ImGuiStyleVar var, float value)` - Scoped style variable
-- `new ScopedTheme(string themeName)` - Scoped theme application
+- `new ScopedTheme(ISemanticTheme theme)` - Scoped theme application
 - `new ScopedThemeColor(Color semanticColor)` - Scoped semantic color
 
 ### Button Class
@@ -396,8 +410,7 @@ ImGuiStyler includes **50+ carefully crafted themes** across multiple families:
 The included demo application showcases all features:
 
 ```bash
-cd ImGuiStylerDemo
-dotnet run
+dotnet run --project examples/ImGuiStylerDemo
 ```
 
 Features demonstrated:
@@ -420,8 +433,8 @@ We welcome contributions! Please see our contributing guidelines:
 
 ### Development Setup
 ```bash
-git clone https://github.com/ktsu-dev/ImGuiStyler.git
-cd ImGuiStyler
+git clone https://github.com/ktsu-dev/ImGuiApp.git
+cd ImGuiApp
 dotnet restore
 dotnet build
 ```
@@ -440,8 +453,8 @@ This project is licensed under the **MIT License** - see the [LICENSE.md](LICENS
 ## 🔗 Related Projects
 
 - **[ktsu.ThemeProvider](https://github.com/ktsu-dev/ThemeProvider)** - Semantic theming foundation
-- **[ktsu.ImGuiPopups](https://github.com/ktsu-dev/ImGuiPopups)** - Modal and popup utilities
-- **[ktsu.Extensions](https://github.com/ktsu-dev/Extensions)** - Utility extensions
+- **[ktsu.ImGui.Popups](https://nuget.org/packages/ktsu.ImGui.Popups)** - Modal and popup utilities (part of this suite)
+- **[ktsu.ImGui.Widgets](https://nuget.org/packages/ktsu.ImGui.Widgets)** - Custom widgets (part of this suite)
 
 ---
 

--- a/ImGui.Widgets/README.md
+++ b/ImGui.Widgets/README.md
@@ -1,4 +1,4 @@
-# ktsu.ImGuiWidgets
+# ktsu.ImGui.Widgets
 
 ImGuiWidgets is a library of custom widgets using ImGui.NET. This library provides a variety of widgets and utilities to enhance your ImGui-based applications.
 
@@ -24,15 +24,15 @@ ImGuiWidgets is a library of custom widgets using ImGui.NET. This library provid
 To install ImGuiWidgets, you can add the library to your .NET project using the following command:
 
 ```bash
-dotnet add package ktsu.ImGuiWidgets
+dotnet add package ktsu.ImGui.Widgets
 ```
 
 ## Usage
 
-To use ImGuiWidgets, you need to include the `ktsu.ImGuiWidgets` namespace in your code:
+To use ImGuiWidgets, you need to include the `ktsu.ImGui.Widgets` namespace in your code:
 
 ```csharp
-using ktsu.ImGuiWidgets;
+using ktsu.ImGui.Widgets;
 ```
 
 Then, you can start using the widgets provided by ImGuiWidgets in your ImGui-based applications.
@@ -347,21 +347,22 @@ Icons can be used to display images with various alignment options and event del
 float iconWidthEms = 7.5f;
 float iconWidthPx = ImGuiApp.EmsToPx(iconWidthEms);
 
-uint textureId = ImGuiApp.GetOrLoadTexture("icon.png");
+// GetOrLoadTexture returns an ImGuiAppTextureInfo; use its TextureId
+ImGuiAppTextureInfo texture = ImGuiApp.GetOrLoadTexture("icon.png");
 
-ImGuiWidgets.Icon("Click Me", textureId, iconWidthPx, Color.White.Value, ImGuiWidgets.IconAlignment.Vertical, new ImGuiWidgets.IconDelegates()
+ImGuiWidgets.Icon("Click Me", texture.TextureId, iconWidthPx, ImGuiWidgets.IconAlignment.Vertical, new ImGuiWidgets.IconOptions()
 {
-    OnClick = () => MessageOK.Open("Click", "You clicked")
+    OnClick = () => Console.WriteLine("You clicked")
 });
 
 ImGui.SameLine();
-ImGuiWidgets.Icon("Double Click Me", textureId, iconWidthPx, Color.White.Value, ImGuiWidgets.IconAlignment.Vertical, new ImGuiWidgets.IconDelegates()
+ImGuiWidgets.Icon("Double Click Me", texture.TextureId, iconWidthPx, ImGuiWidgets.IconAlignment.Vertical, new ImGuiWidgets.IconOptions()
 {
-    OnDoubleClick = () => MessageOK.Open("Double Click", "You clicked twice")
+    OnDoubleClick = () => Console.WriteLine("You clicked twice")
 });
 
 ImGui.SameLine();
-ImGuiWidgets.Icon("Right Click Me", textureId, iconWidthPx, Color.White.Value, ImGuiWidgets.IconAlignment.Vertical, new ImGuiWidgets.IconDelegates()
+ImGuiWidgets.Icon("Right Click Me", texture.TextureId, iconWidthPx, ImGuiWidgets.IconAlignment.Vertical, new ImGuiWidgets.IconOptions()
 {
     OnContextMenu = () =>
     {
@@ -380,12 +381,17 @@ The grid layout allows you to display items in a flexible grid:
 float iconSizeEms = 7.5f;
 float iconSizePx = ImGuiApp.EmsToPx(iconSizeEms);
 
-uint textureId = ImGuiApp.GetOrLoadTexture("icon.png");
+ImGuiAppTextureInfo texture = ImGuiApp.GetOrLoadTexture("icon.png");
 
-ImGuiWidgets.Grid(items, i => ImGuiWidgets.CalcIconSize(i, iconSizePx), (item, cellSize, itemSize) =>
-{
-    ImGuiWidgets.Icon(item, textureId, iconSizePx, Color.White.Value);
-});
+// RowMajorGrid (or ColumnMajorGrid) takes an id, the items, a measure delegate, and a draw delegate
+ImGuiWidgets.RowMajorGrid(
+    "MyGrid",
+    items,
+    item => ImGuiWidgets.CalcIconSize(item, iconSizePx, ImGuiWidgets.IconAlignment.Vertical),
+    (item, cellSize, itemSize) =>
+    {
+        ImGuiWidgets.Icon(item, texture.TextureId, iconSizePx, ImGuiWidgets.IconAlignment.Vertical);
+    });
 ```
 
 ### Color Indicator
@@ -393,10 +399,11 @@ ImGuiWidgets.Grid(items, i => ImGuiWidgets.CalcIconSize(i, iconSizePx), (item, c
 The color indicator widget displays a color when enabled:
 
 ```csharp
+// color is a Hexa.NET.ImGui.ImColor (for example, from ktsu.ImGui.Styler's Color helpers)
+ImColor color = Color.FromHex("#ff0000");
 bool enabled = true;
-Color color = Color.Red;
 
-ImGuiWidgets.ColorIndicator("Color Indicator", enabled, color);
+ImGuiWidgets.ColorIndicator(color, enabled);
 ```
 
 ### Image
@@ -404,9 +411,9 @@ ImGuiWidgets.ColorIndicator("Color Indicator", enabled, color);
 The image widget allows you to display images with alignment options:
 
 ```csharp
-uint textureId = ImGuiApp.GetOrLoadTexture("image.png");
+ImGuiAppTextureInfo texture = ImGuiApp.GetOrLoadTexture("image.png");
 
-ImGuiWidgets.Image(textureId, new Vector2(100, 100));
+ImGuiWidgets.Image(texture.TextureId, new Vector2(100, 100));
 ```
 
 ### Text
@@ -508,7 +515,7 @@ if (ImGuiWidgets.Combo("Fruit", ref selectedFruit, fruits))
     Console.WriteLine($"Selected: {selectedFruit}");
 }
 
-// Strong string combo box (using ktsu.StrongStrings)
+// Strong string combo box (using ktsu.Semantics.Strings)
 using ktsu.Semantics.Strings;
 
 MyStrongString selected = new("Value1");
@@ -530,45 +537,45 @@ if (ImGuiWidgets.Combo("Option", ref selected, options))
 Create resizable layouts with draggable dividers between content regions:
 
 ```csharp
-// Create a horizontal divider container
+// Create a column-based divider container (side-by-side zones)
 var dividerContainer = new ImGuiWidgets.DividerContainer(
     "MyContainer",
-    ImGuiWidgets.DividerLayout.Horizontal
+    ImGuiWidgets.DividerLayout.Columns
 );
 
-// Add content regions
-dividerContainer.AddZone("Left Panel", () =>
+// Add zones with: id, initial size (relative weight), resizable, and a tick delegate (receives delta time)
+dividerContainer.Add("Left Panel", 0.33f, true, dt =>
 {
     ImGui.Text("Left side content");
     ImGui.Button("Left Button");
 });
 
-dividerContainer.AddZone("Right Panel", () =>
+dividerContainer.Add("Right Panel", 0.67f, true, dt =>
 {
     ImGui.Text("Right side content");
     ImGui.Button("Right Button");
 });
 
-// Draw the container in your render loop
-dividerContainer.Draw();
+// Tick the container each frame in your render loop
+dividerContainer.Tick(deltaTime);
 
-// For vertical layout:
-var verticalContainer = new ImGuiWidgets.DividerContainer(
-    "VerticalContainer",
-    ImGuiWidgets.DividerLayout.Vertical
+// For a stacked (top/bottom) layout, use DividerLayout.Rows:
+var stackedContainer = new ImGuiWidgets.DividerContainer(
+    "StackedContainer",
+    ImGuiWidgets.DividerLayout.Rows
 );
 
-verticalContainer.AddZone("Top Panel", () =>
+stackedContainer.Add("Top Panel", 0.5f, true, dt =>
 {
     ImGui.Text("Top content");
 });
 
-verticalContainer.AddZone("Bottom Panel", () =>
+stackedContainer.Add("Bottom Panel", 0.5f, true, dt =>
 {
     ImGui.Text("Bottom content");
 });
 
-verticalContainer.Draw();
+stackedContainer.Tick(deltaTime);
 ```
 
 The dividers can be dragged by the user to resize the content regions dynamically.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 > A comprehensive collection of .NET libraries for building modern, feature-rich desktop applications with Dear ImGui.
 
 [![License](https://img.shields.io/github/license/ktsu-dev/ImGuiApp.svg?label=License&logo=nuget)](LICENSE.md)
-[![NuGet Version](https://img.shields.io/nuget/v/ktsu.ImGuiApp?label=Stable&logo=nuget)](https://nuget.org/packages/ktsu.ImGuiApp)
-[![NuGet Version](https://img.shields.io/nuget/vpre/ktsu.ImGuiApp?label=Latest&logo=nuget)](https://nuget.org/packages/ktsu.ImGuiApp)
-[![NuGet Downloads](https://img.shields.io/nuget/dt/ktsu.ImGuiApp?label=Downloads&logo=nuget)](https://nuget.org/packages/ktsu.ImGuiApp)
+[![NuGet Version](https://img.shields.io/nuget/v/ktsu.ImGui.App?label=Stable&logo=nuget)](https://nuget.org/packages/ktsu.ImGui.App)
+[![NuGet Version](https://img.shields.io/nuget/vpre/ktsu.ImGui.App?label=Latest&logo=nuget)](https://nuget.org/packages/ktsu.ImGui.App)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/ktsu.ImGui.App?label=Downloads&logo=nuget)](https://nuget.org/packages/ktsu.ImGui.App)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ktsu-dev/ImGuiApp?label=Commits&logo=github)](https://github.com/ktsu-dev/ImGuiApp/commits/main)
 [![GitHub contributors](https://img.shields.io/github/contributors/ktsu-dev/ImGuiApp?label=Contributors&logo=github)](https://github.com/ktsu-dev/ImGuiApp/graphs/contributors)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/ktsu-dev/ImGuiApp/dotnet.yml?label=Build&logo=github)](https://github.com/ktsu-dev/ImGuiApp/actions)
@@ -16,11 +16,11 @@
 
 ## Features
 
-- **Application Foundation**: Complete application scaffolding with windowing, OpenGL rendering, font management, texture caching, and DPI awareness via `ktsu.ImGuiApp`
+- **Application Foundation**: Complete application scaffolding with windowing, OpenGL rendering, font management, texture caching, and DPI awareness via `ktsu.ImGui.App`
 - **PID Frame Limiting**: High-precision PID-controlled frame rate limiting with auto-tuning and adaptive throttling for focused, unfocused, idle, and minimized states
-- **Custom Widgets**: Rich collection of UI components including TabPanel, Knob, SearchBox with fuzzy matching, RadialProgressBar with countdown/count-up timers, Grid layouts, DividerContainer with resizable sections, Combo, Tree, and Icons via `ktsu.ImGuiWidgets`
-- **Modal Dialogs**: Professional popup system with MessageOK, Prompt, InputString/Int/Float, FilesystemBrowser, and SearchableList via `ktsu.ImGuiPopups`
-- **Theming System**: 50+ built-in themes (Catppuccin, Tokyo Night, Gruvbox, Dracula, and more) with scoped styling, semantic text colors, button alignment, color palettes, and an interactive theme browser via `ktsu.ImGuiStyler`
+- **Custom Widgets**: Rich collection of UI components including TabPanel, Knob, SearchBox with fuzzy matching, RadialProgressBar with countdown/count-up timers, Grid layouts, DividerContainer with resizable sections, Combo, Tree, and Icons via `ktsu.ImGui.Widgets`
+- **Modal Dialogs**: Professional popup system with MessageOK, Prompt, InputString/Int/Float, FilesystemBrowser, and SearchableList via `ktsu.ImGui.Popups`
+- **Theming System**: 50+ built-in themes (Catppuccin, Tokyo Night, Gruvbox, Dracula, and more) with scoped styling, semantic text colors, button alignment, color palettes, and an interactive theme browser via `ktsu.ImGui.Styler`
 - **Node Graph Framework**: Attribute-based node declaration system with UI-agnostic `ktsu.NodeGraph` metadata library and ImNodes-based visual editor `ktsu.ImGuiNodeEditor` with physics-based layout
 - **Font Management**: Unicode, emoji, and Nerd Font support with GPU memory management via `FontMemoryGuard` and dynamic font scaling
 - **Scoped Styling**: RAII-pattern disposable wrappers for colors, styles, fonts, themes, disable states, and UI scaling
@@ -30,25 +30,25 @@
 
 ### ImGui.App - Application Foundation
 
-[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGuiApp?label=ktsu.ImGuiApp&logo=nuget)](https://nuget.org/packages/ktsu.ImGuiApp)
+[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGui.App?label=ktsu.ImGui.App&logo=nuget)](https://nuget.org/packages/ktsu.ImGui.App)
 
 Complete application scaffolding for Dear ImGui applications with windowing, rendering, font/texture management, and performance tuning.
 
 ### ImGui.Widgets - Custom UI Components
 
-[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGuiWidgets?label=ktsu.ImGuiWidgets&logo=nuget)](https://nuget.org/packages/ktsu.ImGuiWidgets)
+[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGui.Widgets?label=ktsu.ImGui.Widgets&logo=nuget)](https://nuget.org/packages/ktsu.ImGui.Widgets)
 
 Rich collection of custom widgets: TabPanel, Knob, SearchBox, RadialProgressBar, Grid, DividerContainer, Combo, Tree, Icons, ColorIndicator, Text, Image, ScopedDisable, and ScopedId.
 
 ### ImGui.Popups - Modal Dialogs
 
-[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGuiPopups?label=ktsu.ImGuiPopups&logo=nuget)](https://nuget.org/packages/ktsu.ImGuiPopups)
+[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGui.Popups?label=ktsu.ImGui.Popups&logo=nuget)](https://nuget.org/packages/ktsu.ImGui.Popups)
 
 Professional modal dialogs: MessageOK, Prompt, InputString/Int/Float with validation, FilesystemBrowser with glob filtering, and SearchableList with type-safe generics.
 
 ### ImGui.Styler - Themes and Styling
 
-[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGuiStyler?label=ktsu.ImGuiStyler&logo=nuget)](https://nuget.org/packages/ktsu.ImGuiStyler)
+[![NuGet](https://img.shields.io/nuget/v/ktsu.ImGui.Styler?label=ktsu.ImGui.Styler&logo=nuget)](https://nuget.org/packages/ktsu.ImGui.Styler)
 
 Advanced theming system with 50+ built-in themes, scoped styling, semantic text colors, button alignment, color palettes, and an interactive theme browser.
 
@@ -67,30 +67,30 @@ Attribute-driven visual node editor built on ImNodes. Includes `NodeEditorEngine
 ### Package Manager Console
 
 ```powershell
-Install-Package ktsu.ImGuiApp
-Install-Package ktsu.ImGuiWidgets
-Install-Package ktsu.ImGuiPopups
-Install-Package ktsu.ImGuiStyler
+Install-Package ktsu.ImGui.App
+Install-Package ktsu.ImGui.Widgets
+Install-Package ktsu.ImGui.Popups
+Install-Package ktsu.ImGui.Styler
 Install-Package ktsu.NodeGraph
 ```
 
 ### .NET CLI
 
 ```bash
-dotnet add package ktsu.ImGuiApp
-dotnet add package ktsu.ImGuiWidgets
-dotnet add package ktsu.ImGuiPopups
-dotnet add package ktsu.ImGuiStyler
+dotnet add package ktsu.ImGui.App
+dotnet add package ktsu.ImGui.Widgets
+dotnet add package ktsu.ImGui.Popups
+dotnet add package ktsu.ImGui.Styler
 dotnet add package ktsu.NodeGraph
 ```
 
 ### Package Reference
 
 ```xml
-<PackageReference Include="ktsu.ImGuiApp" Version="x.y.z" />
-<PackageReference Include="ktsu.ImGuiWidgets" Version="x.y.z" />
-<PackageReference Include="ktsu.ImGuiPopups" Version="x.y.z" />
-<PackageReference Include="ktsu.ImGuiStyler" Version="x.y.z" />
+<PackageReference Include="ktsu.ImGui.App" Version="x.y.z" />
+<PackageReference Include="ktsu.ImGui.Widgets" Version="x.y.z" />
+<PackageReference Include="ktsu.ImGui.Popups" Version="x.y.z" />
+<PackageReference Include="ktsu.ImGui.Styler" Version="x.y.z" />
 <PackageReference Include="ktsu.NodeGraph" Version="x.y.z" />
 ```
 
@@ -157,7 +157,7 @@ using ktsu.ImGui.Widgets;
 using Hexa.NET.ImGui;
 
 // Tabbed interface
-TabPanel tabPanel = new("MyTabs", closable: true, reorderable: true);
+ImGuiWidgets.TabPanel tabPanel = new("MyTabs", closable: true, reorderable: true);
 tabPanel.AddTab("tab1", "First Tab", () => ImGui.Text("Content 1"));
 tabPanel.Draw();
 
@@ -172,7 +172,7 @@ float timeRemaining = 300.0f;
 ImGuiWidgets.RadialCountdown(timeRemaining, 300.0f);
 
 // Resizable divider layout
-DividerContainer divider = new("MySplit", DividerLayout.Columns);
+ImGuiWidgets.DividerContainer divider = new("MySplit", ImGuiWidgets.DividerLayout.Columns);
 divider.Add("left", 200f, true, dt => ImGui.Text("Left pane"));
 divider.Add("right", 400f, true, dt => ImGui.Text("Right pane"));
 divider.Tick(deltaTime);
@@ -211,7 +211,7 @@ using ktsu.ImGui.Styler;
 using Hexa.NET.ImGui;
 
 // Apply a built-in theme
-Theme.Apply("Catppuccin.Mocha");
+Theme.Apply("Catppuccin Mocha");
 
 // Show interactive theme browser
 Theme.ShowThemeSelector("Select Theme");
@@ -316,8 +316,8 @@ Application lifecycle and utilities.
 | `SetWindowIcon(string)` | `void` | Set window icon from image file |
 | `GetOrLoadTexture(AbsoluteFilePath)` | `ImGuiAppTextureInfo` | Load or retrieve cached GPU texture |
 | `DeleteTexture(uint)` | `void` | Remove texture from GPU |
-| `EmsToPx(float)` | `float` | Convert EMs to pixels |
-| `PtsToPx(int)` | `float` | Convert points to pixels |
+| `EmsToPx(float)` | `int` | Convert EMs to pixels |
+| `PtsToPx(int)` | `int` | Convert points to pixels |
 
 #### Properties
 


### PR DESCRIPTION
## Summary

The documentation referenced the legacy, dot-less NuGet package IDs (`ktsu.ImGuiApp`, `ktsu.ImGuiWidgets`, `ktsu.ImGuiStyler`, `ktsu.ImGuiPopups`), which are abandoned at v1.x/2.1.x. The packages the repo actually builds and publishes today (v2.5.0) use dotted IDs: **`ktsu.ImGui.App`**, **`ktsu.ImGui.Widgets`**, **`ktsu.ImGui.Styler`**, **`ktsu.ImGui.Popups`** (confirmed via the ktsu.Sdk-derived `PackageId` and the namespaces in source). This PR updates every install snippet, badge, and namespace in the docs to the correct names, and audits the rest of the documentation for accuracy while doing so.

The per-library READMEs turned out to be stale copies from the original standalone repos, so the audit caught a number of code examples referencing APIs that no longer exist (or never did).

## Package name / namespace fixes
- All `dotnet add` / `Install-Package` / `<PackageReference>` snippets and NuGet badges across `README.md`, `CLAUDE.md`, and the four per-library READMEs.
- `using` directives in code examples updated to the shipped namespaces (`ktsu.ImGui.App`, etc.).
- The repo/suite brand name in the root README H1/intro (matching `ktsu-dev/ImGuiApp`) was intentionally left as-is.

## Audit fixes (verified against source)
**Styler**
- `Theme.Reset()` → `Theme.ResetToDefault()`
- Removed non-existent `Theme.IsCurrentThemeDark`
- `Color.FromHSV` → `Color.FromHSL`
- `Color.Lighten/Darken/GetOptimalTextColor` were never static `Color` methods — documented as the actual `ImColor` extension methods (`LightenBy`, `DarkenBy`, `CalculateOptimalContrastingColor`, `GetContrastRatioOver`)
- `new ScopedTheme("string")` → `new ScopedTheme(ISemanticTheme)`
- Standardized theme names to the space-separated form the registry/demo use

**Widgets**
- Icon example: `IconDelegates` → `IconOptions`, dropped the non-existent `Color` parameter, use `ImGuiAppTextureInfo.TextureId`
- Grid example: `RowMajorGrid` with an `id` and the correct `CalcIconSize` overload
- `ColorIndicator` argument order/types corrected
- DividerContainer: `Columns`/`Rows`, `Add()`, `Tick()` (was `Horizontal`/`Vertical`, `AddZone()`, `Draw()`)

**Popups**
- `FilesystemBrowser.Open(mode, target, …)` → `FileOpen` / `FileSave` / `ChooseDirectory`
- Corrected dependency list (`ktsu.Semantics.Paths`/`Strings`, not `ktsu.StrongPaths`)

**App / Root**
- Supported frameworks corrected to .NET 8/9/10
- `EmsToPx`/`PtsToPx` documented as returning `int`
- Qualified nested widget types (`ImGuiWidgets.TabPanel`, etc.)
- Standalone clone/demo commands pointed at this repo

## Testing
Docs-only change; all referenced APIs were verified against the current source.

https://claude.ai/code/session_013SjKypvXUFBVfTVrfCxt9D

---
_Generated by [Claude Code](https://claude.ai/code/session_013SjKypvXUFBVfTVrfCxt9D)_