### PR TITLE
feat(ios): touch + keyboard input (Task 5)

### DIFF
--- a/ImGui.App/Platform/iOS/IOSKeyMap.cs
+++ b/ImGui.App/Platform/iOS/IOSKeyMap.cs
@@ -1,0 +1,134 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+#if IOS
+
+namespace ktsu.ImGui.App;
+
+using Hexa.NET.ImGui;
+
+using UIKit;
+
+/// <summary>
+/// Maps hardware-keyboard <see cref="UIKeyboardHidUsage"/> codes (delivered via <c>pressesBegan</c> /
+/// <c>pressesEnded</c>) to Dear ImGui <see cref="ImGuiKey"/> values, mirroring the desktop key table.
+/// Keys ImGui has no slot for return <see cref="ImGuiKey.None"/> and are ignored by the caller.
+/// </summary>
+internal static class IOSKeyMap
+{
+	/// <summary>Translates a UIKit keyboard usage code to the matching <see cref="ImGuiKey"/>.</summary>
+	/// <param name="usage">The hardware key usage from <c>UIKey.KeyCode</c>.</param>
+	/// <returns>The mapped <see cref="ImGuiKey"/>, or <see cref="ImGuiKey.None"/> if unmapped.</returns>
+	public static ImGuiKey Map(UIKeyboardHidUsage usage) => usage switch
+	{
+		UIKeyboardHidUsage.KeyboardTab => ImGuiKey.Tab,
+		UIKeyboardHidUsage.KeyboardLeftArrow => ImGuiKey.LeftArrow,
+		UIKeyboardHidUsage.KeyboardRightArrow => ImGuiKey.RightArrow,
+		UIKeyboardHidUsage.KeyboardUpArrow => ImGuiKey.UpArrow,
+		UIKeyboardHidUsage.KeyboardDownArrow => ImGuiKey.DownArrow,
+		UIKeyboardHidUsage.KeyboardPageUp => ImGuiKey.PageUp,
+		UIKeyboardHidUsage.KeyboardPageDown => ImGuiKey.PageDown,
+		UIKeyboardHidUsage.KeyboardHome => ImGuiKey.Home,
+		UIKeyboardHidUsage.KeyboardEnd => ImGuiKey.End,
+		UIKeyboardHidUsage.KeyboardInsert => ImGuiKey.Insert,
+		UIKeyboardHidUsage.KeyboardDeleteForward => ImGuiKey.Delete,
+		UIKeyboardHidUsage.KeyboardDeleteOrBackspace => ImGuiKey.Backspace,
+		UIKeyboardHidUsage.KeyboardSpacebar => ImGuiKey.Space,
+		UIKeyboardHidUsage.KeyboardReturnOrEnter => ImGuiKey.Enter,
+		UIKeyboardHidUsage.KeyboardEscape => ImGuiKey.Escape,
+		UIKeyboardHidUsage.KeyboardQuote => ImGuiKey.Apostrophe,
+		UIKeyboardHidUsage.KeyboardComma => ImGuiKey.Comma,
+		UIKeyboardHidUsage.KeyboardHyphen => ImGuiKey.Minus,
+		UIKeyboardHidUsage.KeyboardPeriod => ImGuiKey.Period,
+		UIKeyboardHidUsage.KeyboardSlash => ImGuiKey.Slash,
+		UIKeyboardHidUsage.KeyboardSemicolon => ImGuiKey.Semicolon,
+		UIKeyboardHidUsage.KeyboardEqualSign => ImGuiKey.Equal,
+		UIKeyboardHidUsage.KeyboardOpenBracket => ImGuiKey.LeftBracket,
+		UIKeyboardHidUsage.KeyboardBackslash => ImGuiKey.Backslash,
+		UIKeyboardHidUsage.KeyboardCloseBracket => ImGuiKey.RightBracket,
+		UIKeyboardHidUsage.KeyboardGraveAccentAndTilde => ImGuiKey.GraveAccent,
+		UIKeyboardHidUsage.KeyboardCapsLock => ImGuiKey.CapsLock,
+		UIKeyboardHidUsage.KeyboardScrollLock => ImGuiKey.ScrollLock,
+		UIKeyboardHidUsage.KeypadNumLock => ImGuiKey.NumLock,
+		UIKeyboardHidUsage.KeyboardPrintScreen => ImGuiKey.PrintScreen,
+		UIKeyboardHidUsage.KeyboardPause => ImGuiKey.Pause,
+		UIKeyboardHidUsage.Keypad0 => ImGuiKey.Keypad0,
+		UIKeyboardHidUsage.Keypad1 => ImGuiKey.Keypad1,
+		UIKeyboardHidUsage.Keypad2 => ImGuiKey.Keypad2,
+		UIKeyboardHidUsage.Keypad3 => ImGuiKey.Keypad3,
+		UIKeyboardHidUsage.Keypad4 => ImGuiKey.Keypad4,
+		UIKeyboardHidUsage.Keypad5 => ImGuiKey.Keypad5,
+		UIKeyboardHidUsage.Keypad6 => ImGuiKey.Keypad6,
+		UIKeyboardHidUsage.Keypad7 => ImGuiKey.Keypad7,
+		UIKeyboardHidUsage.Keypad8 => ImGuiKey.Keypad8,
+		UIKeyboardHidUsage.Keypad9 => ImGuiKey.Keypad9,
+		UIKeyboardHidUsage.KeypadPeriod => ImGuiKey.KeypadDecimal,
+		UIKeyboardHidUsage.KeypadSlash => ImGuiKey.KeypadDivide,
+		UIKeyboardHidUsage.KeypadAsterisk => ImGuiKey.KeypadMultiply,
+		UIKeyboardHidUsage.KeypadHyphen => ImGuiKey.KeypadSubtract,
+		UIKeyboardHidUsage.KeypadPlus => ImGuiKey.KeypadAdd,
+		UIKeyboardHidUsage.KeypadEnter => ImGuiKey.KeypadEnter,
+		UIKeyboardHidUsage.KeypadEqualSign => ImGuiKey.KeypadEqual,
+		UIKeyboardHidUsage.KeyboardLeftShift => ImGuiKey.LeftShift,
+		UIKeyboardHidUsage.KeyboardLeftControl => ImGuiKey.LeftCtrl,
+		UIKeyboardHidUsage.KeyboardLeftAlt => ImGuiKey.LeftAlt,
+		UIKeyboardHidUsage.KeyboardLeftGui => ImGuiKey.LeftSuper,
+		UIKeyboardHidUsage.KeyboardRightShift => ImGuiKey.RightShift,
+		UIKeyboardHidUsage.KeyboardRightControl => ImGuiKey.RightCtrl,
+		UIKeyboardHidUsage.KeyboardRightAlt => ImGuiKey.RightAlt,
+		UIKeyboardHidUsage.KeyboardRightGui => ImGuiKey.RightSuper,
+		UIKeyboardHidUsage.KeyboardApplication => ImGuiKey.Menu,
+		UIKeyboardHidUsage.Keyboard0 => ImGuiKey.Key0,
+		UIKeyboardHidUsage.Keyboard1 => ImGuiKey.Key1,
+		UIKeyboardHidUsage.Keyboard2 => ImGuiKey.Key2,
+		UIKeyboardHidUsage.Keyboard3 => ImGuiKey.Key3,
+		UIKeyboardHidUsage.Keyboard4 => ImGuiKey.Key4,
+		UIKeyboardHidUsage.Keyboard5 => ImGuiKey.Key5,
+		UIKeyboardHidUsage.Keyboard6 => ImGuiKey.Key6,
+		UIKeyboardHidUsage.Keyboard7 => ImGuiKey.Key7,
+		UIKeyboardHidUsage.Keyboard8 => ImGuiKey.Key8,
+		UIKeyboardHidUsage.Keyboard9 => ImGuiKey.Key9,
+		UIKeyboardHidUsage.KeyboardA => ImGuiKey.A,
+		UIKeyboardHidUsage.KeyboardB => ImGuiKey.B,
+		UIKeyboardHidUsage.KeyboardC => ImGuiKey.C,
+		UIKeyboardHidUsage.KeyboardD => ImGuiKey.D,
+		UIKeyboardHidUsage.KeyboardE => ImGuiKey.E,
+		UIKeyboardHidUsage.KeyboardF => ImGuiKey.F,
+		UIKeyboardHidUsage.KeyboardG => ImGuiKey.G,
+		UIKeyboardHidUsage.KeyboardH => ImGuiKey.H,
+		UIKeyboardHidUsage.KeyboardI => ImGuiKey.I,
+		UIKeyboardHidUsage.KeyboardJ => ImGuiKey.J,
+		UIKeyboardHidUsage.KeyboardK => ImGuiKey.K,
+		UIKeyboardHidUsage.KeyboardL => ImGuiKey.L,
+		UIKeyboardHidUsage.KeyboardM => ImGuiKey.M,
+		UIKeyboardHidUsage.KeyboardN => ImGuiKey.N,
+		UIKeyboardHidUsage.KeyboardO => ImGuiKey.O,
+		UIKeyboardHidUsage.KeyboardP => ImGuiKey.P,
+		UIKeyboardHidUsage.KeyboardQ => ImGuiKey.Q,
+		UIKeyboardHidUsage.KeyboardR => ImGuiKey.R,
+		UIKeyboardHidUsage.KeyboardS => ImGuiKey.S,
+		UIKeyboardHidUsage.KeyboardT => ImGuiKey.T,
+		UIKeyboardHidUsage.KeyboardU => ImGuiKey.U,
+		UIKeyboardHidUsage.KeyboardV => ImGuiKey.V,
+		UIKeyboardHidUsage.KeyboardW => ImGuiKey.W,
+		UIKeyboardHidUsage.KeyboardX => ImGuiKey.X,
+		UIKeyboardHidUsage.KeyboardY => ImGuiKey.Y,
+		UIKeyboardHidUsage.KeyboardZ => ImGuiKey.Z,
+		UIKeyboardHidUsage.KeyboardF1 => ImGuiKey.F1,
+		UIKeyboardHidUsage.KeyboardF2 => ImGuiKey.F2,
+		UIKeyboardHidUsage.KeyboardF3 => ImGuiKey.F3,
+		UIKeyboardHidUsage.KeyboardF4 => ImGuiKey.F4,
+		UIKeyboardHidUsage.KeyboardF5 => ImGuiKey.F5,
+		UIKeyboardHidUsage.KeyboardF6 => ImGuiKey.F6,
+		UIKeyboardHidUsage.KeyboardF7 => ImGuiKey.F7,
+		UIKeyboardHidUsage.KeyboardF8 => ImGuiKey.F8,
+		UIKeyboardHidUsage.KeyboardF9 => ImGuiKey.F9,
+		UIKeyboardHidUsage.KeyboardF10 => ImGuiKey.F10,
+		UIKeyboardHidUsage.KeyboardF11 => ImGuiKey.F11,
+		UIKeyboardHidUsage.KeyboardF12 => ImGuiKey.F12,
+		_ => ImGuiKey.None,
+	};
+}
+
+#endif

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.Input.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.Input.cs
@@ -1,0 +1,80 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+#if IOS
+
+namespace ktsu.ImGui.App;
+
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+/// <summary>
+/// iOS input bridge for <see cref="ImGuiApp"/>: forwards touch, hardware-keyboard, and soft-keyboard
+/// events (raised by <c>ImGuiAppViewController</c>) into Dear ImGui's IO. Touch maps to the single
+/// ImGui mouse (§2.3 of the port plan); a multi-touch sidecar is deferred. Each event also refreshes
+/// the idle timer so input wakes the app from its idle frame-rate.
+/// </summary>
+public static partial class ImGuiApp
+{
+	/// <summary>Reports the primary pointer (touch / pencil) position, in logical points.</summary>
+	/// <param name="position">The pointer location in view points, matching <c>io.DisplaySize</c>.</param>
+	internal static void OnPointerMoved(Vector2 position)
+	{
+		OnUserInput();
+		ImGui.GetIO().AddMousePosEvent(position.X, position.Y);
+	}
+
+	/// <summary>Reports a primary-pointer press or release as the left ImGui mouse button.</summary>
+	/// <param name="down"><see langword="true"/> on touch-down, <see langword="false"/> on touch-up.</param>
+	internal static void OnPointerButton(bool down)
+	{
+		OnUserInput();
+		ImGui.GetIO().AddMouseButtonEvent(0, down);
+	}
+
+	/// <summary>Reports a key press or release, translated to an <see cref="ImGuiKey"/>.</summary>
+	/// <param name="key">The mapped ImGui key; <see cref="ImGuiKey.None"/> is ignored.</param>
+	/// <param name="down"><see langword="true"/> for key-down, <see langword="false"/> for key-up.</param>
+	internal static void OnKey(ImGuiKey key, bool down)
+	{
+		if (key == ImGuiKey.None)
+		{
+			return;
+		}
+
+		OnUserInput();
+		ImGui.GetIO().AddKeyEvent(key, down);
+	}
+
+	/// <summary>Updates the four ImGui keyboard modifier states from the current hardware-key flags.</summary>
+	/// <param name="ctrl">Whether a Control key is held.</param>
+	/// <param name="shift">Whether a Shift key is held.</param>
+	/// <param name="alt">Whether an Alt/Option key is held.</param>
+	/// <param name="super">Whether a Command/Super key is held.</param>
+	internal static void OnModifiers(bool ctrl, bool shift, bool alt, bool super)
+	{
+		ImGuiIOPtr io = ImGui.GetIO();
+		io.AddKeyEvent(ImGuiKey.ModCtrl, ctrl);
+		io.AddKeyEvent(ImGuiKey.ModShift, shift);
+		io.AddKeyEvent(ImGuiKey.ModAlt, alt);
+		io.AddKeyEvent(ImGuiKey.ModSuper, super);
+	}
+
+	/// <summary>Feeds a typed Unicode codepoint into ImGui's text-input queue.</summary>
+	/// <param name="codepoint">The UTF-32 codepoint entered by the user.</param>
+	internal static void OnTextInput(uint codepoint)
+	{
+		OnUserInput();
+		ImGui.GetIO().AddInputCharacter(codepoint);
+	}
+
+	/// <summary>
+	/// Gets a value indicating whether ImGui currently wants text input (an input widget is active),
+	/// so the view controller can present or dismiss the soft keyboard.
+	/// </summary>
+	internal static bool WantsTextInput => Renderer is not null && ImGui.GetIO().WantTextInput;
+}
+
+#endif

