### PR TITLE
Honor ImGui draw-command callbacks; add per-region blend modes

### DIFF
--- a/ImGui.App/ImGui.App.csproj
+++ b/ImGui.App/ImGui.App.csproj
@@ -42,6 +42,9 @@
 
   <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
     <Compile Remove="ImGuiApp.cs" />
+    <!-- Per-region blend modes drive the desktop OpenGL renderer (ImGuiController.SetBlendMode);
+         the iOS stub has no such backend, so this partial is excluded like ImGuiApp.cs above. -->
+    <Compile Remove="ImGuiAppBlend.cs" />
     <Compile Remove="ImGuiAppConfig.cs" />
     <Compile Remove="ImGuiAppWindowState.cs" />
     <Compile Remove="FontMemoryGuard.cs" />

--- a/ImGui.App/ImGuiAppBlend.cs
+++ b/ImGui.App/ImGuiAppBlend.cs
@@ -1,0 +1,72 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.App;
+
+using System.Diagnostics.CodeAnalysis;
+using Hexa.NET.ImGui;
+
+/// <summary>
+/// Blend modes that can be applied to a region of an ImGui draw list via
+/// <see cref="ImGuiApp.SetDrawBlendMode"/>.
+/// </summary>
+public enum ImGuiAppBlendMode
+{
+	/// <summary>
+	/// Standard alpha-over compositing (<c>src*srcAlpha + dst*(1-srcAlpha)</c>). This is the
+	/// default state the renderer sets up for every frame.
+	/// </summary>
+	AlphaBlend,
+
+	/// <summary>
+	/// Additive blending (<c>src*srcAlpha + dst</c>). Overlapping translucent shapes accumulate
+	/// toward white instead of compositing alpha-over, producing a neon/glow look.
+	/// </summary>
+	Additive,
+}
+
+public static partial class ImGuiApp
+{
+	// AddCallback marshals these delegates to native function pointers that live in the ImGui
+	// draw list and are invoked by the renderer during RenderDrawData. They must stay rooted for
+	// the lifetime of the process so the marshalled thunks remain valid.
+	private static readonly ImDrawCallback blendAdditiveCallback = CreateAdditiveCallback();
+	private static readonly ImDrawCallback blendAlphaCallback = CreateAlphaCallback();
+
+	// The method-group-to-delegate conversion crosses an unmanaged (pointer) signature, so it must
+	// happen in an unsafe context; field initializers do not provide one.
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "Converts a method group to the unmanaged ImDrawCallback delegate; no pointers are dereferenced here.")]
+	private static unsafe ImDrawCallback CreateAdditiveCallback() => SetBlendModeAdditive;
+
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "Converts a method group to the unmanaged ImDrawCallback delegate; no pointers are dereferenced here.")]
+	private static unsafe ImDrawCallback CreateAlphaCallback() => SetBlendModeAlpha;
+
+	/// <summary>
+	/// Inserts a blend-mode change into <paramref name="drawList"/> at the current point in its
+	/// command stream. Primitives recorded after this call are drawn with <paramref name="mode"/>
+	/// until another <see cref="SetDrawBlendMode"/> call changes it again.
+	/// </summary>
+	/// <remarks>
+	/// This is the supported way to get additive/glow blending on the desktop (OpenGL) head: the
+	/// renderer keeps its <c>GL</c> instance private, so callers cannot flip <c>glBlendFunc</c>
+	/// directly. After drawing a glow region, call this again with
+	/// <see cref="ImGuiAppBlendMode.AlphaBlend"/> to restore normal compositing for the rest of the
+	/// frame — the blend func is global GL state for the remainder of the draw pass.
+	/// </remarks>
+	/// <param name="drawList">The draw list to record the blend-mode change into. Typically the
+	/// window, background, or foreground draw list.</param>
+	/// <param name="mode">The blend mode to activate for subsequent primitives.</param>
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "AddCallback requires a void* userdata argument; we pass null and retain no pointers.")]
+	public static unsafe void SetDrawBlendMode(ImDrawListPtr drawList, ImGuiAppBlendMode mode)
+	{
+		ImDrawCallback callback = mode == ImGuiAppBlendMode.Additive ? blendAdditiveCallback : blendAlphaCallback;
+		drawList.AddCallback(callback, null);
+	}
+
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "Matches the ImDrawCallback unmanaged signature; the pointers are supplied by the renderer and not retained.")]
+	private static unsafe void SetBlendModeAdditive(ImDrawList* parentList, ImDrawCmd* cmd) => controller?.SetBlendMode(ImGuiAppBlendMode.Additive);
+
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "Matches the ImDrawCallback unmanaged signature; the pointers are supplied by the renderer and not retained.")]
+	private static unsafe void SetBlendModeAlpha(ImDrawList* parentList, ImDrawCmd* cmd) => controller?.SetBlendMode(ImGuiAppBlendMode.AlphaBlend);
+}

