### PR TITLE
iOS: make the config surface platform-neutral and align Start signature

### DIFF
--- a/ImGui.App/FontMemoryGuard.cs
+++ b/ImGui.App/FontMemoryGuard.cs
@@ -431,13 +431,13 @@ public static class FontMemoryGuard
 		};
 	}
 
+#if !IOS
 	/// <summary>
 	/// Attempts to detect available GPU memory and update configuration accordingly.
 	/// Special handling for Intel and AMD integrated GPUs which are primary targets for memory constraints.
 	/// </summary>
 	/// <param name="gl">OpenGL context for querying GPU information.</param>
 	/// <returns>True if GPU memory was successfully detected and configuration updated.</returns>
-#if !IOS
 	public static bool TryDetectAndConfigureGpuMemory(GL gl)
 	{
 		if (gl == null || !CurrentConfig.EnableGpuMemoryDetection)

--- a/ImGui.App/FontMemoryGuard.cs
+++ b/ImGui.App/FontMemoryGuard.cs
@@ -9,7 +9,9 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Hexa.NET.ImGui;
+#if !IOS
 using Silk.NET.OpenGL;
+#endif
 
 /// <summary>
 /// Provides memory guards and limits for font loading to prevent excessive texture memory allocation
@@ -435,6 +437,7 @@ public static class FontMemoryGuard
 	/// </summary>
 	/// <param name="gl">OpenGL context for querying GPU information.</param>
 	/// <returns>True if GPU memory was successfully detected and configuration updated.</returns>
+#if !IOS
 	public static bool TryDetectAndConfigureGpuMemory(GL gl)
 	{
 		if (gl == null || !CurrentConfig.EnableGpuMemoryDetection)
@@ -537,6 +540,7 @@ public static class FontMemoryGuard
 
 		return false;
 	}
+#endif
 
 	/// <summary>
 	/// Determines if a GPU is integrated based on renderer string analysis.

--- a/ImGui.App/ImGui.App.csproj
+++ b/ImGui.App/ImGui.App.csproj
@@ -45,9 +45,9 @@
     <!-- Per-region blend modes drive the desktop OpenGL renderer (ImGuiController.SetBlendMode);
          the iOS stub has no such backend, so this partial is excluded like ImGuiApp.cs above. -->
     <Compile Remove="ImGuiAppBlend.cs" />
-    <Compile Remove="ImGuiAppConfig.cs" />
-    <Compile Remove="ImGuiAppWindowState.cs" />
-    <Compile Remove="FontMemoryGuard.cs" />
+    <!-- ImGuiAppConfig.cs, ImGuiAppWindowState.cs, and FontMemoryGuard.cs are platform-neutral
+         and now compile for net10.0-ios: their Silk.NET-coupled members are gated behind #if !IOS
+         so the shared ImGuiAppConfig surface (and Start(ImGuiAppConfig)) is available on iOS. -->
     <Compile Remove="ForceDpiAware.cs" />
     <Compile Remove="GdiPlusHelper.cs" />
     <Compile Remove="NativeMethods.cs" />

--- a/ImGui.App/ImGuiAppConfig.cs
+++ b/ImGui.App/ImGuiAppConfig.cs
@@ -6,7 +6,9 @@ namespace ktsu.ImGui.App;
 
 using System.Resources;
 using ktsu.ScopedAction;
+#if !IOS
 using Silk.NET.Windowing;
+#endif
 
 /// <summary>
 /// Represents the configuration settings for the ImGui application.
@@ -19,11 +21,17 @@ public class ImGuiAppConfig
 	/// </summary>
 	public bool TestMode { get; init; }
 
+#if !IOS
 	/// <summary>
 	/// Gets or sets the test window to use when TestMode is true.
 	/// This must be set when TestMode is true.
 	/// </summary>
+	/// <remarks>
+	/// Backed by the desktop windowing layer (Silk.NET) and consumed only by the desktop render
+	/// loop, so it is excluded from the <c>net10.0-ios</c> build.
+	/// </remarks>
 	internal IWindow? TestWindow { get; init; }
+#endif
 
 	/// <summary>
 	/// Gets or sets the title of the application window.

--- a/ImGui.App/ImGuiAppConfig.cs
+++ b/ImGui.App/ImGuiAppConfig.cs
@@ -50,7 +50,7 @@ public class ImGuiAppConfig
 
 	/// <summary>
 	/// Gets or sets a value indicating whether the window is created hidden.
-	/// When true, the window starts invisible and must be shown with <see cref="ImGuiApp.Show"/>
+	/// When true, the window starts invisible and must be shown with <c>ImGuiApp.Show</c>
 	/// (typically from a system tray icon). The render loop still runs while hidden.
 	/// </summary>
 	public bool StartHidden { get; init; }
@@ -58,7 +58,7 @@ public class ImGuiAppConfig
 	/// <summary>
 	/// Gets or sets a value indicating whether clicking the window's close button hides the
 	/// window instead of stopping the application. This keeps the render loop alive so the
-	/// window can be shown again via <see cref="ImGuiApp.Show"/>. Implemented on Windows;
+	/// window can be shown again via <c>ImGuiApp.Show</c>. Implemented on Windows;
 	/// on other platforms the window closes normally.
 	/// </summary>
 	public bool HideOnClose { get; init; }

--- a/ImGui.App/ImGuiAppWindowState.cs
+++ b/ImGui.App/ImGuiAppWindowState.cs
@@ -6,7 +6,9 @@ namespace ktsu.ImGui.App;
 
 using System.Numerics;
 
+#if !IOS
 using Silk.NET.Windowing;
+#endif
 
 /// <summary>
 /// Represents the state of the ImGui application window, including size, position, and layout state.
@@ -23,8 +25,14 @@ public class ImGuiAppWindowState
 	/// </summary>
 	public Vector2 Pos { get; set; } = new(-short.MinValue, -short.MinValue);
 
+#if !IOS
 	/// <summary>
 	/// Gets or sets the layout state of the window.
 	/// </summary>
+	/// <remarks>
+	/// Backed by the desktop windowing layer (Silk.NET). iOS controls window sizing itself, so
+	/// this member is excluded from the <c>net10.0-ios</c> build; see the iOS platform port plan.
+	/// </remarks>
 	public WindowState LayoutState { get; set; }
+#endif
 }

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
@@ -36,7 +36,7 @@ public static class ImGuiApp
 	/// <exception cref="PlatformNotSupportedException">Always thrown on iOS until the platform layer lands.</exception>
 	public static void Start(ImGuiAppConfig config)
 	{
-		ArgumentNullException.ThrowIfNull(config);
+		Ensure.NotNull(config);
 		Config = config;
 		throw new PlatformNotSupportedException(NotImplementedMessage);
 	}

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
@@ -10,9 +10,11 @@ using Hexa.NET.ImGui;
 using ktsu.Invoker;
 
 /// <summary>
