### PR TITLE
[patch] Fix "Renderer backend is not initialized" when loading textures from OnStart

### DIFF
--- a/ImGui.App/ImGuiApp.cs
+++ b/ImGui.App/ImGuiApp.cs
@@ -33,6 +33,12 @@ public static partial class ImGuiApp
 	internal static IWindow? window;
 	internal static GL? gl;
 	internal static ImGuiController.ImGuiController? controller;
+
+	// The GPU texture/draw backend. Registered by the backend itself as soon as its GL
+	// context is ready (early in the ImGuiController constructor), so texture operations
+	// invoked from OnStart — which runs mid-construction, before `controller` is assigned —
+	// have a usable backend. See ImGuiController..ctor.
+	internal static IRendererBackend? renderer;
 	internal static IInputContext? inputContext;
 	internal static OpenGLProvider? glProvider;
 	internal static IntPtr currentGLContextHandle; // Track the current GL context handle
@@ -669,6 +675,7 @@ public static partial class ImGuiApp
 	{
 		controller?.Dispose();
 		controller = null;
+		renderer = null;
 	}
 
 	internal static void CleanupInputContext()
@@ -1301,14 +1308,14 @@ public static partial class ImGuiApp
 	{
 		return Invoker.Invoke(() =>
 		{
-			if (controller is null)
+			if (renderer is null)
 			{
 				throw new InvalidOperationException("Renderer backend is not initialized.");
 			}
 
 			// The pooled buffer may be larger than the texture; only the first w*h*4 bytes are pixel data.
 			int pixelByteCount = width * height * 4;
-			return (uint)controller.CreateTexture(bytes.AsSpan(0, pixelByteCount), width, height);
+			return (uint)renderer.CreateTexture(bytes.AsSpan(0, pixelByteCount), width, height);
 		});
 	}
 
@@ -1321,12 +1328,12 @@ public static partial class ImGuiApp
 	{
 		Invoker.Invoke(() =>
 		{
-			if (controller is null)
+			if (renderer is null)
 			{
 				throw new InvalidOperationException("Renderer backend is not initialized.");
 			}
 
-			controller.DeleteTexture((nint)textureId);
+			renderer.DeleteTexture((nint)textureId);
 			Textures.Where(x => x.Value.TextureId == textureId).ToList().ForEach(x => Textures.Remove(x.Key, out ImGuiAppTextureInfo? _));
 		});
 	}
@@ -1765,6 +1772,7 @@ public static partial class ImGuiApp
 		window = null;
 		gl = null;
 		controller = null;
+		renderer = null;
 		inputContext = null;
 		glProvider = null;
 		userHidden = false;

--- a/ImGui.App/ImGuiController/ImGuiController.cs
+++ b/ImGui.App/ImGuiController/ImGuiController.cs
@@ -74,6 +74,12 @@ internal sealed class ImGuiController : IDisposable, IRendererBackend
 		Init(gl, view, input);
 		DebugLogger.Log("ImGuiController: Init completed");
 
