### PR TITLE
[minor] nint texture handles end-to-end (ImGui.App + ImGui.Widgets)

### DIFF
--- a/ImGui.App/ImGuiApp.cs
+++ b/ImGui.App/ImGuiApp.cs
@@ -1409,7 +1409,7 @@ public static partial class ImGuiApp
 	/// <summary>
 	/// Uploads a texture to the GPU using the specified RGBA byte array, width, and height.
 	/// </summary>
-	internal static uint UploadTextureRGBA(byte[] bytes, int width, int height)
+	internal static nint UploadTextureRGBA(byte[] bytes, int width, int height)
 	{
 		return Invoker.Invoke(() =>
 		{
@@ -1420,16 +1420,16 @@ public static partial class ImGuiApp
 
 			// The pooled buffer may be larger than the texture; only the first w*h*4 bytes are pixel data.
 			int pixelByteCount = width * height * 4;
-			return (uint)renderer.CreateTexture(bytes.AsSpan(0, pixelByteCount), width, height);
+			return renderer.CreateTexture(bytes.AsSpan(0, pixelByteCount), width, height);
 		});
 	}
 
 	/// <summary>
 	/// Deletes the specified texture from the GPU.
 	/// </summary>
-	/// <param name="textureId">The OpenGL texture ID to delete.</param>
-	/// <exception cref="InvalidOperationException">Thrown if the OpenGL context is not initialized.</exception>
-	public static void DeleteTexture(uint textureId)
+	/// <param name="textureId">The GPU texture handle to delete (see <see cref="ImGuiAppTextureInfo.TextureId"/>).</param>
+	/// <exception cref="InvalidOperationException">Thrown if the renderer backend is not initialized.</exception>
+	public static void DeleteTexture(nint textureId)
 	{
 		Invoker.Invoke(() =>
 		{
@@ -1438,7 +1438,7 @@ public static partial class ImGuiApp
 				throw new InvalidOperationException("Renderer backend is not initialized.");
 			}
 
-			renderer.DeleteTexture((nint)textureId);
+			renderer.DeleteTexture(textureId);
 			Textures.Where(x => x.Value.TextureId == textureId).ToList().ForEach(x => Textures.Remove(x.Key, out ImGuiAppTextureInfo? _));
 		});
 	}

--- a/ImGui.App/ImGuiAppTextureInfo.cs
+++ b/ImGui.App/ImGuiAppTextureInfo.cs
@@ -18,9 +18,11 @@ public class ImGuiAppTextureInfo
 	public AbsoluteFilePath Path { get; set; } = new();
 
 	/// <summary>
-	/// Gets or sets the OpenGL texture ID.
+	/// Gets or sets the GPU texture handle. This is a pointer-sized, platform-agnostic value: on the
+	/// desktop OpenGL backend it is the GL texture name; on the iOS Metal backend it is the
+	/// <c>id&lt;MTLTexture&gt;</c> handle.
 	/// </summary>
-	public uint TextureId { get; set; }
+	public nint TextureId { get; set; }
 
 	/// <summary>
 	/// Gets or sets the ImGui texture reference for ImGui 1.92+ texture system.

--- a/ImGui.Widgets/Avatar.cs
+++ b/ImGui.Widgets/Avatar.cs
@@ -42,7 +42,7 @@ public static partial class ImGuiWidgets
 	/// <param name="diameter">Avatar diameter in pixels. When 0, defaults to twice the frame height so it scales with DPI.</param>
 	/// <param name="status">Presence status drawn as a dot at the bottom-right.</param>
 	/// <returns>True if the avatar was clicked.</returns>
-	public static bool Avatar(string id, uint textureId, float diameter = 0f, AvatarStatus status = AvatarStatus.None) =>
+	public static bool Avatar(string id, nint textureId, float diameter = 0f, AvatarStatus status = AvatarStatus.None) =>
 		AvatarImpl.Draw(id, textureId, null, diameter, status);
 
 	/// <summary>
