### PR TITLE
feat(ios): app menu (iPad) + Stop() semantics + no-op surface (Task 7)

### DIFF
--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.NoOps.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.NoOps.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+#if IOS
+
+namespace ktsu.ImGui.App;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// iOS no-op surface for <see cref="ImGuiApp"/>: desktop window-management APIs that have no meaning
+/// on iOS, where the OS owns window visibility, sizing, and the app icon. They are kept on the public
+/// surface (matching the desktop signatures) so cross-platform consumer code compiles unchanged, and
+/// each logs a one-time warning on first use rather than silently doing nothing (§3 of the port plan).
+/// </summary>
+/// <remarks>
+/// Not stubbed: the overlay API (<c>EnableOverlay</c>/<c>DisableOverlay</c>/<c>SetOverlayGeometry</c>)
+/// and <c>SetWindowIcon</c>'s overlay siblings depend on desktop-only types (e.g. <c>OverlayCorner</c>
+/// in the iOS-excluded <c>OverlayWindow.cs</c>); the transparent click-through overlay is inherently a
+/// desktop concept and stays desktop-only. <see cref="ImGuiAppConfig.InitialWindowState"/> is likewise
+/// ignored on iOS — the OS controls window sizing.
+/// </remarks>
+public static partial class ImGuiApp
+{
+	/// <summary>Tracks which no-op APIs have already logged, so each warns at most once per process.</summary>
+	private static readonly HashSet<string> warnedNoOps = [];
+
+	/// <summary>Logs a one-time "no-op on iOS" warning for the named API.</summary>
+	/// <param name="api">The API name (used as the dedupe key and in the message).</param>
+	/// <param name="reason">Why the API does nothing on iOS.</param>
+	private static void WarnIosNoOp(string api, string reason)
+	{
+		if (warnedNoOps.Add(api))
+		{
+			DebugLogger.Log($"ImGuiApp.{api} is a no-op on iOS: {reason}");
+		}
+	}
+
+	/// <summary>
+	/// No-op on iOS: the operating system controls window visibility; an app cannot show its own window.
+	/// Logs a warning once. Present so cross-platform code that calls <see cref="Show"/> still compiles.
+	/// </summary>
+	public static void Show() =>
+		WarnIosNoOp(nameof(Show), "iOS controls window visibility; an app cannot show or hide its own window.");
+
+	/// <summary>
+	/// No-op on iOS: the operating system controls window visibility; an app cannot hide its own window.
+	/// Logs a warning once. Present so cross-platform code that calls <see cref="Hide"/> still compiles.
+	/// </summary>
+	public static void Hide() =>
+		WarnIosNoOp(nameof(Hide), "iOS controls window visibility; an app cannot show or hide its own window.");
+
+	/// <summary>
+	/// No-op on iOS: the app icon is provided by the app bundle (asset catalogue / Info.plist), not set
+	/// at runtime. Logs a warning once. Present so cross-platform code that calls
+	/// <see cref="SetWindowIcon(string)"/> still compiles.
+	/// </summary>
+	/// <param name="iconPath">Ignored on iOS; the bundle icon is used instead.</param>
+	public static void SetWindowIcon(string iconPath) =>
+		WarnIosNoOp(nameof(SetWindowIcon), $"the app icon comes from the iOS app bundle, not a runtime path ('{iconPath}').");
+}
+
+#endif

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.Render.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.Render.cs
@@ -198,10 +198,9 @@ public static partial class ImGuiApp
 			io.Fonts.AddFontDefault();
 		}
 