--- a/ImGui.App/Platform/iOS/ImGuiAppViewController.cs
+++ b/ImGui.App/Platform/iOS/ImGuiAppViewController.cs
@@ -7,8 +7,12 @@
 namespace ktsu.ImGui.App;
 
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Text;
 
 using CoreAnimation;
+
+using CoreGraphics;
 
 using Foundation;
 
@@ -25,6 +29,14 @@ public class ImGuiAppViewController : UIViewController
 {
 	private CADisplayLink? displayLink;
 	private double lastTimestamp;
+
+	// Input state. The primary touch drives the single ImGui mouse (additional fingers are ignored
+	// for v1); the soft keyboard is an invisible first-responder presented while ImGui wants text.
+	private UITouch? primaryTouch;
+	private SoftKeyboardView? softKeyboard;
+
+	/// <summary>The controller becomes first responder so hardware key presses reach <c>PressesBegan</c>.</summary>
+	public override bool CanBecomeFirstResponder => true;
 
 	// CI smoke-test harness: when the IMGUIAPP_IOS_SMOKE_FRAMES environment variable is a positive
 	// integer (set via simctl's SIMCTL_CHILD_ prefix), the app runs that many frames, prints a
@@ -46,6 +58,11 @@ public class ImGuiAppViewController : UIViewController
 		base.ViewDidLoad();
 
 		ImGuiApp.InitializeRenderer((MetalView)View!);
+
+		// Invisible, zero-sized soft-keyboard responder. Zero frame means it never intercepts touches;
+		// it only matters as a first responder when ImGui wants text input.
+		softKeyboard = new SoftKeyboardView { Frame = CGRect.Empty };
+		View!.AddSubview(softKeyboard);
 
 		float fps = Math.Max(1, (float)ImGuiApp.Config.PerformanceSettings.FocusedFps);
 		displayLink = CADisplayLink.Create(OnDisplayLink);
@@ -69,6 +86,14 @@ public class ImGuiAppViewController : UIViewController
 		ImGuiApp.IsVisible = true;
 		ImGuiApp.RaiseStart();
 		ResumeRendering();
+	}
+
+	/// <summary>Takes first-responder status so a hardware keyboard reaches the press handlers.</summary>
+	/// <param name="animated">Whether the appearance is animated.</param>
+	public override void ViewDidAppear(bool animated)
+	{
+		base.ViewDidAppear(animated);
+		BecomeFirstResponder();
 	}
 
 	/// <summary>Marks the app not visible and pauses the frame loop.</summary>
