### PR TITLE
ci: fix intermittent coverage broken-pipe flake (exit code 7)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="ktsu.ScopedAction" Version="1.1.10" />
     <PackageVersion Include="ktsu.FuzzySearch" Version="1.2.2" />
     <PackageVersion Include="ktsu.TextFilter" Version="1.5.9" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Silk.NET" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.OpenGL" Version="2.23.0" />


### PR DESCRIPTION
## The flake

The Windows **Build, Test & Release** job has been intermittently failing with **exit code 7** even though every test passes. The signature in the logs:

```
total: 507, failed: 0, succeeded: 507, skipped: 0
error: 1
<random>.Tests.dll (net10.0|x64) failed
Test run completed with non-success exit code: 7
```

A *random* test assembly reports an **error** (not a test failure) on each run — the code-coverage collector's named-pipe IPC disconnects during teardown when multiple test assemblies run under Microsoft.Testing.Platform. It's cost several re-runs across the recent iOS PRs (#205/#206/#207).

## Root cause

This is the known **broken-pipe regression introduced in `Microsoft.Testing.Extensions.CodeCoverage` 18.3.1** ([microsoft/codecoverage#202](https://github.com/microsoft/codecoverage/issues/202)). `Directory.Packages.props` pinned the affected **18.3.2**.

## Fix

Bump to the latest **18.6.2**, which is several releases past the regression:

```
18.3.2 (broken) → 18.4.1 → 18.5.1 → 18.5.2 → 18.6.2 (latest)
```

Test-only package; no product-code change.

## Verification & honesty

The flake is **Windows-named-pipe-specific and intermittent**, so it can't be reproduced in this Linux dev container (the desktop test apphost pack isn't available offline). I verified that `18.6.2` is published on NuGet and resolves cleanly; **CI is the real proving ground**, and because the flake is probabilistic, confidence comes from watching several green runs rather than one.

If `18.6.2` still flakes, the fallbacks are: pin the last known-good `18.1.0` (predates .NET 10, so a compat risk), or add test-retry/sequential-assembly execution in the external KtsuBuild runner (where the `dotnet test`/MTP invocation actually lives — out of this repo's scope).

https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG

---
_Generated by [Claude Code](https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG)_