+		// Register as the renderer backend now that the GL context is live. This must happen
+		// before onConfigureIO runs: user OnStart code (invoked from there) may load textures,
+		// and that path resolves the backend via ImGuiApp.renderer. The ImGuiApp.controller
+		// field is not assigned until this constructor returns, so it cannot be relied on here.
+		ImGuiApp.renderer = this;
+
 		ImGuiIOPtr io = ImGui.GetIO();
 		if (imGuiFontConfig is not null)
 		{

--- a/examples/ImGuiAppDemo/DemoImages.cs
+++ b/examples/ImGuiAppDemo/DemoImages.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Examples.App;
+
+using ktsu.ImGui.App;
+using ktsu.Semantics.Paths;
+using ktsu.Semantics.Strings;
+
+/// <summary>
+/// Shared demo image assets, split by the texture-loading path that uploads them so the demo
+/// exercises both. <see cref="EagerlyLoaded"/> is uploaded from OnStart — while the renderer
+/// backend is still being constructed (OnStart runs inside the ImGuiController constructor,
+/// before ImGuiApp's controller field is assigned). <see cref="LazilyLoaded"/> is uploaded on
+/// first render in the main loop. Keeping the two sets disjoint matters: textures are cached by
+/// path, so a single image would only ever upload through whichever path touched it first.
+/// </summary>
+internal static class DemoImages
+{
+	/// <summary>
+	/// Images loaded eagerly from OnStart. This exercises — and guards against regression of —
+	/// the mid-construction texture-upload path that previously threw
+	/// "Renderer backend is not initialized." If that breaks again, the demo crashes on launch.
+	/// </summary>
+	internal static readonly string[] EagerlyLoaded =
+	[
+		"trevor-curious.png",
+		"trevor-thinking.png",
+		"trevor-working.png",
+	];
+
+	/// <summary>
+	/// Images loaded lazily on first render in the main loop (the normal in-frame upload path).
+	/// </summary>
+	internal static readonly string[] LazilyLoaded =
+	[
+		"trevor-exploring.png",
+		"trevor-success.png",
+		"trevor-failure.png",
+	];
+
+	/// <summary>
+	/// Resolves a demo image file name to its absolute path in the output directory.
+	/// </summary>
+	/// <param name="fileName">The image file name (e.g. "trevor-curious.png").</param>
+	/// <returns>The absolute path to the image alongside the executable.</returns>
+	internal static AbsoluteFilePath Path(string fileName) =>
+		AppContext.BaseDirectory.As<AbsoluteDirectoryPath>() / fileName.As<FileName>();
+
+	/// <summary>
+	/// Eagerly uploads every image in <see cref="EagerlyLoaded"/>. Called from OnStart.
+	/// </summary>
+	internal static void LoadEager()
+	{
+		foreach (string fileName in EagerlyLoaded)
+		{
+			_ = ImGuiApp.GetOrLoadTexture(Path(fileName));
+		}
+	}
+}

--- a/examples/ImGuiAppDemo/Demos/GraphicsDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/GraphicsDemo.cs
@@ -41,6 +41,17 @@ internal sealed class GraphicsDemo : IDemoTab
 				ImGui.SameLine();
 				ImGui.Image(iconTexture.TextureRef, new Vector2(16, 16));
 
+				// Two texture-loading paths, side by side. The eager set was uploaded from OnStart
+				// (mid-construction); these GetOrLoadTexture calls are cache hits. The lazy set is
+				// uploaded here on first render — the normal in-loop path.
+				ImGui.SeparatorText("Texture Loading Paths:");
+
+				ImGui.Text("Eagerly loaded in OnStart (mid-construction):");
+				RenderImageRow(DemoImages.EagerlyLoaded);
+
+				ImGui.Text("Lazily loaded on first render:");
+				RenderImageRow(DemoImages.LazilyLoaded);
+
 				// Custom drawing with ImDrawList
 				ImGui.SeparatorText("Custom Drawing Canvas:");
 				ImGui.ColorEdit4("Draw Color", ref drawColor);
@@ -96,6 +107,20 @@ internal sealed class GraphicsDemo : IDemoTab
 			ImGui.EndChild();
 
 			ImGui.EndTabItem();
+		}
+	}
+
+	// Renders a horizontal row of demo images, loading (or returning cached) textures by path.
+	private static void RenderImageRow(string[] fileNames)
+	{
+		for (int i = 0; i < fileNames.Length; i++)
+		{
+			ImGuiAppTextureInfo texture = ImGuiApp.GetOrLoadTexture(DemoImages.Path(fileNames[i]));
+			ImGui.Image(texture.TextureRef, new Vector2(64, 64));
+			if (i < fileNames.Length - 1)
+			{
+				ImGui.SameLine();
+			}
 		}
 	}
 }

--- a/examples/ImGuiAppDemo/ImGuiAppDemo.cs
+++ b/examples/ImGuiAppDemo/ImGuiAppDemo.cs
@@ -45,6 +45,7 @@ internal static class ImGuiAppDemo
 	{
 		Title = "ImGuiApp Demo",
 		IconPath = AppContext.BaseDirectory.As<AbsoluteDirectoryPath>() / "icon.png".As<FileName>(),
+		OnStart = OnStart,
 		OnRender = OnRender,
 		OnAppMenu = OnAppMenu,
 		SaveIniSettings = false,
@@ -68,6 +69,18 @@ internal static class ImGuiAppDemo
 			IdleTimeoutSeconds = 5.0, // Consider idle after 5 seconds (default is 30)
 		},
 	});