--- a/ImGui.App/ImGuiController/ImGuiController.cs
+++ b/ImGui.App/ImGuiController/ImGuiController.cs
@@ -591,6 +591,37 @@ internal sealed class ImGuiController : IRendererBackend
 		_gl.VertexAttribPointer((uint)_attribLocationVtxColor, 4, GLEnum.UnsignedByte, true, (uint)sizeof(ImDrawVert), (void*)16);
 	}
 
+	/// <summary>
+	/// Switches the OpenGL blend function for the remainder of the current draw pass.
+	/// Invoked from a draw-command callback (see <see cref="ImGuiApp.SetDrawBlendMode"/>) so the
+	/// change applies only to the primitives recorded after it, until another blend-mode callback
+	/// or the <c>ImDrawCallback_ResetRenderState</c> sentinel restores the default state.
+	/// </summary>
+	/// <param name="mode">The blend mode to activate.</param>
+	internal void SetBlendMode(ImGuiAppBlendMode mode)
+	{
+		if (_gl is null)
+		{
+			return;
+		}
+
+		_gl.BlendEquation(GLEnum.FuncAdd);
+		switch (mode)
+		{
+			case ImGuiAppBlendMode.Additive:
+				// src*srcAlpha + dst*1: overlapping translucent shapes accumulate toward white
+				// instead of compositing alpha-over, giving a neon/glow look.
+				_gl.BlendFuncSeparate(GLEnum.SrcAlpha, GLEnum.One, GLEnum.One, GLEnum.One);
+				break;
+
+			case ImGuiAppBlendMode.AlphaBlend:
+			default:
+				// Matches the default established in SetupRenderState.
+				_gl.BlendFuncSeparate(GLEnum.SrcAlpha, GLEnum.OneMinusSrcAlpha, GLEnum.One, GLEnum.OneMinusSrcAlpha);
+				break;
+		}
+	}
+
 	/// <inheritdoc />
 	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "Required for native ImGui/OpenGL render loop; unsafe pointers are used only for GPU buffer uploads and draw calls, scoped to the call.")]
 	[SuppressMessage("Major Code Smell", "S927:Parameter names should match base declaration and other partial definitions", Justification = "Parameter name 'drawDataPtr' is used consistently in this implementation; renaming could break existing callers using named arguments.")]