@@ -90,7 +90,7 @@ public static partial class ImGuiWidgets
 	internal static class AvatarImpl
 	{
 		[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here.", Justification = "Required for native ImGui interop; pointer is scoped to the call and not retained.")]
-		internal static bool Draw(string id, uint textureId, string? displayName, float diameter, AvatarStatus status)
+		internal static bool Draw(string id, nint textureId, string? displayName, float diameter, AvatarStatus status)
 		{
 			float resolvedDiameter = diameter > 0f ? diameter : ImGui.GetFrameHeight() * 2.0f;
 			float radius = resolvedDiameter * 0.5f;

--- a/ImGui.Widgets/Icon.cs
+++ b/ImGui.Widgets/Icon.cs
@@ -81,7 +81,7 @@ public static partial class ImGuiWidgets
 	/// <param name="imageSize">The size of the image.</param>
 	/// <param name="iconAlignment">The alignment of the icon.</param>
 	/// <returns>Was the icon bounds clicked</returns>
-	public static bool Icon(string label, uint textureId, float imageSize, IconAlignment iconAlignment) =>
+	public static bool Icon(string label, nint textureId, float imageSize, IconAlignment iconAlignment) =>
 		IconImpl.Show(label, textureId, new(imageSize, imageSize), iconAlignment, new());
 
 	/// <summary>
@@ -92,7 +92,7 @@ public static partial class ImGuiWidgets
 	/// <param name="imageSize">The size of the image.</param>
 	/// <param name="iconAlignment">The alignment of the icon.</param>
 	/// <returns>Was the icon bounds clicked</returns>
-	public static bool Icon(string label, uint textureId, Vector2 imageSize, IconAlignment iconAlignment) =>
+	public static bool Icon(string label, nint textureId, Vector2 imageSize, IconAlignment iconAlignment) =>
 		IconImpl.Show(label, textureId, imageSize, iconAlignment, new());
 
 	/// <summary>
@@ -104,7 +104,7 @@ public static partial class ImGuiWidgets
 	/// <param name="iconAlignment">The alignment of the icon.</param>
 	/// <param name="options">Additional options</param>
 	/// <returns>Was the icon bounds clicked</returns>
-	public static bool Icon(string label, uint textureId, float imageSize, IconAlignment iconAlignment, IconOptions options) =>
+	public static bool Icon(string label, nint textureId, float imageSize, IconAlignment iconAlignment, IconOptions options) =>
 		IconImpl.Show(label, textureId, new(imageSize, imageSize), iconAlignment, options);
 
 	/// <summary>
@@ -116,7 +116,7 @@ public static partial class ImGuiWidgets
 	/// <param name="iconAlignment">The alignment of the icon.</param>
 	/// <param name="options">Additional options</param>
 	/// <returns>Was the icon bounds clicked</returns>
-	public static bool Icon(string label, uint textureId, Vector2 imageSize, IconAlignment iconAlignment, IconOptions options) =>
+	public static bool Icon(string label, nint textureId, Vector2 imageSize, IconAlignment iconAlignment, IconOptions options) =>
 		IconImpl.Show(label, textureId, imageSize, iconAlignment, options);
 
 	/// <summary>
@@ -170,7 +170,7 @@ public static partial class ImGuiWidgets
 	/// </summary>
 	internal static class IconImpl
 	{
-		internal static bool Show(string label, uint textureId, Vector2 imageSize, IconAlignment iconAlignment, IconOptions options)
+		internal static bool Show(string label, nint textureId, Vector2 imageSize, IconAlignment iconAlignment, IconOptions options)
 		{
 			Ensure.NotNull(label);
 			Ensure.NotNull(options);
@@ -257,7 +257,7 @@ public static partial class ImGuiWidgets
 		}
 
 		[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here.", Justification = "Required for native ImGui interop; pointer is scoped to the call and not retained.")]
-		private static void VerticalLayout(string label, uint textureId, Vector2 imageSize, Vector2 labelSize, Vector2 boundingBoxSize, Vector2 itemSpacing, Vector4 color = default, Vector2 cursorStartPos = default)
+		private static void VerticalLayout(string label, nint textureId, Vector2 imageSize, Vector2 labelSize, Vector2 boundingBoxSize, Vector2 itemSpacing, Vector4 color = default, Vector2 cursorStartPos = default)
 		{
 			Vector2 imageTopLeft = cursorStartPos + new Vector2((boundingBoxSize.X - imageSize.X) / 2, 0);
 			ImGui.SetCursorScreenPos(imageTopLeft);
@@ -280,7 +280,7 @@ public static partial class ImGuiWidgets
 		}
 
 		[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here.", Justification = "Required for native ImGui interop; pointer is scoped to the call and not retained.")]
-		private static void HorizontalLayout(string label, uint textureId, Vector2 imageSize, Vector2 labelSize, Vector2 boundingBoxSize, Vector2 itemSpacing, Vector4 color = default, Vector2 cursorStartPos = default)
+		private static void HorizontalLayout(string label, nint textureId, Vector2 imageSize, Vector2 labelSize, Vector2 boundingBoxSize, Vector2 itemSpacing, Vector4 color = default, Vector2 cursorStartPos = default)
 		{
 			unsafe
 			{

--- a/ImGui.Widgets/Image.cs
+++ b/ImGui.Widgets/Image.cs
@@ -22,7 +22,7 @@ public static partial class ImGuiWidgets
 	/// <param name="textureId">The ID of the texture to display.</param>
 	/// <param name="size">The size of the image.</param>
 	/// <returns>True if the image is clicked; otherwise, false.</returns>
-	public static bool Image(uint textureId, Vector2 size) => ImageImpl.Show(textureId, size, Vector4.One);
+	public static bool Image(nint textureId, Vector2 size) => ImageImpl.Show(textureId, size, Vector4.One);
 
 	/// <summary>
 	/// Displays an image with the specified texture ID, size, and color.
@@ -31,7 +31,7 @@ public static partial class ImGuiWidgets
 	/// <param name="size">The size of the image.</param>
 	/// <param name="color">The color to apply to the image.</param>
 	/// <returns>True if the image is clicked; otherwise, false.</returns>
-	public static bool Image(uint textureId, Vector2 size, Vector4 color) => ImageImpl.Show(textureId, size, color);
+	public static bool Image(nint textureId, Vector2 size, Vector4 color) => ImageImpl.Show(textureId, size, color);
 
 	/// <summary>
 	/// Displays a centered image with the specified texture ID and size.
@@ -39,7 +39,7 @@ public static partial class ImGuiWidgets
 	/// <param name="textureId">The ID of the texture to display.</param>
 	/// <param name="size">The size of the image.</param>
 	/// <returns>True if the image is clicked; otherwise, false.</returns>
-	public static bool ImageCentered(uint textureId, Vector2 size) => ImageImpl.Centered(textureId, size, Vector4.One);
+	public static bool ImageCentered(nint textureId, Vector2 size) => ImageImpl.Centered(textureId, size, Vector4.One);
 
 	/// <summary>
 	/// Displays a centered image with the specified texture ID, size, and color.
@@ -48,7 +48,7 @@ public static partial class ImGuiWidgets
 	/// <param name="size">The size of the image.</param>
 	/// <param name="color">The color to apply to the image.</param>
 	/// <returns>True if the image is clicked; otherwise, false.</returns>
-	public static bool ImageCentered(uint textureId, Vector2 size, Vector4 color) => ImageImpl.Centered(textureId, size, color);
+	public static bool ImageCentered(nint textureId, Vector2 size, Vector4 color) => ImageImpl.Centered(textureId, size, color);
 
 	/// <summary>
 	/// Displays a centered image within a container with the specified texture ID, size, and container size.
@@ -57,7 +57,7 @@ public static partial class ImGuiWidgets
 	/// <param name="size">The size of the image.</param>
 	/// <param name="containerSize">The size of the container.</param>
 	/// <returns>True if the image is clicked; otherwise, false.</returns>
-	public static bool ImageCenteredWithin(uint textureId, Vector2 size, Vector2 containerSize) => ImageImpl.CenteredWithin(textureId, size, containerSize, Vector4.One);
+	public static bool ImageCenteredWithin(nint textureId, Vector2 size, Vector2 containerSize) => ImageImpl.CenteredWithin(textureId, size, containerSize, Vector4.One);
 
 	/// <summary>
 	/// Displays a centered image within a container with the specified texture ID, size, container size, and color.
@@ -67,7 +67,7 @@ public static partial class ImGuiWidgets
 	/// <param name="containerSize">The size of the container.</param>
 	/// <param name="color">The color to apply to the image.</param>
 	/// <returns>True if the image is clicked; otherwise, false.</returns>
-	public static bool ImageCenteredWithin(uint textureId, Vector2 size, Vector2 containerSize, Vector4 color) => ImageImpl.CenteredWithin(textureId, size, containerSize, color);
+	public static bool ImageCenteredWithin(nint textureId, Vector2 size, Vector2 containerSize, Vector4 color) => ImageImpl.CenteredWithin(textureId, size, containerSize, color);
 
 	internal static class ImageImpl
 	{
@@ -77,7 +77,7 @@ public static partial class ImGuiWidgets
 		/// <param name="textureId">The ID of the texture to display.</param>
 		/// <param name="size">The size of the image.</param>
 		/// <returns>True if the image is clicked; otherwise, false.</returns>
-		internal static bool Show(uint textureId, Vector2 size) => Show(textureId, size, Vector4.One);
+		internal static bool Show(nint textureId, Vector2 size) => Show(textureId, size, Vector4.One);
 
 		/// <summary>
 		/// Displays an image with the specified texture ID, size, and color.
@@ -88,7 +88,7 @@ public static partial class ImGuiWidgets
 		/// <returns>True if the image is clicked; otherwise, false.</returns>
 		[SuppressMessage("Major Code Smell", "S3427:Method overloads with default parameter values should not overlap", Justification = "The no-arg overload intentionally uses Vector4.One as default, distinct from the default(Vector4) sentinel; both are needed for correct behavior.")]
 		[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "Required for native ImGui/OpenGL interop; pointers are scoped to the call and not retained.")]
-		internal static bool Show(uint textureId, Vector2 size, Vector4 color = default)
+		internal static bool Show(nint textureId, Vector2 size, Vector4 color = default)
 		{
 			unsafe
 			{
@@ -111,7 +111,7 @@ public static partial class ImGuiWidgets
 		/// <param name="textureId">The ID of the texture to display.</param>
 		/// <param name="size">The size of the image.</param>
 		/// <returns>True if the image is clicked; otherwise, false.</returns>
-		internal static bool Centered(uint textureId, Vector2 size) => Centered(textureId, size, Vector4.One);
+		internal static bool Centered(nint textureId, Vector2 size) => Centered(textureId, size, Vector4.One);
 
 		/// <summary>
 		/// Displays a centered image with the specified texture ID, size, and color.
@@ -120,7 +120,7 @@ public static partial class ImGuiWidgets
 		/// <param name="size">The size of the image.</param>
 		/// <param name="color">The color to apply to the image.</param>
 		/// <returns>True if the image is clicked; otherwise, false.</returns>
-		internal static bool Centered(uint textureId, Vector2 size, Vector4 color)
+		internal static bool Centered(nint textureId, Vector2 size, Vector4 color)
 		{
 			bool clicked = false;
 			using (new Alignment.Center(size))
@@ -138,7 +138,7 @@ public static partial class ImGuiWidgets
 		/// <param name="size">The size of the image.</param>
 		/// <param name="containerSize">The size of the container.</param>
 		/// <returns>True if the image is clicked; otherwise, false.</returns>
-		internal static bool CenteredWithin(uint textureId, Vector2 size, Vector2 containerSize) => CenteredWithin(textureId, size, containerSize, Vector4.One);
+		internal static bool CenteredWithin(nint textureId, Vector2 size, Vector2 containerSize) => CenteredWithin(textureId, size, containerSize, Vector4.One);
 
 		/// <summary>
 		/// Displays a centered image within a container with the specified texture ID, size, container size, and color.
@@ -148,7 +148,7 @@ public static partial class ImGuiWidgets
 		/// <param name="containerSize">The size of the container.</param>
 		/// <param name="color">The color to apply to the image.</param>
 		/// <returns>True if the image is clicked; otherwise, false.</returns>
-		internal static bool CenteredWithin(uint textureId, Vector2 imageSize, Vector2 containerSize, Vector4 color)
+		internal static bool CenteredWithin(nint textureId, Vector2 imageSize, Vector2 containerSize, Vector4 color)
 		{
 			bool clicked = false;
 			using (new Alignment.CenterWithin(imageSize, containerSize))

--- a/tests/ImGui.App.Tests/ErrorHandlingAndEdgeCaseTests.cs
+++ b/tests/ImGui.App.Tests/ErrorHandlingAndEdgeCaseTests.cs
@@ -151,12 +151,12 @@ public class ErrorHandlingAndEdgeCaseTests
 	{
 		ImGuiAppTextureInfo textureInfo = new()
 		{
-			TextureId = uint.MaxValue,
+			TextureId = unchecked((nint)uint.MaxValue),
 			Width = int.MaxValue,
 			Height = int.MaxValue
 		};
 
-		Assert.AreEqual(uint.MaxValue, textureInfo.TextureId);
+		Assert.AreEqual(unchecked((nint)uint.MaxValue), textureInfo.TextureId);
 		Assert.AreEqual(int.MaxValue, textureInfo.Width);
 		Assert.AreEqual(int.MaxValue, textureInfo.Height);
 	}
@@ -166,12 +166,12 @@ public class ErrorHandlingAndEdgeCaseTests
 	{
 		ImGuiAppTextureInfo textureInfo = new()
 		{
-			TextureId = uint.MinValue,
+			TextureId = (nint)uint.MinValue,
 			Width = int.MinValue,
 			Height = int.MinValue
 		};
 
-		Assert.AreEqual(uint.MinValue, textureInfo.TextureId);
+		Assert.AreEqual((nint)uint.MinValue, textureInfo.TextureId);
 		Assert.AreEqual(int.MinValue, textureInfo.Width);
 		Assert.AreEqual(int.MinValue, textureInfo.Height);
 	}

--- a/tests/ImGui.App.Tests/ImGuiAppDataStructureTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppDataStructureTests.cs
@@ -30,7 +30,7 @@ public class ImGuiAppDataStructureTests
 		ImGuiAppTextureInfo textureInfo = new();
 
 		Assert.AreEqual(new AbsoluteFilePath(), textureInfo.Path);
-		Assert.AreEqual(0u, textureInfo.TextureId);
+		Assert.AreEqual((nint)0, textureInfo.TextureId);
 		Assert.AreEqual(0, textureInfo.Width);
 		Assert.AreEqual(0, textureInfo.Height);
 	}
@@ -42,12 +42,12 @@ public class ImGuiAppDataStructureTests
 		AbsoluteFilePath testPath = Path.GetFullPath("test_texture.png").As<AbsoluteFilePath>();
 
 		textureInfo.Path = testPath;
-		textureInfo.TextureId = 123u;
+		textureInfo.TextureId = (nint)123;
 		textureInfo.Width = 256;
 		textureInfo.Height = 512;
 
 		Assert.AreEqual(testPath, textureInfo.Path);
-		Assert.AreEqual(123u, textureInfo.TextureId);
+		Assert.AreEqual((nint)123, textureInfo.TextureId);
 		Assert.AreEqual(256, textureInfo.Width);
 		Assert.AreEqual(512, textureInfo.Height);
 	}

--- a/tests/ImGui.App.Tests/ImGuiAppDataStructureTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppDataStructureTests.cs
@@ -30,7 +30,7 @@ public class ImGuiAppDataStructureTests
 		ImGuiAppTextureInfo textureInfo = new();
 
 		Assert.AreEqual(new AbsoluteFilePath(), textureInfo.Path);
-		Assert.AreEqual((nint)0, textureInfo.TextureId);
+		Assert.AreEqual(0, textureInfo.TextureId);
 		Assert.AreEqual(0, textureInfo.Width);
 		Assert.AreEqual(0, textureInfo.Height);
 	}
@@ -42,12 +42,12 @@ public class ImGuiAppDataStructureTests
 		AbsoluteFilePath testPath = Path.GetFullPath("test_texture.png").As<AbsoluteFilePath>();
 
 		textureInfo.Path = testPath;
-		textureInfo.TextureId = (nint)123;
+		textureInfo.TextureId = 123;
 		textureInfo.Width = 256;
 		textureInfo.Height = 512;
 
 		Assert.AreEqual(testPath, textureInfo.Path);
-		Assert.AreEqual((nint)123, textureInfo.TextureId);
+		Assert.AreEqual(123, textureInfo.TextureId);
 		Assert.AreEqual(256, textureInfo.Width);
 		Assert.AreEqual(512, textureInfo.Height);
 	}

--- a/tests/ImGui.App.Tests/ImGuiAppTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppTests.cs
@@ -426,7 +426,7 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		bool textureExists = ImGuiApp.TryGetTexture(mockTexturePath, out ImGuiAppTextureInfo? retrievedTexture);
 		Assert.IsTrue(textureExists, "Texture should exist after adding");
 		Assert.IsNotNull(retrievedTexture, "Retrieved texture should not be null");
-		Assert.AreEqual((nint)1001, retrievedTexture!.TextureId, "Texture ID should match");
+		Assert.AreEqual(1001, retrievedTexture!.TextureId, "Texture ID should match");
 
 		// Remove the texture to simulate deletion
 		texturesDict.TryRemove(mockTexturePath, out _);
@@ -451,7 +451,7 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		textureExists = ImGuiApp.TryGetTexture(mockTexturePath, out ImGuiAppTextureInfo? reloadedTexture);
 		Assert.IsTrue(textureExists, "Texture should exist after reloading");
 		Assert.IsNotNull(reloadedTexture, "Reloaded texture should not be null");
-		Assert.AreEqual((nint)1002, reloadedTexture!.TextureId, "New texture ID should match");
+		Assert.AreEqual(1002, reloadedTexture!.TextureId, "New texture ID should match");
 		Assert.AreNotEqual(firstTextureInfo.TextureId, reloadedTexture.TextureId, "Reloaded texture should have a different ID");
 	}
 
@@ -489,7 +489,7 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		nint id = ImGuiApp.UploadTextureRGBA(new byte[2 * 2 * 4], 2, 2);
 
 		Assert.AreEqual(1, backend.CreateTextureCallCount, "Upload should route through the registered backend");
-		Assert.AreEqual((nint)7, id, "Returned texture id should come from the backend");
+		Assert.AreEqual(7, id, "Returned texture id should come from the backend");
 	}
 
 	[TestMethod]
@@ -501,7 +501,7 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		ImGuiApp.renderer = backend;
 		ImGuiApp.controller = null;
 
-		ImGuiApp.DeleteTexture((nint)123);
+		ImGuiApp.DeleteTexture(123);
 
 		Assert.AreEqual(1, backend.DeleteTextureCallCount, "Delete should route through the registered backend");
 	}

--- a/tests/ImGui.App.Tests/ImGuiAppTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppTests.cs
@@ -426,7 +426,7 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		bool textureExists = ImGuiApp.TryGetTexture(mockTexturePath, out ImGuiAppTextureInfo? retrievedTexture);
 		Assert.IsTrue(textureExists, "Texture should exist after adding");
 		Assert.IsNotNull(retrievedTexture, "Retrieved texture should not be null");
-		Assert.AreEqual(1001u, retrievedTexture!.TextureId, "Texture ID should match");
+		Assert.AreEqual((nint)1001, retrievedTexture!.TextureId, "Texture ID should match");
 
 		// Remove the texture to simulate deletion
 		texturesDict.TryRemove(mockTexturePath, out _);
@@ -451,7 +451,7 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		textureExists = ImGuiApp.TryGetTexture(mockTexturePath, out ImGuiAppTextureInfo? reloadedTexture);
 		Assert.IsTrue(textureExists, "Texture should exist after reloading");
 		Assert.IsNotNull(reloadedTexture, "Reloaded texture should not be null");
-		Assert.AreEqual(1002u, reloadedTexture!.TextureId, "New texture ID should match");
+		Assert.AreEqual((nint)1002, reloadedTexture!.TextureId, "New texture ID should match");
 		Assert.AreNotEqual(firstTextureInfo.TextureId, reloadedTexture.TextureId, "Reloaded texture should have a different ID");
 	}
 
@@ -486,10 +486,10 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		ImGuiApp.renderer = backend;
 		ImGuiApp.controller = null;
 
-		uint id = ImGuiApp.UploadTextureRGBA(new byte[2 * 2 * 4], 2, 2);
+		nint id = ImGuiApp.UploadTextureRGBA(new byte[2 * 2 * 4], 2, 2);
 
 		Assert.AreEqual(1, backend.CreateTextureCallCount, "Upload should route through the registered backend");
-		Assert.AreEqual(7u, id, "Returned texture id should come from the backend");
+		Assert.AreEqual((nint)7, id, "Returned texture id should come from the backend");
 	}
 
 	[TestMethod]
@@ -501,7 +501,7 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		ImGuiApp.renderer = backend;
 		ImGuiApp.controller = null;
 
-		ImGuiApp.DeleteTexture(123u);
+		ImGuiApp.DeleteTexture((nint)123);
 
 		Assert.AreEqual(1, backend.DeleteTextureCallCount, "Delete should route through the registered backend");
 	}


### PR DESCRIPTION
## Summary

Widens the GPU texture handle from `uint` (an OpenGL texture name) to `nint` (pointer-sized) across the public surface, so it can hold a Metal `id<MTLTexture>` on the forthcoming iOS backend. This implements the iOS port plan's resolved decision (`uint → nint`) and was chosen to **propagate into `ImGui.Widgets`** for end-to-end consistency.

## ⚠️ Breaking change (public API)
- **ImGui.App:** `ImGuiAppTextureInfo.TextureId` and `ImGuiApp.DeleteTexture(uint)` → `nint`.
- **ImGui.Widgets:** `Image` / `ImageCentered` / `ImageCenteredWithin`, `Icon` (all overloads), and `Avatar` texture-id parameters → `nint`.

Callers passing a raw `uint` now need an explicit `(nint)` cast. Values flowing from `ImGuiAppTextureInfo.TextureId` (the common case, as in the demos) need **no change**.

**Versioning:** tagged `[minor]` to match the plan's "feature release" framing. If you'd rather treat this public break as `[major]`, say the word and I'll retag before merge.

## Why it's low-risk under the hood
- The `IRendererBackend` seam was already `nint` (`CreateTexture`/`DeleteTexture`), so the desktop OpenGL path is unchanged — it narrows to `uint` internally where GL needs it.
- `ImTextureID` has an implicit `IntPtr → ImTextureID` conversion, so the `ImTextureRef` construction sites compile unchanged.
- The change is uniform across `net8.0/9.0/10.0`, so it introduces **no new cross-TFM ApiCompat differences** (no suppression edits needed).

## Verification
- ✅ `ImGui.App` tests: 284 pass.
- ✅ `ImGui.Widgets` tests: 97 pass.
- ✅ `ImGui.Widgets` + `ImGuiWidgetsDemo` build against the widened API.
- (SonarCloud is advisory here, as on prior PRs.)

Part of the iOS platform port; unblocks the Metal renderer (Task 4), where `nint` handles are actually returned.

https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG

---
_Generated by [Claude Code](https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG)_