@@ -120,6 +145,7 @@ public class ImGuiAppViewController : UIViewController
 		lastTimestamp = timestamp;
 
 		ImGuiApp.Tick(delta);
+		UpdateSoftKeyboard();
 
 		if (smokeFramesRemaining > 0)
 		{
@@ -134,7 +160,149 @@ public class ImGuiAppViewController : UIViewController
 		}
 	}
 
-	/// <summary>Tears down the display link.</summary>
+	/// <summary>Begins tracking the first finger as the ImGui mouse and presses the left button.</summary>
+	/// <param name="touches">The touches that began.</param>
+	/// <param name="evt">The owning UIKit event.</param>
+	public override void TouchesBegan(NSSet touches, UIEvent? evt)
+	{
+		base.TouchesBegan(touches, evt);
+		if (primaryTouch is null && touches.AnyObject is UITouch touch)
+		{
+			primaryTouch = touch;
+			ImGuiApp.OnPointerMoved(LocationOf(touch));
+			ImGuiApp.OnPointerButton(down: true);
+		}
+	}
+
+	/// <summary>Tracks the primary finger's movement as ImGui mouse motion.</summary>
+	/// <param name="touches">The touches that moved.</param>
+	/// <param name="evt">The owning UIKit event.</param>
+	public override void TouchesMoved(NSSet touches, UIEvent? evt)
+	{
+		base.TouchesMoved(touches, evt);
+		if (primaryTouch is not null && touches.Contains(primaryTouch))
+		{
+			ImGuiApp.OnPointerMoved(LocationOf(primaryTouch));
+		}
+	}
+
+	/// <summary>Releases the ImGui mouse button when the primary finger lifts.</summary>
+	/// <param name="touches">The touches that ended.</param>
+	/// <param name="evt">The owning UIKit event.</param>
+	public override void TouchesEnded(NSSet touches, UIEvent? evt)
+	{
+		base.TouchesEnded(touches, evt);
+		EndPrimaryTouch(touches);
+	}
+
+	/// <summary>Releases the ImGui mouse button when the primary touch is cancelled.</summary>
+	/// <param name="touches">The touches that were cancelled.</param>
+	/// <param name="evt">The owning UIKit event.</param>
+	public override void TouchesCancelled(NSSet touches, UIEvent? evt)
+	{
+		base.TouchesCancelled(touches, evt);
+		EndPrimaryTouch(touches);
+	}
+
+	/// <summary>Forwards hardware key-down events (key, modifiers, typed characters) to ImGui.</summary>
+	/// <param name="presses">The presses that began.</param>
+	/// <param name="evt">The owning UIKit presses event.</param>
+	public override void PressesBegan(NSSet<UIPress> presses, UIPressesEvent? evt)
+	{
+		if (!HandlePresses(presses, down: true))
+		{
+			base.PressesBegan(presses, evt);
+		}
+	}
+
+	/// <summary>Forwards hardware key-up events to ImGui.</summary>
+	/// <param name="presses">The presses that ended.</param>
+	/// <param name="evt">The owning UIKit presses event.</param>
+	public override void PressesEnded(NSSet<UIPress> presses, UIPressesEvent? evt)
+	{
+		if (!HandlePresses(presses, down: false))
+		{
+			base.PressesEnded(presses, evt);
+		}
+	}
+
+	private void EndPrimaryTouch(NSSet touches)
+	{
+		if (primaryTouch is not null && touches.Contains(primaryTouch))
+		{
+			ImGuiApp.OnPointerMoved(LocationOf(primaryTouch));
+			ImGuiApp.OnPointerButton(down: false);
+			primaryTouch = null;
+		}
+	}
+
+	private Vector2 LocationOf(UITouch touch)
+	{
+		CGPoint point = touch.LocationInView(View);
+		return new Vector2((float)point.X, (float)point.Y);
+	}
+
+	private bool HandlePresses(NSSet<UIPress> presses, bool down)
+	{
+		bool handled = false;
+		foreach (UIPress press in presses)
+		{
+			if (press.Key is not UIKey key)
+			{
+				continue;
+			}
+
+			UIKeyModifierFlags mods = key.ModifierFlags;
+			ImGuiApp.OnModifiers(
+				mods.HasFlag(UIKeyModifierFlags.Control),
+				mods.HasFlag(UIKeyModifierFlags.Shift),
+				mods.HasFlag(UIKeyModifierFlags.Alternate),
+				mods.HasFlag(UIKeyModifierFlags.Command));
+			ImGuiApp.OnKey(IOSKeyMap.Map(key.KeyCode), down);
+
+			// Hardware-typed characters, but only when the soft keyboard isn't also capturing them
+			// (otherwise iPad-with-Magic-Keyboard would deliver each character twice).
+			if (down && softKeyboard?.IsFirstResponder != true)
+			{
+				foreach (Rune rune in (key.Characters ?? string.Empty).EnumerateRunes())
+				{
+					if (rune.Value >= 0x20 && rune.Value != 0x7f)
+					{
+						ImGuiApp.OnTextInput((uint)rune.Value);
+					}
+				}
+			}
+
+			handled = true;
+		}
+
+		return handled;
+	}
+
+	/// <summary>
+	/// Presents or dismisses the soft keyboard to match ImGui's text-input intent. Called each frame
+	/// after <see cref="ImGuiApp.Tick(float)"/> so a freshly focused input field raises the keyboard.
+	/// </summary>
+	private void UpdateSoftKeyboard()
+	{
+		if (softKeyboard is null)
+		{
+			return;
+		}
+
+		bool want = ImGuiApp.WantsTextInput;
+		if (want && !softKeyboard.IsFirstResponder)
+		{
+			softKeyboard.BecomeFirstResponder();
+		}
+		else if (!want && softKeyboard.IsFirstResponder)
+		{
+			softKeyboard.ResignFirstResponder();
+			BecomeFirstResponder(); // restore hardware-key capture to the controller
+		}
+	}
+
+	/// <summary>Tears down the display link and input responder.</summary>
 	/// <param name="disposing"><see langword="true"/> when called from <see cref="IDisposable.Dispose"/>.</param>
 	protected override void Dispose(bool disposing)
 	{
@@ -143,6 +311,8 @@ public class ImGuiAppViewController : UIViewController
 			displayLink?.Invalidate();
 			displayLink?.Dispose();
 			displayLink = null;
+			softKeyboard?.Dispose();
+			softKeyboard = null;
 		}
 
 		base.Dispose(disposing);