+
+	// Loading textures from OnStart exercises the texture-upload path while the renderer backend
+	// is still being constructed (OnStart runs inside the ImGuiController ctor, before the
+	// controller field is assigned). This guards against the "Renderer backend is not
+	// initialized" regression: if it returns, the demo crashes here on launch. GraphicsDemo
+	// loads a disjoint set lazily in the render loop to cover the other path.
+	private static void OnStart()
+	{
+		AbsoluteFilePath iconPath = AppContext.BaseDirectory.As<AbsoluteDirectoryPath>() / "icon.png".As<FileName>();
+		_ = ImGuiApp.GetOrLoadTexture(iconPath);
+		DemoImages.LoadEager();
+	}
 
 	private static void OnRender(float dt)
 	{

--- a/examples/ImGuiAppDemo/ImGuiAppDemo.csproj
+++ b/examples/ImGuiAppDemo/ImGuiAppDemo.csproj
@@ -12,6 +12,9 @@
     <Content Include="icon.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="trevor-*.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/ImGuiAppDemo/trevor-curious.png
+++ b/examples/ImGuiAppDemo/trevor-curious.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0050955623cbc28f9014a5b37f9bcb4cf7777388bdfed5bd1adf323487cd96af
+size 1104200

--- a/examples/ImGuiAppDemo/trevor-exploring.png
+++ b/examples/ImGuiAppDemo/trevor-exploring.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:025299f311fd4e164e5cfe938fad8d7d7cdad53a20f25fcf1f610e86613c6abb
+size 1825223

--- a/examples/ImGuiAppDemo/trevor-failure.png
+++ b/examples/ImGuiAppDemo/trevor-failure.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28ffc0ae9eec7a66a1671816a44620a65343804d100dcb524fe9008b1045d4f1
+size 1684023

--- a/examples/ImGuiAppDemo/trevor-success.png
+++ b/examples/ImGuiAppDemo/trevor-success.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be53a319d1ba25b5ba29417cf26c8e68b41c14a17fab1bcdfc9734d978bfbbdf
+size 1787834

--- a/examples/ImGuiAppDemo/trevor-thinking.png
+++ b/examples/ImGuiAppDemo/trevor-thinking.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30ce7cfc5d680c1bc42853afe0a2e42ac7e8baf0ea8c5c6c44f5db8c4dd6683f
+size 1646648

--- a/examples/ImGuiAppDemo/trevor-working.png
+++ b/examples/ImGuiAppDemo/trevor-working.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9041fa04137dded8917061bd21fd59f08eb05a90f78cb162995344c8ec997e01
+size 1185446

--- a/tests/ImGui.App.Tests/ImGuiAppTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppTests.cs
@@ -455,6 +455,57 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		Assert.AreNotEqual(firstTextureInfo.TextureId, reloadedTexture.TextureId, "Reloaded texture should have a different ID");
 	}
 
