### PR TITLE
feat(ios): font parity + imgui.ini redirect (Task 6)

### DIFF
--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.Render.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.Render.cs
@@ -159,7 +159,7 @@ public static partial class ImGuiApp
 	/// (no <c>RendererHasTextures</c>): add fonts, build with <c>ImFontAtlasBuildMain</c>, upload the
 	/// RGBA32 pixels, hand the texture id back to ImGui with <c>SetTexID</c>, then free the CPU copy.
 	/// Glyphs are rasterized at the physical pixel size for the display scale and rendered back down via
-	/// <c>FontGlobalScale</c>, so text is crisp on a 2x/3x screen rather than an upscaled low-res atlas.
+	/// <c>style.FontScaleMain</c>, so text is crisp on a 2x/3x screen rather than an upscaled low-res atlas.
 	/// </summary>
 	/// <param name="io">The ImGui IO whose font atlas to build.</param>
 	private static unsafe void BuildFontAtlas(ImGuiIOPtr io)
@@ -198,7 +198,10 @@ public static partial class ImGuiApp
 			io.Fonts.AddFontDefault();
 		}
 
-		io.FontGlobalScale = 1f / ScaleFactor;
+		// FontScaleMain is the 1.92 replacement for the removed io.FontGlobalScale: a global multiplier
+		// on rendered font size. The atlas is rasterised at pointSize * scale, so scaling by 1/scale lays
+		// text out at the logical point size while keeping it pixel-crisp on the high-DPI framebuffer.
+		ImGui.GetStyle().FontScaleMain = 1f / ScaleFactor;
 
 		if (!io.Fonts.TexIsBuilt)
 		{

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.Render.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.Render.cs
@@ -8,8 +8,10 @@ namespace ktsu.ImGui.App;
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Text;
 
 using CoreGraphics;
 
@@ -23,7 +25,7 @@ using HexaGen.Runtime;
 /// iOS renderer orchestration for <see cref="ImGuiApp"/>: stands up the Dear ImGui context and font
 /// atlas, owns the Metal <see cref="IRendererBackend"/>, and drives the per-frame begin/submit cycle
 /// the <c>Tick</c> loop calls into. This mirrors the role the desktop <c>ImGuiController</c> plays,
-/// scoped to what the Metal port needs for v1 (default font atlas; full font parity is a later task).
+/// scoped to what the Metal port needs for v1 (Nerd Font + emoji atlas, DPI-aware crisp text).
 /// </summary>
 public static partial class ImGuiApp
 {
@@ -109,24 +111,94 @@ public static partial class ImGuiApp
 		ImGuiIOPtr io = ImGui.GetIO();
 		io.BackendFlags |= ImGuiBackendFlags.RendererHasVtxOffset;
 
-		// Note: ini persistence (honouring Config.SaveIniSettings and redirecting imgui.ini away from
-		// the read-only app bundle to a writable directory) is handled by the later ini-redirect task.
+		ConfigureIniPersistence(io);
 
 		Renderer = new MetalRendererBackend(view.MetalLayer);
 		BuildFontAtlas(io);
 	}
 
+	/// <summary>Holds the native UTF-8 ini path for the process lifetime; ImGui reads the pointer lazily.</summary>
+	private static nint iniFilenameHandle;
+
 	/// <summary>
-	/// Builds the default font atlas and uploads it to the GPU via the backend, mirroring the desktop
-	/// legacy-atlas path (no <c>RendererHasTextures</c>): build with <c>ImFontAtlasBuildMain</c>, upload
-	/// the RGBA32 pixels, hand the texture id back to ImGui with <c>SetTexID</c>, then free the CPU copy.
+	/// Points <c>io.IniFilename</c> at a sandbox-writable location, or disables persistence. The CWD on
+	/// iOS is the read-only app bundle, so the desktop default (<c>imgui.ini</c> in CWD) can't be written;
+	/// redirect to <c>Library/Application Support/&lt;bundleId&gt;/imgui.ini</c> (per §2.6 of the port plan).
+	/// When <see cref="ImGuiAppConfig.SaveIniSettings"/> is false, clear the filename so ImGui never reads
+	/// or writes it.
+	/// </summary>
+	/// <param name="io">The ImGui IO to configure.</param>
+	private static unsafe void ConfigureIniPersistence(ImGuiIOPtr io)
+	{
+		if (!Config.SaveIniSettings)
+		{
+			io.IniFilename = null;
+			return;
+		}
+
+		// LocalApplicationData == ~/Library/Application Support inside the app sandbox. Scope by bundle id
+		// to keep the file tidy, and create the directory since ImGui only writes the file, not the path.
+		string baseDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+		string? bundleId = NSBundle.MainBundle.BundleIdentifier;
+		string dir = string.IsNullOrEmpty(bundleId) ? baseDir : Path.Combine(baseDir, bundleId);
+		Directory.CreateDirectory(dir);
+		string iniPath = Path.Combine(dir, "imgui.ini");
+
+		// ImGui stores the char* and dereferences it lazily (NewFrame load, periodic auto-save,
+		// DestroyContext), so the UTF-8 buffer must outlive this call — allocate it for the process.
+		byte[] utf8 = Encoding.UTF8.GetBytes(iniPath);
+		iniFilenameHandle = Marshal.AllocHGlobal(utf8.Length + 1);
+		Marshal.Copy(utf8, 0, iniFilenameHandle, utf8.Length);
+		Marshal.WriteByte(iniFilenameHandle, utf8.Length, 0); // NUL terminator
+		io.IniFilename = (byte*)iniFilenameHandle;
+	}
+
+	/// <summary>
+	/// Builds the font atlas with parity to the desktop (Nerd Font default, merged emoji, extended
+	/// Unicode ranges) and uploads it to the GPU via the backend. Mirrors the desktop legacy-atlas path
+	/// (no <c>RendererHasTextures</c>): add fonts, build with <c>ImFontAtlasBuildMain</c>, upload the
+	/// RGBA32 pixels, hand the texture id back to ImGui with <c>SetTexID</c>, then free the CPU copy.
+	/// Glyphs are rasterized at the physical pixel size for the display scale and rendered back down via
+	/// <c>FontGlobalScale</c>, so text is crisp on a 2x/3x screen rather than an upscaled low-res atlas.
 	/// </summary>
 	/// <param name="io">The ImGui IO whose font atlas to build.</param>
 	private static unsafe void BuildFontAtlas(ImGuiIOPtr io)
 	{
-		// The context is freshly created here, so add the default font unconditionally; richer font
-		// configuration (sizes, emoji, Nerd Font ranges) shared with desktop is a later task.
-		io.Fonts.AddFontDefault();
+		// Rasterize at pointSize * scale (physical pixels); FontGlobalScale below brings rendering back
+		// to the logical point size so glyphs map 1:1 onto the high-DPI framebuffer.
+		float pixelSize = FontAppearance.DefaultFontPointSize * ScaleFactor;
+
+		uint* unicodeRanges = Config.EnableUnicodeSupport
+			? FontHelper.GetExtendedUnicodeRanges(io.Fonts)
+			: null;
+		byte[]? emojiBytes = ImGuiAppConfig.EmojiFont;
+		uint* emojiRanges = emojiBytes is not null ? FontHelper.GetEmojiRanges() : null;
+
+		// DefaultFonts (the bundled Nerd Font) first, then any user-supplied Fonts; merge the emoji
+		// glyphs onto each so coloured emoji render inline with text.
+		ImFontPtr? defaultFont = null;
+		foreach ((_, byte[] fontBytes) in Config.DefaultFonts.Concat(Config.Fonts))
+		{
+			ImFontPtr? font = FontHelper.AddCustomFont(io, fontBytes, pixelSize, unicodeRanges, mergeWithPrevious: false);
+			defaultFont ??= font;
+
+			if (emojiBytes is not null && emojiRanges is not null)
+			{
+				FontHelper.AddCustomFont(io, emojiBytes, pixelSize, emojiRanges, mergeWithPrevious: true);
+			}
+		}
+
+		if (defaultFont is { } resolved)
+		{
+			io.FontDefault = resolved;
+		}
+		else
+		{
+			// No configured font loaded (e.g. resources unavailable); fall back to ImGui's built-in font.
+			io.Fonts.AddFontDefault();
+		}
+
+		io.FontGlobalScale = 1f / ScaleFactor;
 
 		if (!io.Fonts.TexIsBuilt)
 		{

--- a/docs/plans/2026-05-28-ios-platform-port.md
+++ b/docs/plans/2026-05-28-ios-platform-port.md
@@ -39,6 +39,18 @@
 >   which crashes on the Apple ARM64 ABI when called through HexaGen's fixed function-pointer — use
 >   `ImGui.TextUnformatted`. On-device arm64 slices / an `xcframework` and a productized native-cimgui
 >   distribution (vs. the CI build-and-embed) remain follow-ups for shipping to real hardware.
+> - ✅ **Task 5 — touch + keyboard input** — `ImGuiAppViewController` `Touches*` overrides drive the
+>   single ImGui mouse (primary finger → `AddMousePosEvent`/`AddMouseButtonEvent`); `PressesBegan/Ended`
+>   map `UIKeyboardHidUsage` → `ImGuiKey` (`IOSKeyMap`) with modifiers + typed characters; a hidden
+>   `IUIKeyInput` first-responder (`SoftKeyboardView`) toggled by `io.WantTextInput` feeds the soft
+>   keyboard. `ImGuiApp.iOS.Input` bridges into ImGui IO. The smoke run exercises the input IO calls so
+>   their Apple-ARM64-ABI safety is CI-checked; touch/key *behaviour* still needs on-device verification.
+> - ✅ **Task 6 — DPI, fonts, ini redirect** (§2.4–2.6) — `ScaleFactor` from `UIScreen.Scale` (Task 4);
+>   the iOS font atlas now loads the bundled Nerd Font + merged NotoEmoji + extended Unicode ranges
+>   (shared `FontHelper`) rasterized at `pointSize × ScaleFactor` with `FontGlobalScale = 1/ScaleFactor`
+>   for crisp text on 2x/3x screens; `imgui.ini` redirects to `Library/Application Support/<bundleId>/`
+>   (or disabled when `SaveIniSettings` is false). The smoke run builds/uploads the real atlas and draws
+>   Unicode + emoji glyphs; crispness and `.ini` persistence-across-relaunch still need on-device checks.
 
 **Goal:** Make `ImGuiApp.Start(config)` actually run a Dear ImGui application on iOS (iPhone + iPad, iOS 15+) with parity for the OnStart / OnUpdate / OnRender / OnAppMenu lifecycle, fonts, textures, and DPI scaling.
 

--- a/scripts/build-cimgui-ios.sh
+++ b/scripts/build-cimgui-ios.sh
@@ -83,7 +83,12 @@ for s in "${SRCS[@]}"; do
 	o="$WORK/$(echo "$s" | tr '/.' '__').o"
 	echo "  CXX $s"
 	# -fvisibility=default keeps the cimgui C exports in the dylib's dynamic export table.
-	xcrun --sdk "$SDK" clang++ -O2 -std=c++17 -fvisibility=default -arch "$ARCH" -isysroot "$SYSROOT" "$MIN" \
+	# -DIMGUI_USE_WCHAR32 makes ImWchar 32-bit, matching Hexa.NET.ImGui's bindings (which pass uint
+	# codepoints) AND sizing ImFontGlyphRangesBuilder's bitset for the full Unicode range. Without it
+	# ImWchar defaults to 16-bit (max 0xFFFF), so AddChar() for emoji codepoints (0x1F300+) indexes the
+	# builder's UsedChars vector out of bounds and aborts (imgui.h operator[] assertion). Must be applied
+	# to every translation unit so imgui + cimgui agree on the ImWchar ABI.
+	xcrun --sdk "$SDK" clang++ -O2 -std=c++17 -fvisibility=default -DIMGUI_USE_WCHAR32 -arch "$ARCH" -isysroot "$SYSROOT" "$MIN" \
 		-I. -Iimgui -c "$s" -o "$o"
 	OBJS+=("$o")
 done

--- a/tests/ImGui.App.iOS.SmokeTest/Program.cs
+++ b/tests/ImGui.App.iOS.SmokeTest/Program.cs
@@ -25,6 +25,10 @@ ImGuiApp.Start(new ImGuiAppConfig
 		// ARM64 ABI (varargs are passed on the stack; the callee walks a bogus va_list).
 		// TextUnformatted maps to the non-variadic igTextUnformatted and is safe.
 		ImGui.TextUnformatted("iOS Metal renderer smoke test");
+		// Exercise the merged font atlas draw path: an accented Latin glyph (extended Unicode range)
+		// and an emoji glyph (merged NotoEmoji range). Missing glyphs are skipped, not fatal, so this
+		// can't fail the smoke on its own — its value is that building/uploading the real atlas didn't.
+		ImGui.TextUnformatted("Unicode café é ü ñ  emoji \U0001F600 \U0001F389");
 		ImGui.Button("Tap");
 		ImGui.End();
 


### PR DESCRIPTION
## Summary

Task 6 of the iOS port (`docs/plans/2026-05-28-ios-platform-port.md`, §2.4–2.6). `ScaleFactor` was already wired from `UIScreen.Scale` in Task 4 (#206); this PR completes **fonts** and **`imgui.ini` persistence**.

## Fonts (§2.5)

The iOS atlas previously loaded only ImGui's tiny built-in bitmap font. `BuildFontAtlas` now mirrors the desktop's essentials using the **shared** `FontHelper`:
- Loads the bundled **Nerd Font** (`Config.DefaultFonts`) + any user `Config.Fonts`
- **Merges NotoEmoji** glyphs inline
- Applies **extended Unicode ranges** (when `EnableUnicodeSupport`)
- Falls back to `AddFontDefault()` if no configured font resolves

**DPI crispness:** glyphs are rasterized at `DefaultFontPointSize × ScaleFactor` (physical pixels) and rendered back down with `io.FontGlobalScale = 1/ScaleFactor`, so text maps 1:1 onto the 2×/3× framebuffer instead of being an upscaled low-res atlas.

## `imgui.ini` redirect (§2.6)

CWD on iOS is the read-only app bundle. `ConfigureIniPersistence` points `io.IniFilename` at **`Library/Application Support/<bundleId>/imgui.ini`** (`LocalApplicationData`, created if missing) via a process-lifetime UTF-8 buffer — or clears it when `Config.SaveIniSettings` is false.

## Verification

The smoke app now **builds and uploads the real atlas** (Nerd Font + emoji + Unicode) and draws Unicode/emoji glyphs, so a crash in font loading/rasterization/upload on iOS arm64 is CI-caught (the same coverage strategy that caught the variadic `igText` issue). 

**Still needs on-device verification** (the headless simulator can't assert visual output): text *crispness* at 3×, emoji *appearance*, and `.ini` *persistence across relaunch*. Flagged honestly per the plan's Verify section.

## Notes
- Only iOS-gated code (`#if IOS` `ImGuiApp.iOS.Render.cs`) + the smoke app changed; **desktop is untouched**.
- `GlobalScale` (user zoom) interaction with font sizing is left as-is for v1 — out of Task 6's DPI/fonts/ini scope.

Plan status list updated to mark Tasks 5 & 6 complete.

https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG

---
_Generated by [Claude Code](https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG)_