-/// Scaffolding stub for the iOS build of ImGuiApp. The UIKit/Metal platform layer is under
-/// active development; this type exists so the library compiles for net10.0-ios. Calling
-/// <see cref="Start"/> currently throws.
+/// Scaffolding for the iOS build of ImGuiApp. The UIKit/Metal platform layer is under active
+/// development; this type exposes the same public surface as the desktop build so cross-platform
+/// callers compile against <c>net10.0-ios</c>, but the render loop is not wired up yet. Calling
+/// <see cref="Start"/> currently throws — the next chunk lands the <c>UIApplicationDelegate</c> +
+/// <c>CADisplayLink</c> lifecycle. Track progress in docs/plans/2026-05-28-ios-platform-port.md.
 /// </summary>
 public static class ImGuiApp
 {
@@ -20,16 +22,56 @@ public static class ImGuiApp
 		"ImGuiApp iOS backend is not yet implemented. Track progress in docs/plans/2026-05-28-ios-platform-port.md.";
 
 	/// <summary>
-	/// Placeholder entry point. Throws until the iOS platform layer (UIKit + Metal) lands.
+	/// Gets the active application configuration. Populated by <see cref="Start"/> so the rest of
+	/// the (forthcoming) iOS platform layer can read lifecycle callbacks, fonts, and settings.
 	/// </summary>
-	/// <exception cref="PlatformNotSupportedException">Always thrown on iOS for now.</exception>
-	public static void Start() => throw new PlatformNotSupportedException(NotImplementedMessage);
+	internal static ImGuiAppConfig Config { get; set; } = new();
+
+	/// <summary>
+	/// Bootstraps the iOS application. Mirrors the desktop <c>Start(ImGuiAppConfig)</c> signature so
+	/// cross-platform code compiles unchanged; the UIKit + Metal lifecycle is not yet implemented, so
+	/// this currently records the configuration and throws.
+	/// </summary>
+	/// <param name="config">The application configuration (lifecycle callbacks, fonts, settings).</param>
+	/// <exception cref="PlatformNotSupportedException">Always thrown on iOS until the platform layer lands.</exception>
+	public static void Start(ImGuiAppConfig config)
+	{
+		ArgumentNullException.ThrowIfNull(config);
+		Config = config;
+		throw new PlatformNotSupportedException(NotImplementedMessage);
+	}
 
 	/// <summary>
 	/// Placeholder. Throws until the iOS platform layer lands.
 	/// </summary>
 	/// <exception cref="PlatformNotSupportedException">Always thrown on iOS for now.</exception>
 	public static void Stop() => throw new PlatformNotSupportedException(NotImplementedMessage);
+
+	/// <summary>
+	/// Gets the DPI scale factor for the application. On iOS this will initialise from
+	/// <c>UIScreen.MainScreen.Scale</c> once the platform layer lands; until then it reports 1.
+	/// </summary>
+	public static float ScaleFactor { get; private set; } = 1.0f;
+
+	/// <summary>
+	/// Gets the user-controlled global UI scale factor for accessibility. Identical semantics to desktop.
+	/// </summary>
+	public static float GlobalScale { get; private set; } = 1.0f;
+
+	/// <summary>
+	/// Converts a measurement in ems to pixels. Until the ImGui frame is wired up on iOS there is no
+	/// active font, so this mirrors the desktop uninitialised fallback of ems times the default point size.
+	/// </summary>
+	/// <param name="ems">The measurement in ems.</param>
+	/// <returns>The equivalent measurement in pixels.</returns>
+	public static int EmsToPx(float ems) => (int)(ems * FontAppearance.DefaultFontPointSize);
+
+	/// <summary>
+	/// Converts a measurement in points to pixels using the current scale factor. Matches desktop semantics.
+	/// </summary>
+	/// <param name="pts">The measurement in points.</param>
+	/// <returns>The equivalent measurement in pixels.</returns>
+	public static int PtsToPx(int pts) => (int)(pts * ScaleFactor);
 
 	// Below: symbol-compatibility stubs so the platform-neutral helpers in the same assembly
 	// (UIScaler, FontAppearance) link successfully against the iOS TFM. Because Start()

--- a/docs/plans/2026-05-28-ios-platform-port.md
+++ b/docs/plans/2026-05-28-ios-platform-port.md
@@ -1,8 +1,17 @@
 # iOS Platform Port for ImGui.App
 
-> **Status:** Design — not yet under implementation. Each task below is a separate PR-sized chunk.
-> **Owner:** TBD (Mac required for verification — Linux container cannot build `net10.0-ios`).
+> **Status:** In progress. Each task below is a separate PR-sized chunk.
+> **Owner:** TBD (Mac required for runtime verification — Linux container cannot build `net10.0-ios`).
 > **Predecessor:** PR #180 landed the `net10.0-ios` TFM and a throwing stub at `ImGui.App/Platform/iOS/ImGuiApp.iOS.cs`.
+>
+> **Progress log:**
+> - ✅ **Task 1** — `IRendererBackend` seam introduced; desktop routes through it (`IRendererBackend.cs`).
+> - ✅ **Task 2** — `macos-14` CI job compile-checks `net10.0-ios` (`.github/workflows/dotnet.yml`).
+> - 🚧 **Task 3 groundwork** — the platform-neutral public surface (`ImGuiAppConfig`,
+>   `ImGuiAppWindowState`, `FontMemoryGuard.FontMemoryConfig`) now compiles for `net10.0-ios`
+>   (Silk.NET-coupled members gated behind `#if !IOS`), and the iOS entry point exposes the
+>   cross-platform `Start(ImGuiAppConfig)` signature. The `UIApplicationDelegate` + `CADisplayLink`
+>   lifecycle (the rest of Task 3) is the next chunk; `Start` still throws until it lands.
 
 **Goal:** Make `ImGuiApp.Start(config)` actually run a Dear ImGui application on iOS (iPhone + iPad, iOS 15+) with parity for the OnStart / OnUpdate / OnRender / OnAppMenu lifecycle, fonts, textures, and DPI scaling.
 


### PR DESCRIPTION
## Summary

Continues the [iOS platform port](docs/plans/2026-05-28-ios-platform-port.md). With Task 1 (`IRendererBackend` seam) and Task 2 (`macos-14` CI compile job) already landed, this PR does the **Task 3 groundwork**: it decouples the platform-neutral public configuration surface from Silk.NET so it compiles for `net10.0-ios`, and aligns the iOS entry point with the cross-platform `Start(ImGuiAppConfig)` signature.

Previously the iOS build exposed a no-arg `Start()` — an API mismatch that would break cross-platform callers writing `ImGuiApp.Start(config)`. This establishes the shared `ImGuiAppConfig` seam the forthcoming UIKit lifecycle plugs into.

## Changes

- **`FontMemoryGuard`** — gate the only GL-typed method (`TryDetectAndConfigureGpuMemory`) and the `Silk.NET.OpenGL` `using` behind `#if !IOS`. The `FontMemoryConfig` POCO, the memory constants, and the GPU renderer-string heuristics are all pure C# and now build on iOS.
- **`ImGuiAppConfig` / `ImGuiAppWindowState`** — gate the Silk.NET-coupled members (`TestWindow`, `LayoutState`) behind `#if !IOS` so the shared configuration surface compiles for the iOS TFM.
- **`ImGui.App.csproj`** — stop excluding `ImGuiAppConfig.cs`, `ImGuiAppWindowState.cs`, and `FontMemoryGuard.cs` from the `net10.0-ios` build.
- **`ImGuiApp.iOS`** — `Start` now takes `ImGuiAppConfig` (records it, still throws `PlatformNotSupportedException` until the `UIApplicationDelegate` + `CADisplayLink` lifecycle lands); add `ScaleFactor`, `GlobalScale`, `EmsToPx`, `PtsToPx` to match the desktop public shape.
- **Plan doc** — refreshed the progress log (Tasks 1 & 2 ✅, Task 3 groundwork 🚧).

## What's next

The rest of Task 3 — the native `UIApplicationDelegate`, `ImGuiAppViewController`, and `CADisplayLink` lifecycle that makes `Start` actually run a (headless, pre-Metal) ImGui frame — is the next PR-sized chunk.

## Verification

- Desktop build (`net8.0;net9.0;net10.0`) green.
- All **284** `ImGui.App` tests pass.
- The `net10.0-ios` compile is verified by the `macos-14` CI job (Linux/Windows cannot build the iOS TFM). No runtime verification is possible without a Mac + simulator, per the port plan.

https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG

---
_Generated by [Claude Code](https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG)_