### PR TITLE
Fix ForceDirectedLayout.Tests CI crash: exclude native C ABI shim from code coverage

### DIFF
--- a/ForceDirectedLayout/NativeExports.cs
+++ b/ForceDirectedLayout/NativeExports.cs
@@ -5,6 +5,7 @@
 namespace ktsu.ForceDirectedLayout;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -43,6 +44,14 @@ public static class LayoutResult
 ///
 /// All buffer parameters are caller-owned. The library writes into the buffer but never retains a pointer past the call return.
 /// </remarks>
+// Excluded from code coverage: these [UnmanagedCallersOnly] entry points are reachable only
+// through native function pointers, never from managed code, so managed tests cannot exercise
+// them. Excluding the type also keeps the coverage instrumenter away from UnmanagedCallersOnly
+// method bodies - instrumenting them crashes the dynamic code-coverage collector on .NET 10 CI
+// runners (the interprocess collector dies with "Pipe was disconnected" during report generation),
+// which is what failed the ForceDirectedLayout.Tests run.
+[ExcludeFromCodeCoverage(Justification = "C ABI boundary shim invoked only via native function pointers; uncoverable by managed tests and crashes the .NET 10 dynamic coverage collector when instrumented.")]
+[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here.", Justification = "The C ABI surface marshals raw caller-owned pointers across the native boundary; every pointer argument is null- and range-checked before use and never retained past the call.")]
 public static unsafe class NativeExports
 {
 	[ThreadStatic]

--- a/ForceDirectedLayout/Vec2D.cs
+++ b/ForceDirectedLayout/Vec2D.cs
@@ -5,6 +5,7 @@
 namespace ktsu.ForceDirectedLayout;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -73,12 +74,14 @@ public struct Vec2D : IEquatable<Vec2D>
 	public static Vec2D operator -(Vec2D v) => new(-v.X, -v.Y);
 
 	/// <inheritdoc/>
+	[SuppressMessage("Major Code Smell", "S1244:Floating point numbers should not be tested for equality", Justification = "Value-equality for a blittable vector requires exact component comparison; a tolerance would break the Equals/GetHashCode contract. Use a range check at call sites that need approximate equality.")]
 	public static bool operator ==(Vec2D a, Vec2D b) => a.X == b.X && a.Y == b.Y;
 
 	/// <inheritdoc/>
 	public static bool operator !=(Vec2D a, Vec2D b) => !(a == b);
 
 	/// <inheritdoc/>
+	[SuppressMessage("Major Code Smell", "S1244:Floating point numbers should not be tested for equality", Justification = "Value-equality for a blittable vector requires exact component comparison; a tolerance would break the Equals/GetHashCode contract. Use a range check at call sites that need approximate equality.")]
 	public readonly bool Equals(Vec2D other) => X == other.X && Y == other.Y;
 
 	/// <inheritdoc/>


### PR DESCRIPTION
## Problem

CI run [26700545963](https://github.com/ktsu-dev/ImGuiApp/actions/runs/26700545963) failed. All 498 tests **pass**, but the test host for `ForceDirectedLayout.Tests` crashes during code-coverage teardown:

```
Unhandled exception. System.Exception: Pipe was disconnected.
   at Microsoft.CodeCoverage.Interprocess.LoggerClient.ReadMessageFromPipe()
   ...TestingPlatformCoverageDynamicTestSessionLifetimeHandler.OnTestSessionFinishingAsync
```
→ process exit `0xE0434352`, test-platform exit 7, job exit 1.

It is the **only** test assembly referencing code with `[UnmanagedCallersOnly]` native entry points (`NativeExports`). On the .NET 10 runner the coverage engine takes that assembly down the dynamic native-instrumentation path, which crashes — consistent with the [.NET 10 dynamic-native-instrumentation breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/code-coverage-dynamic-native-instrumentation) and [microsoft/codecoverage#202](https://github.com/microsoft/codecoverage/issues/202).

## Fix

Mark `NativeExports` with `[ExcludeFromCodeCoverage]`. Those boundary methods are reachable only via native function pointers and cannot be exercised by managed tests anyway, so excluding them keeps the coverage instrumenter away from them while preserving coverage for the rest of the engine.

Rejected alternative: setting `EnableMicrosoftTestingExtensionsCodeCoverage=false` on the project breaks the run a different way — CI passes `--coverage` to every test app, so a project without the extension fails with an unknown-option error (verified: exit 5, only 478/498 tests run).

Also suppresses two new SonarAnalyzer warnings with justifications:
- **S1244** on `Vec2D` `==`/`Equals` — exact equality is intentional for a blittable value type; a tolerance would break the `Equals`/`GetHashCode` contract.
- **S6640** on the `unsafe NativeExports` class — `unsafe` is required for C ABI pointer marshalling.

## Verification

- Clean Release build, 0 errors.
- Exact KtsuBuild test command (`dotnet test --coverage --coverage-output coverage.xml --report-trx …`) → **498 pass, exit 0**, coverage + TRX still produced.
- ⚠️ The crash is **CI-environment-specific** — not reproducible locally across 6+ faithful invocations (local always uses the in-process collector). **This CI run is the real verification.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)