### PR TITLE
iOS: native UIKit lifecycle (UIApplicationDelegate + CADisplayLink)

### DIFF
--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
@@ -6,6 +6,7 @@
 
 namespace ktsu.ImGui.App;
 
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
 using Hexa.NET.ImGui;
@@ -117,6 +118,7 @@ public static class ImGuiApp
 	/// Requests application shutdown. iOS applications are not meant to self-terminate (the OS owns
 	/// the lifecycle), so this logs a warning, pauses rendering, and asks UIKit to exit.
 	/// </summary>
+	[SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Best-effort termination via a private selector; any failure must be logged and swallowed so Stop never throws back into consumer code.")]
 	public static void Stop()
 	{
 		DebugLogger.Log("ImGuiApp.Stop() called on iOS. iOS applications should not terminate themselves; " +

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
@@ -6,57 +6,150 @@
 
 namespace ktsu.ImGui.App;
 
+using System.Numerics;
+
 using Hexa.NET.ImGui;
+
 using ktsu.Invoker;
 
+using ObjCRuntime;
+
+using UIKit;
+
 /// <summary>
-/// Scaffolding for the iOS build of ImGuiApp. The UIKit/Metal platform layer is under active
-/// development; this type exposes the same public surface as the desktop build so cross-platform
-/// callers compile against <c>net10.0-ios</c>, but the render loop is not wired up yet. Calling
-/// <see cref="Start"/> currently throws — the next chunk lands the <c>UIApplicationDelegate</c> +
-/// <c>CADisplayLink</c> lifecycle. Track progress in docs/plans/2026-05-28-ios-platform-port.md.
+/// iOS entry point for ImGuiApp. This is the platform-neutral orchestration half of the port:
+/// it owns the application configuration, the main-thread <see cref="Invoker"/>, the lifecycle
+/// state (focus / visibility / idle / scale), and the per-frame tick. The UIKit plumbing lives in
+/// <c>ImGuiAppDelegate</c> (application lifecycle) and <c>ImGuiAppViewController</c> (view +
+/// <c>CADisplayLink</c>), which call back into the <c>internal</c> hooks below.
 /// </summary>
+/// <remarks>
+/// Renderer status: this layer drives the lifecycle (<see cref="ImGuiAppConfig.OnStart"/>,
+/// <see cref="ImGuiAppConfig.OnUpdate"/>, <see cref="ImGuiAppConfig.OnRender"/>) but does not yet
+/// stand up an ImGui frame or submit draw data — the Metal backend is the next chunk. See
+/// docs/plans/2026-05-28-ios-platform-port.md.
+/// </remarks>
 public static class ImGuiApp
 {
 	private const string NotImplementedMessage =
-		"ImGuiApp iOS backend is not yet implemented. Track progress in docs/plans/2026-05-28-ios-platform-port.md.";
+		"This ImGuiApp feature is not yet implemented on iOS. Track progress in docs/plans/2026-05-28-ios-platform-port.md.";
 
-	/// <summary>
-	/// Gets the active application configuration. Populated by <see cref="Start"/> so the rest of
-	/// the (forthcoming) iOS platform layer can read lifecycle callbacks, fonts, and settings.
-	/// </summary>
+	/// <summary>Gets the active application configuration, populated by <see cref="Start"/>.</summary>
 	internal static ImGuiAppConfig Config { get; set; } = new();
 
-	/// <summary>
-	/// Bootstraps the iOS application. Mirrors the desktop <c>Start(ImGuiAppConfig)</c> signature so
-	/// cross-platform code compiles unchanged; the UIKit + Metal lifecycle is not yet implemented, so
-	/// this currently records the configuration and throws.
-	/// </summary>
-	/// <param name="config">The application configuration (lifecycle callbacks, fonts, settings).</param>
-	/// <exception cref="PlatformNotSupportedException">Always thrown on iOS until the platform layer lands.</exception>
-	public static void Start(ImGuiAppConfig config)
-	{
-		Ensure.NotNull(config);
-		Config = config;
-		throw new PlatformNotSupportedException(NotImplementedMessage);
-	}
+	/// <summary>The root view controller, retained so <see cref="Stop"/> can pause the display link.</summary>
+	internal static ImGuiAppViewController? ViewController { get; set; }
+
+	/// <summary>Tracks whether <see cref="ImGuiAppConfig.OnStart"/> has already run for this process.</summary>
+	private static bool started;
+
+	/// <summary>Timestamp of the most recent user input, used for idle detection (mirrors desktop).</summary>
+	private static DateTime lastInputTime = DateTime.UtcNow;
 
 	/// <summary>
-	/// Placeholder. Throws until the iOS platform layer lands.
+	/// Gets an instance of the <see cref="Invoker"/> used to marshal delegates onto the main UI
+	/// thread. Constructed on the main thread in <see cref="RaiseStart"/> and drained each frame.
 	/// </summary>
-	/// <exception cref="PlatformNotSupportedException">Always thrown on iOS for now.</exception>
-	public static void Stop() => throw new PlatformNotSupportedException(NotImplementedMessage);
+	public static Invoker Invoker { get; internal set; } = null!;
+
+	/// <summary>Gets a value indicating whether the application is the active (foreground) app.</summary>
+	public static bool IsFocused { get; internal set; } = true;
+
+	/// <summary>Gets a value indicating whether the application's view is on screen.</summary>
+	public static bool IsVisible { get; internal set; } = true;
+
+	/// <summary>Gets a value indicating whether the application is idle (no recent user input).</summary>
+	public static bool IsIdle { get; private set; }
 
 	/// <summary>
-	/// Gets the DPI scale factor for the application. On iOS this will initialise from
-	/// <c>UIScreen.MainScreen.Scale</c> once the platform layer lands; until then it reports 1.
+	/// Gets the DPI scale factor for the application, initialised from <c>UIScreen.MainScreen.Scale</c>
+	/// (typically 2 or 3) when the platform layer starts.
 	/// </summary>
-	public static float ScaleFactor { get; private set; } = 1.0f;
+	public static float ScaleFactor { get; internal set; } = 1.0f;
 
 	/// <summary>
 	/// Gets the user-controlled global UI scale factor for accessibility. Identical semantics to desktop.
 	/// </summary>
 	public static float GlobalScale { get; private set; } = 1.0f;
+
+	/// <summary>
+	/// Gets the current window state. iOS owns window sizing, so this reports the screen's native
+	/// size at origin (0, 0); there is no separate layout state on iOS.
+	/// </summary>
+	public static ImGuiAppWindowState WindowState
+	{
+		get
+		{
+			CoreGraphics.CGSize size = UIScreen.MainScreen.NativeBounds.Size;
+			return new ImGuiAppWindowState
+			{
+				Size = new Vector2((float)size.Width, (float)size.Height),
+				Pos = Vector2.Zero,
+			};
+		}
+	}
+
+	/// <summary>
+	/// Bootstraps and runs the iOS application. Mirrors the desktop <c>Start(ImGuiAppConfig)</c>
+	/// signature. This hands control to <c>UIApplication.Main</c> and does not return until the OS
+	/// terminates the process (the standard iOS application model).
+	/// </summary>
+	/// <param name="config">The application configuration (lifecycle callbacks, fonts, settings).</param>
+	public static void Start(ImGuiAppConfig config)
+	{
+		Ensure.NotNull(config);
+		Config = config;
+
+		if (config.TestMode)
+		{
+			// Headless path for any future iOS test target: run the lifecycle synchronously without
+			// handing control to UIKit (UIApplication.Main cannot run inside a unit-test host).
+			RaiseStart();
+			Tick(1.0f / 60.0f);
+			return;
+		}
+
+		// Pass the delegate Type (not just its registered name) so the trimmer roots it under AOT.
+		UIApplication.Main(Environment.GetCommandLineArgs(), null, typeof(ImGuiAppDelegate));
+	}
+
+	/// <summary>
+	/// Requests application shutdown. iOS applications are not meant to self-terminate (the OS owns
+	/// the lifecycle), so this logs a warning, pauses rendering, and asks UIKit to exit.
+	/// </summary>
+	public static void Stop()
+	{
+		DebugLogger.Log("ImGuiApp.Stop() called on iOS. iOS applications should not terminate themselves; " +
+			"the OS owns the application lifecycle. Pausing rendering and requesting exit.");
+
+		ViewController?.PauseRendering();
+
+		try
+		{
+			// There is no public terminate API on iOS; this is the long-documented private selector.
+			UIApplication.SharedApplication?.PerformSelector(new Selector("terminateWithSuccess"), null, 0);
+		}
+		catch (Exception ex)
+		{
+			DebugLogger.Log($"ImGuiApp.Stop(): terminate request failed: {ex.Message}");
+		}
+	}
+
+	/// <summary>
+	/// Sets the global UI scale factor for accessibility. Identical semantics and range to desktop.
+	/// </summary>
+	/// <param name="scale">The scale factor to set. Valid range is 0.5 to 3.0.</param>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown when scale is outside the valid range.</exception>
+	public static void SetGlobalScale(float scale)
+	{
+		if (scale is < 0.5f or > 3.0f)
+		{
+			throw new ArgumentOutOfRangeException(nameof(scale), scale, "Scale must be between 0.5 and 3.0");
+		}
+
+		GlobalScale = scale;
+		Config.OnGlobalScaleChanged?.Invoke(scale);
+	}
 
 	/// <summary>
 	/// Converts a measurement in ems to pixels. Until the ImGui frame is wired up on iOS there is no
@@ -73,18 +166,62 @@ public static class ImGuiApp
 	/// <returns>The equivalent measurement in pixels.</returns>
 	public static int PtsToPx(int pts) => (int)(pts * ScaleFactor);
 
-	// Below: symbol-compatibility stubs so the platform-neutral helpers in the same assembly
-	// (UIScaler, FontAppearance) link successfully against the iOS TFM. Because Start()
-	// throws unconditionally above, nothing in user code reaches these on iOS today — they
-	// only need to exist. When the real iOS port lands, these get replaced with backing
-	// fields driven by ImGuiAppDelegate / ImGuiAppViewController.
+	/// <summary>
+	/// Records that user input occurred, resetting the idle timer. Called by the (forthcoming) touch
+	/// and keyboard input bridge.
+	/// </summary>
+	internal static void OnUserInput() => lastInputTime = DateTime.UtcNow;
 
 	/// <summary>
-	/// Marshals delegates to the main UI thread. iOS placeholder — unset on the stub; the
-	/// real port will populate this from <c>NSObject.InvokeOnMainThread</c> equivalent.
+	/// Runs one-time startup: constructs the main-thread <see cref="Invoker"/> and fires
+	/// <see cref="ImGuiAppConfig.OnStart"/>. Idempotent — only the first call has an effect. Must be
+	/// invoked on the main UI thread (the Invoker captures its owning thread here).
 	/// </summary>
-	public static Invoker Invoker { get; internal set; } = null!;
+	internal static void RaiseStart()
+	{
+		if (started)
+		{
+			return;
+		}
 
+		started = true;
+		Invoker = new Invoker();
+		Config.OnStart?.Invoke();
+	}
+
+	/// <summary>
+	/// Advances the application by one frame. Mirrors the desktop ordering: update the consumer, drain
+	/// queued main-thread work, then run the render callback. ImGui frame construction and GPU
+	/// submission are intentionally absent until the Metal backend lands.
+	/// </summary>
+	/// <param name="deltaSeconds">Elapsed wall-clock time since the previous frame, in seconds.</param>
+	internal static void Tick(float deltaSeconds)
+	{
+		UpdateIdleState();
+
+		Config.OnUpdate?.Invoke(deltaSeconds);
+		Invoker?.DoInvokes();
+		Config.OnRender?.Invoke(deltaSeconds);
+	}
+
+	/// <summary>Recomputes <see cref="IsIdle"/> from the configured idle timeout and last input time.</summary>
+	private static void UpdateIdleState()
+	{
+		ImGuiAppPerformanceSettings settings = Config.PerformanceSettings;
+		if (!settings.EnableIdleDetection)
+		{
+			IsIdle = false;
+			return;
+		}
+
+		double secondsSinceInput = (DateTime.UtcNow - lastInputTime).TotalSeconds;
+		IsIdle = secondsSinceInput >= settings.IdleTimeoutSeconds;
+	}
+
+	/// <summary>
+	/// Resolves a font for the requested appearance. Not yet implemented on iOS (fonts land with the
+	/// Metal backend); the symbol exists so <c>FontAppearance</c> links against the iOS assembly.
+	/// </summary>
 	internal static ImFontPtr FindBestFontForAppearance(string name, int sizePoints, out float sizePixels)
 	{
 		sizePixels = sizePoints;

--- a/ImGui.App/Platform/iOS/ImGuiAppDelegate.cs
+++ b/ImGui.App/Platform/iOS/ImGuiAppDelegate.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+#if IOS
+
+namespace ktsu.ImGui.App;
+
+using Foundation;
+
+using UIKit;
+
+/// <summary>
+/// The <c>UIApplicationDelegate</c> for an ImGuiApp iOS process. Owns the single <see cref="UIWindow"/>
+/// and its root <see cref="ImGuiAppViewController"/>, and forwards the application activation lifecycle
+/// to <see cref="ImGuiApp.IsFocused"/>. Instantiated by UIKit via <c>UIApplication.Main</c>; the
+/// <c>[Register]</c> name is the stable Objective-C class name UIKit looks up.
+/// </summary>
+[Register("ImGuiAppDelegate")]
+public class ImGuiAppDelegate : UIApplicationDelegate
+{
+	/// <summary>Gets or sets the application's single window.</summary>
+	public override UIWindow? Window { get; set; }
+
+	/// <summary>
+	/// Creates the window and root view controller and brings them on screen. UIKit calls this once,
+	/// on the main thread, after the process launches.
+	/// </summary>
+	/// <param name="application">The shared application instance.</param>
+	/// <param name="launchOptions">Launch options dictionary (unused).</param>
+	/// <returns><see langword="true"/> to indicate the launch was handled.</returns>
+	public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+	{
+		ImGuiApp.ScaleFactor = (float)UIScreen.MainScreen.Scale;
+
+		ImGuiAppViewController viewController = new();
+		ImGuiApp.ViewController = viewController;
+
+		Window = new UIWindow(UIScreen.MainScreen.Bounds)
+		{
+			RootViewController = viewController,
+		};
+		Window.MakeKeyAndVisible();
+
+		return true;
+	}
+
+	/// <summary>Called when the app becomes the foreground, active application.</summary>
+	/// <param name="application">The shared application instance.</param>
+	public override void OnActivated(UIApplication application)
+	{
+		ImGuiApp.IsFocused = true;
+		ImGuiApp.ViewController?.ResumeRendering();
+	}
+
+	/// <summary>Called when the app is about to move from active to inactive (e.g. an incoming call).</summary>
+	/// <param name="application">The shared application instance.</param>
+	public override void OnResignActivation(UIApplication application) => ImGuiApp.IsFocused = false;
+
+	/// <summary>Called when the app enters the background; pause rendering to save power.</summary>
+	/// <param name="application">The shared application instance.</param>
+	public override void DidEnterBackground(UIApplication application) => ImGuiApp.ViewController?.PauseRendering();
+
+	/// <summary>Called when the app is about to re-enter the foreground.</summary>
+	/// <param name="application">The shared application instance.</param>
+	public override void WillEnterForeground(UIApplication application) => ImGuiApp.ViewController?.ResumeRendering();
+}
+
+#endif

--- a/ImGui.App/Platform/iOS/ImGuiAppDelegate.cs
+++ b/ImGui.App/Platform/iOS/ImGuiAppDelegate.cs
@@ -6,6 +6,8 @@
 
 namespace ktsu.ImGui.App;
 
+using System.Diagnostics.CodeAnalysis;
+
 using Foundation;
 
 using UIKit;
@@ -17,6 +19,7 @@ using UIKit;
 /// <c>[Register]</c> name is the stable Objective-C class name UIKit looks up.
 /// </summary>
 [Register("ImGuiAppDelegate")]
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "This type is a UIKit UIApplicationDelegate; the 'Delegate' suffix is the platform-idiomatic name and matches the Objective-C class registered via [Register].")]
 public class ImGuiAppDelegate : UIApplicationDelegate
 {
 	/// <summary>Gets or sets the application's single window.</summary>
@@ -29,7 +32,8 @@ public class ImGuiAppDelegate : UIApplicationDelegate
 	/// <param name="application">The shared application instance.</param>
 	/// <param name="launchOptions">Launch options dictionary (unused).</param>
 	/// <returns><see langword="true"/> to indicate the launch was handled.</returns>
-	public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+	[SuppressMessage("Interoperability", "CA1422:Validate platform compatibility", Justification = "The single-scene 'new UIWindow(CGRect)' path is supported on iOS 15-25; it is only obsoleted at iOS 26+, where the UIWindowScene API applies. Multi-scene support is a documented post-v1 follow-up in the iOS port plan.")]
+	public override bool FinishedLaunching(UIApplication application, NSDictionary? launchOptions)
 	{
 		ImGuiApp.ScaleFactor = (float)UIScreen.MainScreen.Scale;
 

--- a/ImGui.App/Platform/iOS/ImGuiAppViewController.cs
+++ b/ImGui.App/Platform/iOS/ImGuiAppViewController.cs
@@ -6,9 +6,9 @@
 
 namespace ktsu.ImGui.App;
 
-using CoreAnimation;
+using System.Diagnostics.CodeAnalysis;
 
-using CoreGraphics;
+using CoreAnimation;
 
 using Foundation;
 
@@ -20,6 +20,7 @@ using UIKit;
 /// each tick to <see cref="ImGuiApp.Tick(float)"/>. Until the Metal backend lands, the view is a
 /// solid colour with a centred title label so the lifecycle can be verified in isolation.
 /// </summary>
+[SuppressMessage("Design", "CA1010:Generic interface should also be provided", Justification = "Inherited non-generic IEnumerable comes from the UIKit base type UIViewController; a generic counterpart cannot be added to a framework base class.")]
 public class ImGuiAppViewController : UIViewController
 {
 	private CADisplayLink? displayLink;
@@ -45,9 +46,10 @@ public class ImGuiAppViewController : UIViewController
 		};
 		view.AddSubview(titleLabel);
 
-		int fps = Math.Max(1, (int)ImGuiApp.Config.PerformanceSettings.FocusedFps);
+		float fps = Math.Max(1, (float)ImGuiApp.Config.PerformanceSettings.FocusedFps);
 		displayLink = CADisplayLink.Create(OnDisplayLink);
-		displayLink.PreferredFramesPerSecond = fps;
+		// PreferredFramesPerSecond is obsolete from iOS 15; CAFrameRateRange is the supported control.
+		displayLink.PreferredFrameRateRange = CAFrameRateRange.Create(fps, fps, fps);
 		displayLink.AddToRunLoop(NSRunLoop.Main, NSRunLoopMode.Common);
 		displayLink.Paused = true; // resumed in ViewWillAppear / on activation
 	}

--- a/ImGui.App/Platform/iOS/ImGuiAppViewController.cs
+++ b/ImGui.App/Platform/iOS/ImGuiAppViewController.cs
@@ -1,0 +1,133 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+#if IOS
+
+namespace ktsu.ImGui.App;
+
+using CoreAnimation;
+
+using CoreGraphics;
+
+using Foundation;
+
+using UIKit;
+
+/// <summary>
+/// The root view controller for an ImGuiApp iOS process. Hosts the rendering view and drives the
+/// frame loop via a <see cref="CADisplayLink"/> synchronised to the display's refresh, forwarding
+/// each tick to <see cref="ImGuiApp.Tick(float)"/>. Until the Metal backend lands, the view is a
+/// solid colour with a centred title label so the lifecycle can be verified in isolation.
+/// </summary>
+public class ImGuiAppViewController : UIViewController
+{
+	private CADisplayLink? displayLink;
+	private UILabel? titleLabel;
+	private double lastTimestamp;
+
+	/// <summary>
+	/// Builds the view contents and the display link. Called once by UIKit after the view loads.
+	/// </summary>
+	public override void ViewDidLoad()
+	{
+		base.ViewDidLoad();
+
+		UIView view = View!;
+		view.BackgroundColor = UIColor.FromRGB((byte)115, (byte)140, (byte)153); // matches the desktop clear colour
+
+		titleLabel = new UILabel(view.Bounds)
+		{
+			Text = ImGuiApp.Config.Title,
+			TextAlignment = UITextAlignment.Center,
+			TextColor = UIColor.White,
+			AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight,
+		};
+		view.AddSubview(titleLabel);
+
+		int fps = Math.Max(1, (int)ImGuiApp.Config.PerformanceSettings.FocusedFps);
+		displayLink = CADisplayLink.Create(OnDisplayLink);
+		displayLink.PreferredFramesPerSecond = fps;
+		displayLink.AddToRunLoop(NSRunLoop.Main, NSRunLoopMode.Common);
+		displayLink.Paused = true; // resumed in ViewWillAppear / on activation
+	}
+
+	/// <summary>Marks the app visible, runs one-time startup, and resumes the frame loop.</summary>
+	/// <param name="animated">Whether the appearance is animated.</param>
+	public override void ViewWillAppear(bool animated)
+	{
+		base.ViewWillAppear(animated);
+		ImGuiApp.IsVisible = true;
+		ImGuiApp.RaiseStart();
+		ResumeRendering();
+	}
+
+	/// <summary>Marks the app not visible and pauses the frame loop.</summary>
+	/// <param name="animated">Whether the disappearance is animated.</param>
+	public override void ViewDidDisappear(bool animated)
+	{
+		base.ViewDidDisappear(animated);
+		ImGuiApp.IsVisible = false;
+		PauseRendering();
+	}
+
+	/// <summary>Forwards layout changes (rotation, size class changes) to the resize callback.</summary>
+	public override void ViewDidLayoutSubviews()
+	{
+		base.ViewDidLayoutSubviews();
+		ImGuiApp.Config.OnMoveOrResize?.Invoke();
+	}
+
+	/// <summary>Resumes the display link if it has been created.</summary>
+	internal void ResumeRendering()
+	{
+		if (displayLink is not null)
+		{
+			lastTimestamp = 0; // forces the next frame to seed the delta rather than report a huge gap
+			displayLink.Paused = false;
+		}
+	}
+
+	/// <summary>Pauses the display link if it has been created.</summary>
+	internal void PauseRendering()
+	{
+		if (displayLink is not null)
+		{
+			displayLink.Paused = true;
+		}
+	}
+
+	/// <summary>Per-frame callback from the display link; computes delta and advances the app.</summary>
+	private void OnDisplayLink()
+	{
+		double timestamp = displayLink!.Timestamp;
+		if (lastTimestamp == 0)
+		{
+			lastTimestamp = timestamp;
+			return;
+		}
+
+		float delta = (float)(timestamp - lastTimestamp);
+		lastTimestamp = timestamp;
+
+		ImGuiApp.Tick(delta);
+	}
+
+	/// <summary>Tears down the display link.</summary>
+	/// <param name="disposing"><see langword="true"/> when called from <see cref="IDisposable.Dispose"/>.</param>
+	protected override void Dispose(bool disposing)
+	{
+		if (disposing)
+		{
+			displayLink?.Invalidate();
+			displayLink?.Dispose();
+			displayLink = null;
+			titleLabel?.Dispose();
+			titleLabel = null;
+		}
+
+		base.Dispose(disposing);
+	}
+}
+
+#endif

--- a/docs/plans/2026-05-28-ios-platform-port.md
+++ b/docs/plans/2026-05-28-ios-platform-port.md
@@ -7,11 +7,15 @@
 > **Progress log:**
 > - ✅ **Task 1** — `IRendererBackend` seam introduced; desktop routes through it (`IRendererBackend.cs`).
 > - ✅ **Task 2** — `macos-14` CI job compile-checks `net10.0-ios` (`.github/workflows/dotnet.yml`).
-> - 🚧 **Task 3 groundwork** — the platform-neutral public surface (`ImGuiAppConfig`,
->   `ImGuiAppWindowState`, `FontMemoryGuard.FontMemoryConfig`) now compiles for `net10.0-ios`
+> - ✅ **Task 3 groundwork** — the platform-neutral public surface (`ImGuiAppConfig`,
+>   `ImGuiAppWindowState`, `FontMemoryGuard.FontMemoryConfig`) compiles for `net10.0-ios`
 >   (Silk.NET-coupled members gated behind `#if !IOS`), and the iOS entry point exposes the
->   cross-platform `Start(ImGuiAppConfig)` signature. The `UIApplicationDelegate` + `CADisplayLink`
->   lifecycle (the rest of Task 3) is the next chunk; `Start` still throws until it lands.
+>   cross-platform `Start(ImGuiAppConfig)` signature.
+> - 🚧 **Task 3 lifecycle** — native UIKit plumbing landed: `ImGuiAppDelegate`
+>   (`UIApplicationDelegate`, window + focus lifecycle), `ImGuiAppViewController` (`CADisplayLink`
+>   frame pump + visibility), and `ImGuiApp.Start` now runs `UIApplication.Main` and ticks
+>   `OnStart`/`OnUpdate`/`OnRender`. No ImGui frame or GPU submission yet — that's Task 4 (Metal).
+>   **Compiles on the macOS CI job but is not yet runtime-verified on a device/simulator.**
 
 **Goal:** Make `ImGuiApp.Start(config)` actually run a Dear ImGui application on iOS (iPhone + iPad, iOS 15+) with parity for the OnStart / OnUpdate / OnRender / OnAppMenu lifecycle, fonts, textures, and DPI scaling.
 

--- a/docs/plans/2026-05-28-ios-platform-port.md
+++ b/docs/plans/2026-05-28-ios-platform-port.md
@@ -258,11 +258,13 @@ After Task 2 lands, the Mac job catches compile regressions automatically; manua
 
 ---
 
-## 7. Open Questions
+## 7. Open Questions — RESOLVED (2026-06-06)
 
-1. **`uint TextureId` → `nint TextureId`** is a public-API breaking change for anyone storing the raw handle. Acceptable in a feature release, but flag in CHANGELOG. Alternative: keep `uint` and lose the top 32 bits of the Metal handle (risky on 64-bit pointer comparison).
-2. **Do we ship `.metallib` source-compiled at consumer build time, or precompiled in our NuGet?** Precompiled is simpler but locks shader to one Metal version. Source-compiled requires consumers to have the iOS workload, which they already need to consume the iOS TFM, so probably fine.
-3. **AOT trimming budget.** Hexa.NET.ImGui's P/Invoke surface is large; we may need `<IsTrimmable>false</IsTrimmable>` for v1 and tighten later. Costs binary size.
-4. **iPad Stage Manager / multi-window.** Single-scene is fine for v1; document the limitation.
+1. **`uint TextureId` → `nint TextureId`.** **Decision: change to `nint`.** One pointer-sized handle holds both GL names and `id<MTLTexture>`. Public-API breaking change for anyone reading the raw id — flag in CHANGELOG and bump accordingly.
+2. **`.metallib` packaging.** **Decision: source-compile at consumer build time** via an MSBuild target invoking `xcrun metal`. Consumers already need the iOS workload (which ships the Metal toolchain), so the shader always matches their Metal version.
+3. **AOT trimming budget.** **Decision: trim-correct from the start.** Annotate / root the necessary types (`TrimmerRootDescriptor`, `DynamicDependency`) rather than disabling trimming. Expect Mac/CI round-trips chasing linker strips.
+4. **iPad Stage Manager / multi-window.** Single-scene is fine for v1; document the limitation. (Unchanged — still deferred.)
 
-Answer these before starting Task 4 (Metal renderer); the others can wait.
+**Verification path (decided):** invest in an automated **iOS-simulator CI job first**, before writing the native Metal renderer, so runtime behaviour (launch, tick, render, exit) is caught in CI rather than relying on ad-hoc Mac smoke tests. This re-orders the plan: the simulator harness + CI job is the immediate next chunk, ahead of Task 4.
+
+**Renderer bindings (decided, no external dep):** use the `Metal` / `CoreAnimation` bindings built into the Microsoft.iOS SDK (`MTLDevice`, `MTLCommandQueue`, `CAMetalLayer`, …) rather than a third-party NuGet or hand-rolled P/Invoke.


### PR DESCRIPTION
## Summary

Implements the **lifecycle half of Task 3** of the [iOS platform port](docs/plans/2026-05-28-ios-platform-port.md). `ImGuiApp.Start(config)` now runs a real iOS application and ticks the `OnStart`/`OnUpdate`/`OnRender` lifecycle. **No ImGui frame or GPU submission yet** — that arrives with the Metal backend (Task 4). Until then the view is a solid colour with a centred title label, so the UIKit plumbing can be verified in isolation from rendering (exactly the isolation the plan's Task 3 calls for).

## Changes

- **`ImGuiAppDelegate`** — `[Register]`'d `UIApplicationDelegate`. Owns the `UIWindow` + root view controller; forwards activation (`OnActivated`/`OnResignActivation`) to `IsFocused`, and background/foreground transitions to render pause/resume.
- **`ImGuiAppViewController`** — hosts the view and drives a `CADisplayLink` at the configured `FocusedFps`, computing per-frame delta and calling `ImGuiApp.Tick`. Routes `ViewWillAppear`/`ViewDidDisappear` → `IsVisible` + one-time `RaiseStart`, and `ViewDidLayoutSubviews` → `OnMoveOrResize`.
- **`ImGuiApp.iOS`** — `Start` bootstraps `UIApplication.Main` (passing the delegate `Type` so the AOT trimmer roots it); `Stop` pauses rendering and requests exit with a warning; adds `IsFocused`/`IsVisible`/`IsIdle`/`WindowState`/`SetGlobalScale` to match the desktop surface; `ScaleFactor` seeds from `UIScreen.MainScreen.Scale`; the main-thread `Invoker` is built in `RaiseStart` and drained each frame (mirroring the desktop loop's `OnUpdate → DoInvokes → OnRender` ordering). A `TestMode` path ticks synchronously without `UIApplication.Main`.

## Verification

- Desktop build (`net8.0;net9.0;net10.0`) unaffected — all new code is under `#if IOS`. ✅ (built locally)
- The `net10.0-ios` compile is verified by the `macos-14` CI job.
- ⚠️ **Runtime behaviour is not yet verified.** Per the port plan, the first real iOS code needs a Mac + simulator to confirm it launches, `OnStart` fires, and the display link ticks at 60 Hz with correct focus/visibility transitions. I can't do that from this environment — a manual smoke test on a Mac is the next gate before Task 4.

## Next

Task 4 — the Metal renderer backend — is the substantial next chunk and has open design questions (texture-handle type, shader packaging, AOT trimming budget). I'm raising those with the maintainer before starting it.

https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG

---
_Generated by [Claude Code](https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG)_