-		// FontScaleMain is the 1.92 replacement for the removed io.FontGlobalScale: a global multiplier
-		// on rendered font size. The atlas is rasterised at pointSize * scale, so scaling by 1/scale lays
-		// text out at the logical point size while keeping it pixel-crisp on the high-DPI framebuffer.
-		ImGui.GetStyle().FontScaleMain = 1f / ScaleFactor;
+		// FontScaleMain (the 1.92 successor to io.FontGlobalScale) is applied per-frame in
+		// TryBeginImGuiFrame so it tracks the user's GlobalScale; the atlas itself is just rasterised at
+		// pointSize * ScaleFactor here.
 
 		if (!io.Fonts.TexIsBuilt)
 		{
@@ -242,6 +241,12 @@ public static partial class ImGuiApp
 		io.DisplaySize = new Vector2((float)bounds.Width, (float)bounds.Height);
 		io.DisplayFramebufferScale = new Vector2(scale, scale);
 		io.DeltaTime = deltaSeconds > 0f ? deltaSeconds : 1f / 60f;
+
+		// The atlas is rasterised at pointSize * ScaleFactor; FontScaleMain renders it back down to the
+		// logical point size (1/ScaleFactor) and folds in the user's accessibility GlobalScale, so text is
+		// pixel-crisp at the default scale and grows with the Accessibility menu. GlobalScale defaults to
+		// 1, so this is exactly 1/ScaleFactor (the crisp default) unless the user changes it.
+		ImGui.GetStyle().FontScaleMain = GlobalScale / scale;
 
 		RenderView.MetalLayer.DrawableSize = new CGSize(bounds.Width * scale, bounds.Height * scale);
 

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
@@ -207,11 +207,63 @@ public static partial class ImGuiApp
 
 		Config.OnUpdate?.Invoke(deltaSeconds);
 		Invoker?.DoInvokes();
+
+		if (frameBegun)
+		{
+			RenderAppMenu();
+		}
+
 		Config.OnRender?.Invoke(deltaSeconds);
 
 		if (frameBegun)
 		{
 			EndImGuiFrameAndRender();
+		}
+	}
+
+	/// <summary>The discrete accessibility UI-scale steps offered in the app menu (75%–200%).</summary>
+	private static readonly float[] AccessibilityScales = [0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f];
+
+	/// <summary>
+	/// Renders the application menu bar. On iPad this shows the consumer's
+	/// <see cref="ImGuiAppConfig.OnAppMenu"/> plus an accessibility UI-scale submenu, mirroring the
+	/// desktop main menu bar. iPhone has no main-menu-bar paradigm and little vertical space, so this is
+	/// a no-op there (§2.3 of the port plan). Must be called inside an active ImGui frame.
+	/// </summary>
+	private static void RenderAppMenu()
+	{
+		if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Pad)
+		{
+			return; // iPhone: no app menu bar.
+		}
+
+		if (ImGui.BeginMainMenuBar())
+		{
+			Config.OnAppMenu?.Invoke();
+			RenderAccessibilityMenu();
+			ImGui.EndMainMenuBar();
+		}
+	}
+
+	/// <summary>Renders the accessibility UI-scale submenu, driving <see cref="SetGlobalScale"/>.</summary>
+	private static void RenderAccessibilityMenu()
+	{
+		if (ImGui.BeginMenu("Accessibility"))
+		{
+			// TextUnformatted, not Text: ImGui.Text is the variadic igText, which crashes on the Apple
+			// ARM64 ABI through HexaGen's fixed function-pointer.
+			ImGui.TextUnformatted("UI Scale:");
+			ImGui.Separator();
+
+			foreach (float scale in AccessibilityScales)
+			{
+				if (ImGui.MenuItem($"{(int)(scale * 100)}%", "", Math.Abs(GlobalScale - scale) < 0.01f))
+				{
+					SetGlobalScale(scale);
+				}
+			}
+
+			ImGui.EndMenu();
 		}
 	}
 

--- a/docs/plans/2026-05-28-ios-platform-port.md
+++ b/docs/plans/2026-05-28-ios-platform-port.md
@@ -51,6 +51,13 @@
 >   for crisp text on 2x/3x screens; `imgui.ini` redirects to `Library/Application Support/<bundleId>/`
 >   (or disabled when `SaveIniSettings` is false). The smoke run builds/uploads the real atlas and draws
 >   Unicode + emoji glyphs; crispness and `.ini` persistence-across-relaunch still need on-device checks.
+> - ✅ **Task 7 — app menu, Stop(), no-op surface** (§2.3) — `Tick` renders `Config.OnAppMenu` in a main
+>   menu bar on iPad (with an accessibility UI-scale submenu wired to `GlobalScale` → per-frame
+>   `FontScaleMain`); iPhone is a no-op (no menu-bar paradigm). `Stop()` already logs the "iOS apps
+>   shouldn't self-terminate" warning before requesting exit. Desktop window APIs with no iOS meaning
+>   (`Show`/`Hide`/`SetWindowIcon`) are kept on the public surface as one-time-warning no-ops so
+>   cross-platform code compiles; the overlay API stays desktop-only (its `OverlayCorner` type lives in
+>   the iOS-excluded `OverlayWindow.cs`). The smoke run exercises the menu-bar ImGui calls for ABI safety.
 
 **Goal:** Make `ImGuiApp.Start(config)` actually run a Dear ImGui application on iOS (iPhone + iPad, iOS 15+) with parity for the OnStart / OnUpdate / OnRender / OnAppMenu lifecycle, fonts, textures, and DPI scaling.
 