@@ -673,7 +704,20 @@ internal sealed class ImGuiController : IRendererBackend
 				{
 					if (cmdPtr.UserCallback != null)
 					{
-						throw new NotImplementedException();
+						// Honor draw-command callbacks the way the stock imgui_impl_opengl3 backend
+						// does. The ImDrawCallback_ResetRenderState sentinel asks the backend to
+						// restore its own pipeline state (used after a callback changes GL state, e.g.
+						// a per-region blend-mode switch). Any other value is a real user callback —
+						// invoke it with this command's draw list and command rather than crashing.
+						if ((nint)cmdPtr.UserCallback == ImGui.ImDrawCallbackResetRenderState)
+						{
+							SetupRenderState(drawDataPtr, framebufferWidth, framebufferHeight);
+						}
+						else
+						{
+							ImDrawCmd localCmd = cmdPtr;
+							((delegate* unmanaged[Cdecl]<ImDrawList*, ImDrawCmd*, void>)cmdPtr.UserCallback)(cmdListPtr.Handle, &localCmd);
+						}
 					}
 					else
 					{

--- a/examples/ImGuiAppDemo/Demos/GraphicsDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/GraphicsDemo.cs
@@ -102,7 +102,26 @@ internal sealed class GraphicsDemo : IDemoTab
 				Vector2 rectPos = shapeStart + new Vector2(200 + (MathF.Sin(t) * 30), 30);
 				drawList.AddRectFilled(rectPos, rectPos + new Vector2(40, 40), ImGui.ColorConvertFloat4ToU32(new Vector4(0, 1, 0, 0.7f)));
 
-				ImGui.Dummy(new Vector2(400, 100)); // Reserve space
+				// Blend-mode comparison: the same three overlapping translucent circles drawn with
+				// the default alpha-over compositing (left) and with additive blending (right).
+				// Additive makes the overlaps accumulate toward white for a neon/glow look.
+				uint red = ImGui.ColorConvertFloat4ToU32(new Vector4(1.0f, 0.2f, 0.2f, 0.5f));
+				uint green = ImGui.ColorConvertFloat4ToU32(new Vector4(0.2f, 1.0f, 0.2f, 0.5f));
+				uint blue = ImGui.ColorConvertFloat4ToU32(new Vector4(0.2f, 0.4f, 1.0f, 0.5f));
+
+				Vector2 alphaCenter = shapeStart + new Vector2(80, 150);
+				drawList.AddCircleFilled(alphaCenter + new Vector2(-15, 0), 30, red, 32);
+				drawList.AddCircleFilled(alphaCenter + new Vector2(15, 0), 30, green, 32);
+				drawList.AddCircleFilled(alphaCenter + new Vector2(0, 22), 30, blue, 32);
+
+				Vector2 additiveCenter = shapeStart + new Vector2(260, 150);
+				ImGuiApp.SetDrawBlendMode(drawList, ImGuiAppBlendMode.Additive);
+				drawList.AddCircleFilled(additiveCenter + new Vector2(-15, 0), 30, red, 32);
+				drawList.AddCircleFilled(additiveCenter + new Vector2(15, 0), 30, green, 32);
+				drawList.AddCircleFilled(additiveCenter + new Vector2(0, 22), 30, blue, 32);
+				ImGuiApp.SetDrawBlendMode(drawList, ImGuiAppBlendMode.AlphaBlend); // restore for the rest of the frame
+
+				ImGui.Dummy(new Vector2(400, 230)); // Reserve space
 			}
 			ImGui.EndChild();
 


### PR DESCRIPTION
## Summary

The OpenGL renderer threw `NotImplementedException` on **any** draw-command `UserCallback`. That made the standard ImGui technique for a per-region GL-state change — inserting an `ImDrawList.AddCallback` to flip `glBlendFunc` (e.g. to additive `SRC_ALPHA, ONE` for a glow effect) and reset it after — crash the app instead of working. The blend func was also set once globally per frame, with no public escape hatch, since `GL` is `internal`.

This PR makes draw-command callbacks work the way the stock `imgui_impl_opengl3` backend does, and layers a small GL-free API on top so consumers can request additive blending without touching `GL`.

## Changes

- **`ImGuiController.RenderDrawData`** now honors callbacks: a `null` `UserCallback` draws normally, the `ImDrawCallback_ResetRenderState` sentinel re-runs `SetupRenderState`, and any other callback is invoked (Cdecl, matching `ImDrawCallback`) with its draw list and command — instead of throwing.
- **`ImGuiController.SetBlendMode(ImGuiAppBlendMode)`** switches the renderer's `glBlendFunc` for the remainder of the draw pass. `Additive` → `BlendFuncSeparate(SRC_ALPHA, ONE, ONE, ONE)`; `AlphaBlend` → the default alpha-over func from `SetupRenderState`.
- **Public API** (`ImGui.App/ImGuiAppBlend.cs`): `enum ImGuiAppBlendMode { AlphaBlend, Additive }` and `ImGuiApp.SetDrawBlendMode(ImDrawListPtr, ImGuiAppBlendMode)`, which records a blend-mode callback into the given draw list. Keeps `GL` private; the callbacks are rooted statics so their marshalled thunks stay valid.
- **`GraphicsDemo`** draws the same three overlapping translucent circles with alpha-over (left) vs additive (right) to show the glow effect.

## Usage

```csharp
ImGuiApp.SetDrawBlendMode(drawList, ImGuiAppBlendMode.Additive);
//  ... draw glow primitives ...
ImGuiApp.SetDrawBlendMode(drawList, ImGuiAppBlendMode.AlphaBlend); // restore for the rest of the frame
```

The blend func is global GL state for the remainder of the pass, so a glow region must always be closed with `AlphaBlend` (or the reset sentinel) before the rest of the UI draws.

## Testing

- `ImGui.App` and `ImGuiAppDemo` compile cleanly (verified locally).
- The render path uses a concrete `GL` and isn't exercised by the mock-GL unit tests, and the GUI is headless here — the additive/glow result is best confirmed by running `ImGuiAppDemo` → Graphics tab.

This is the upstream change that the downstream MeltdownMonitor "regulation field additive blend" investigation was blocked on.

https://claude.ai/code/session_017viDbPJ3QzMA8KhA4UqR8w

---
_Generated by [Claude Code](https://claude.ai/code/session_017viDbPJ3QzMA8KhA4UqR8w)_