+	// Minimal IRendererBackend stand-in: records calls without touching a real GL context.
+	private sealed class FakeRendererBackend : IRendererBackend
+	{
+		public int CreateTextureCallCount { get; private set; }
+		public int DeleteTextureCallCount { get; private set; }
+		public nint NextHandle { get; init; }
+
+		public nint CreateTexture(ReadOnlySpan<byte> rgba, int width, int height)
+		{
+			CreateTextureCallCount++;
+			return NextHandle;
+		}
+
+		public void DeleteTexture(nint id) => DeleteTextureCallCount++;
+		public void RenderDrawData(Hexa.NET.ImGui.ImDrawDataPtr drawData) { }
+		public void Dispose() { }
+	}
+
+	[TestMethod]
+	public void UploadTextureRGBA_WithBackendRegisteredButControllerUnset_UploadsViaBackend()
+	{
+		// Reproduces the OnStart-during-construction case (regression from d2b7e72):
+		// the renderer backend is registered early in the ImGuiController constructor,
+		// but ImGuiApp.controller has not been assigned yet because we are still inside
+		// `controller = new(...)`. Texture upload must succeed via the backend regardless.
+		ResetState();
+		ImGuiApp.Invoker = new Invoker.Invoker();
+		FakeRendererBackend backend = new() { NextHandle = 7 };
+		ImGuiApp.renderer = backend;
+		ImGuiApp.controller = null;
+
+		uint id = ImGuiApp.UploadTextureRGBA(new byte[2 * 2 * 4], 2, 2);
+
+		Assert.AreEqual(1, backend.CreateTextureCallCount, "Upload should route through the registered backend");
+		Assert.AreEqual(7u, id, "Returned texture id should come from the backend");
+	}
+
+	[TestMethod]
+	public void DeleteTexture_WithBackendRegisteredButControllerUnset_DeletesViaBackend()
+	{
+		ResetState();
+		ImGuiApp.Invoker = new Invoker.Invoker();
+		FakeRendererBackend backend = new();
+		ImGuiApp.renderer = backend;
+		ImGuiApp.controller = null;
+
+		ImGuiApp.DeleteTexture(123u);
+
+		Assert.AreEqual(1, backend.DeleteTextureCallCount, "Delete should route through the registered backend");
+	}
+
 	[TestMethod]
 	public void PerformanceSettings_DefaultValues_AreCorrect()
 	{


### PR DESCRIPTION
## Summary

Loading a texture from `OnStart` (e.g. `ImGuiApp.GetOrLoadTexture(...)`) crashed on startup with:

```
System.InvalidOperationException: Renderer backend is not initialized.
   at ktsu.ImGui.App.ImGuiApp.UploadTextureRGBA(...)
   at ktsu.ImGui.App.ImGuiApp.GetOrLoadTexture(...)
   ...inside ImGuiController..ctor → onConfigureIO → OnStart
```

This was reported in AppFramework/Launcher and reproduces in ImGuiApp itself.

## Root cause

`OnStart` is invoked **inside** the `ImGuiController` constructor (via `onConfigureIO`), but the static `ImGuiApp.controller` field is only assigned once that constructor *returns*. Commit `d2b7e72` ("introduce IRendererBackend seam for the iOS port") changed the texture-upload guard:

```diff
- if (gl is null)         throw "OpenGL context is not initialized.";
+ if (controller is null) throw "Renderer backend is not initialized.";
```

`gl` is assigned **before** the controller is constructed, so the old guard passed during `OnStart`; `controller` is assigned **after**, so the new guard throws. The operation itself was always valid mid-construction — `ImGuiController.CreateTexture` only needs `_gl` (set first thing in `Init()`), not the later `CreateDeviceResources()`.

## Fix

- Add `internal static IRendererBackend? renderer` to `ImGuiApp`.
- `ImGuiController` registers itself (`ImGuiApp.renderer = this`) right after `Init()` — the moment its GL context is live, before `onConfigureIO`/`OnStart` runs.
- `UploadTextureRGBA` / `DeleteTexture` resolve the backend via `renderer` instead of the late-assigned `controller`.
- `renderer` is cleared alongside `controller` in `CleanupController()` and `Reset()`.

This restores the prior invariant (backend usable as soon as the GL context exists) while keeping the iOS `IRendererBackend` seam intact, and does not change `OnStart` timing.

## Tests & demo coverage

- Added regression tests reproducing the exact mid-construction state (`renderer` set, `controller` still null) for both upload and delete. They fail with the identical production error before the fix, pass after.
- Full `ImGui.App` suite: **277/277 pass**; Release build across `net10.0;net9.0;net8.0`: **0 warnings, 0 errors**.
- The demo now exercises **both** texture-loading paths so a recurrence is caught on launch:
  - **Eager** — `OnStart` uploads `icon.png` + 3 images mid-construction (the regression path).
  - **Lazy** — `GraphicsDemo` uploads a disjoint set of 3 images on first render.
  - The two image sets are disjoint because textures are cached by path, so a shared image would only ever upload through whichever path ran first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)