--- a/tests/ImGui.App.iOS.SmokeTest/Program.cs
+++ b/tests/ImGui.App.iOS.SmokeTest/Program.cs
@@ -32,6 +32,20 @@ ImGuiApp.Start(new ImGuiAppConfig
 		ImGui.Button("Tap");
 		ImGui.End();
 
+		// Exercise the app-menu draw path (BeginMainMenuBar/BeginMenu/MenuItem) so its ImGui calls are
+		// CI-checked on the Apple ARM64 ABI. ImGuiApp.RenderAppMenu only renders on iPad, and the smoke
+		// sim is an iPhone, so call these directly here rather than relying on that path.
+		if (ImGui.BeginMainMenuBar())
+		{
+			if (ImGui.BeginMenu("Smoke"))
+			{
+				ImGui.MenuItem("Item", string.Empty, false);
+				ImGui.EndMenu();
+			}
+
+			ImGui.EndMainMenuBar();
+		}
+
 		// CI can't inject real touches/keys into the headless simulator, so exercise the ImGui input
 		// IO calls the iOS input bridge makes (pointer, button, key, modifier, text, wheel). This
 		// verifies they don't crash on the Apple ARM64 ABI the way the variadic igText did.


### PR DESCRIPTION
## Summary

Task 7 of the iOS port (`docs/plans/2026-05-28-ios-platform-port.md`, §2.3): the app menu, `Stop()` semantics, and a consistent no-op surface for desktop window APIs.

## App menu (iPad)
`Tick` now renders `Config.OnAppMenu` inside a main menu bar **on iPad**, alongside an **Accessibility** UI-scale submenu (75%–200%) wired to `SetGlobalScale`. **iPhone is a no-op** — no main-menu-bar paradigm and little vertical space (idiom check via `UIDevice.CurrentDevice.UserInterfaceIdiom`).

To make the accessibility scale actually do something, `GlobalScale` now feeds the **per-frame `FontScaleMain`** (`GlobalScale / ScaleFactor`) instead of the fixed `1/ScaleFactor` set at atlas-build time. `GlobalScale` defaults to `1`, so **default rendering is byte-for-byte unchanged** — only the user picking a scale changes anything.

## `Stop()`
Already logs the "iOS apps shouldn't self-terminate; the OS owns the lifecycle" warning before requesting exit via the `terminateWithSuccess` selector. Left as-is (audited, no change needed).

## No-op surface
`Show()`, `Hide()`, and `SetWindowIcon(string)` are kept on the public iOS surface (matching the desktop signatures) as **one-time-warning no-ops** (`ImGuiApp.iOS.NoOps.cs`), so cross-platform consumer code **compiles unchanged** and gets a clear log line on first use rather than silent nothing.

**Deliberately not stubbed:** the overlay API (`EnableOverlay`/`DisableOverlay`/`SetOverlayGeometry`) — its `OverlayCorner` type lives in the iOS-excluded `OverlayWindow.cs`, and a transparent click-through overlay is inherently a desktop concept. `InitialWindowState` remains ignored on iOS (the OS controls window sizing).

## Verification
The smoke app now exercises the menu-bar ImGui calls (`BeginMainMenuBar`/`BeginMenu`/`MenuItem`) **directly** in `OnRender`, so their Apple-ARM64-ABI safety is CI-checked even though the iPhone smoke sim skips the iPad-only `RenderAppMenu` path (the same coverage approach that caught the variadic `igText` and the emoji `ImWchar` bugs). Menu *appearance* on a real iPad is the on-device follow-up CI can't assert.

Only iOS-gated code (`#if IOS`) + the smoke app changed; desktop is untouched. Plan status list updated (Task 7 complete).

https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG

---
_Generated by [Claude Code](https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG)_