--- a/ImGui.App/Platform/iOS/ImGuiAppViewController.cs
+++ b/ImGui.App/Platform/iOS/ImGuiAppViewController.cs
@@ -165,6 +165,7 @@ public class ImGuiAppViewController : UIViewController
 	/// <param name="evt">The owning UIKit event.</param>
 	public override void TouchesBegan(NSSet touches, UIEvent? evt)
 	{
+		Ensure.NotNull(touches);
 		base.TouchesBegan(touches, evt);
 		if (primaryTouch is null && touches.AnyObject is UITouch touch)
 		{
@@ -179,6 +180,7 @@ public class ImGuiAppViewController : UIViewController
 	/// <param name="evt">The owning UIKit event.</param>
 	public override void TouchesMoved(NSSet touches, UIEvent? evt)
 	{
+		Ensure.NotNull(touches);
 		base.TouchesMoved(touches, evt);
 		if (primaryTouch is not null && touches.Contains(primaryTouch))
 		{
@@ -191,6 +193,7 @@ public class ImGuiAppViewController : UIViewController
 	/// <param name="evt">The owning UIKit event.</param>
 	public override void TouchesEnded(NSSet touches, UIEvent? evt)
 	{
+		Ensure.NotNull(touches);
 		base.TouchesEnded(touches, evt);
 		EndPrimaryTouch(touches);
 	}
@@ -200,6 +203,7 @@ public class ImGuiAppViewController : UIViewController
 	/// <param name="evt">The owning UIKit event.</param>
 	public override void TouchesCancelled(NSSet touches, UIEvent? evt)
 	{
+		Ensure.NotNull(touches);
 		base.TouchesCancelled(touches, evt);
 		EndPrimaryTouch(touches);
 	}
@@ -207,8 +211,9 @@ public class ImGuiAppViewController : UIViewController
 	/// <summary>Forwards hardware key-down events (key, modifiers, typed characters) to ImGui.</summary>
 	/// <param name="presses">The presses that began.</param>
 	/// <param name="evt">The owning UIKit presses event.</param>
-	public override void PressesBegan(NSSet<UIPress> presses, UIPressesEvent? evt)
+	public override void PressesBegan(NSSet<UIPress> presses, UIPressesEvent evt)
 	{
+		Ensure.NotNull(presses);
 		if (!HandlePresses(presses, down: true))
 		{
 			base.PressesBegan(presses, evt);
@@ -218,8 +223,9 @@ public class ImGuiAppViewController : UIViewController
 	/// <summary>Forwards hardware key-up events to ImGui.</summary>
 	/// <param name="presses">The presses that ended.</param>
 	/// <param name="evt">The owning UIKit presses event.</param>
-	public override void PressesEnded(NSSet<UIPress> presses, UIPressesEvent? evt)
+	public override void PressesEnded(NSSet<UIPress> presses, UIPressesEvent evt)
 	{
+		Ensure.NotNull(presses);
 		if (!HandlePresses(presses, down: false))
 		{
 			base.PressesEnded(presses, evt);

--- a/ImGui.App/Platform/iOS/SoftKeyboardView.cs
+++ b/ImGui.App/Platform/iOS/SoftKeyboardView.cs
@@ -1,0 +1,63 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+#if IOS
+
+namespace ktsu.ImGui.App;
+
+using System.Text;
+
+using Foundation;
+
+using Hexa.NET.ImGui;
+
+using ObjCRuntime;
+
+using UIKit;
+
+/// <summary>
+/// An invisible, zero-sized first-responder that surfaces the iOS soft keyboard and funnels typed
+/// text into Dear ImGui. The view controller makes it the first responder while
+/// <see cref="ImGuiApp.WantsTextInput"/> is set (an ImGui input widget is active) and resigns it
+/// otherwise. Conforming to <see cref="IUIKeyInput"/> is enough for UIKit to present the keyboard and
+/// route <c>insertText:</c> / <c>deleteBackward</c> here.
+/// </summary>
+internal sealed class SoftKeyboardView : UIView, IUIKeyInput
+{
+	/// <summary>Gets a value indicating that this view can become first responder (required to type).</summary>
+	public override bool CanBecomeFirstResponder => true;
+
+	/// <summary>Gets a value indicating there is always "text", so UIKit keeps delivering deletes.</summary>
+	[Export("hasText")]
+	public bool HasText => true;
+
+	/// <summary>Receives typed text from the keyboard and forwards each codepoint to ImGui.</summary>
+	/// <param name="text">The inserted text (usually one character; more on paste / IME commit).</param>
+	[Export("insertText:")]
+	public void InsertText(string text)
+	{
+		foreach (Rune rune in (text ?? string.Empty).EnumerateRunes())
+		{
+			if (rune.Value is '\n' or '\r')
+			{
+				ImGuiApp.OnKey(ImGuiKey.Enter, down: true);
+				ImGuiApp.OnKey(ImGuiKey.Enter, down: false);
+			}
+			else if (rune.Value >= 0x20 && rune.Value != 0x7f)
+			{
+				ImGuiApp.OnTextInput((uint)rune.Value);
+			}
+		}
+	}
+
+	/// <summary>Receives a backspace from the keyboard and forwards it to ImGui as a key press.</summary>
+	[Export("deleteBackward")]
+	public void DeleteBackward()
+	{
+		ImGuiApp.OnKey(ImGuiKey.Backspace, down: true);
+		ImGuiApp.OnKey(ImGuiKey.Backspace, down: false);
+	}
+}
+
+#endif

--- a/tests/ImGui.App.iOS.SmokeTest/Program.cs
+++ b/tests/ImGui.App.iOS.SmokeTest/Program.cs
@@ -27,5 +27,19 @@ ImGuiApp.Start(new ImGuiAppConfig
 		ImGui.TextUnformatted("iOS Metal renderer smoke test");
 		ImGui.Button("Tap");
 		ImGui.End();
+
+		// CI can't inject real touches/keys into the headless simulator, so exercise the ImGui input
+		// IO calls the iOS input bridge makes (pointer, button, key, modifier, text, wheel). This
+		// verifies they don't crash on the Apple ARM64 ABI the way the variadic igText did.
+		ImGuiIOPtr io = ImGui.GetIO();
+		io.AddMousePosEvent(8f, 8f);
+		io.AddMouseButtonEvent(0, true);
+		io.AddMouseButtonEvent(0, false);
+		io.AddMouseWheelEvent(0f, 1f);
+		io.AddKeyEvent(ImGuiKey.ModShift, true);
+		io.AddKeyEvent(ImGuiKey.A, true);
+		io.AddKeyEvent(ImGuiKey.A, false);
+		io.AddKeyEvent(ImGuiKey.ModShift, false);
+		io.AddInputCharacter((uint)'A');
 	},
 });


### PR DESCRIPTION
## Summary

Task 5 of the iOS port (`docs/plans/2026-05-28-ios-platform-port.md`): wires iOS input into Dear ImGui, on top of the now-landed Metal renderer (#206). Follows port-plan §2.3.

## What's here
- **Touch → single ImGui mouse.** The view controller's `TouchesBegan/Moved/Ended/Cancelled` track the primary finger and drive `AddMousePosEvent` + `AddMouseButtonEvent(0)` (coords via `LocationInView`, in the same logical points as `io.DisplaySize`). Additional fingers are ignored for v1; a multi-touch/pencil-pressure sidecar is deferred.
- **Hardware keyboard.** `PressesBegan/PressesEnded` map `UIKey.KeyCode` (`UIKeyboardHidUsage`) → `ImGuiKey` via **`IOSKeyMap`** (mirrors the desktop key table), forward Ctrl/Shift/Alt/Cmd modifiers, and feed typed characters — guarded so iPad-with-Magic-Keyboard doesn't double-enter text when the soft keyboard is also capturing.
- **Soft keyboard.** **`SoftKeyboardView`** is an invisible, zero-sized `IUIKeyInput` first-responder. The controller presents/dismisses it each frame to match `io.WantTextInput`, funnelling `insertText:` → `AddInputCharacter` and `deleteBackward` → `Backspace`. The controller itself is the first responder otherwise, so a hardware keyboard works without a focused input.
- **`ImGuiApp.iOS.Input`** bridges all of the above into ImGui's IO and refreshes the idle timer so input wakes the app from its idle frame-rate.

## Verification
CI builds `net10.0-ios` and runs the simulator smoke test (hard gate). Because the headless simulator can't inject real touches/keys, the smoke app now also **exercises the ImGui input IO calls** (`AddMousePosEvent`/`AddMouseButtonEvent`/`AddMouseWheelEvent`/`AddKeyEvent`/`AddInputCharacter`) to confirm they don't crash on the Apple ARM64 ABI — the same class of issue that made the variadic `igText` crash in #206. **The touch/key *behaviour* (correct mapping, soft-keyboard show/hide) still needs on-device verification** — CI proves it compiles, links, and doesn't crash the lifecycle/input path.

## Deferred (per the port plan)
Multi-touch + Apple Pencil pressure sidecar; full font parity and `imgui.ini` redirect (Task 6); on-device arm64 native-cimgui distribution.

https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG

---
_Generated by [Claude Code](https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG)_