### PR TITLE
feat(ios): AutoDiscoverExtensions flag (Task 8, part 1)

### DIFF
--- a/ImGui.App/ImGuiAppConfig.cs
+++ b/ImGui.App/ImGuiAppConfig.cs
@@ -124,6 +124,17 @@ public class ImGuiAppConfig
 	public bool SaveIniSettings { get; init; } = true;
 
 	/// <summary>
+	/// Gets or sets a value indicating whether to auto-discover ImGui extensions (ImGuizmo, ImNodes,
+	/// ImPlot) by reflecting over loaded assemblies at startup. Default is true.
+	/// <para>
+	/// On iOS this is effectively always off: reflective assembly scanning is unfriendly to the AOT
+	/// trimmer, so the iOS build excludes the extension manager entirely and never auto-discovers,
+	/// regardless of this value. iOS consumers that want an extension must wire it up manually.
+	/// </para>
+	/// </summary>
+	public bool AutoDiscoverExtensions { get; init; } = true;
+
+	/// <summary>
 	/// Gets or sets the performance settings for throttled rendering.
 	/// </summary>
 	public ImGuiAppPerformanceSettings PerformanceSettings { get; init; } = new();

--- a/ImGui.App/ImGuiController/ImGuiController.cs
+++ b/ImGui.App/ImGuiController/ImGuiController.cs
@@ -127,9 +127,15 @@ internal sealed class ImGuiController : IRendererBackend
 
 		ImGui.StyleColorsDark();
 
-		ImGuiExtensionManager.Initialize();
-		ImGuiExtensionManager.SetImGuiContext();
-		ImGuiExtensionManager.CreateExtensionContexts();
+		// Auto-discovery reflects over loaded assemblies to find ImGuizmo/ImNodes/ImPlot; consumers can
+		// opt out via AutoDiscoverExtensions. When off, the per-frame BeginFrame and Cleanup calls below
+		// are harmless no-ops (their delegates stay null).
+		if (ImGuiApp.Config.AutoDiscoverExtensions)
+		{
+			ImGuiExtensionManager.Initialize();
+			ImGuiExtensionManager.SetImGuiContext();
+			ImGuiExtensionManager.CreateExtensionContexts();
+		}
 	}
 
 	internal void BeginFrame()


### PR DESCRIPTION
## Summary

Task 8, part 1 of a short sequence (§2.7 of the iOS port plan). Adds an opt-out for the reflection-based extension auto-discovery.

- New `ImGuiAppConfig.AutoDiscoverExtensions` (default `true`).
- The desktop `ImGuiController` now gates `ImGuiExtensionManager.Initialize/SetImGuiContext/CreateExtensionContexts` on the flag. When off, the per-frame `BeginFrame` and `Cleanup` calls are harmless no-ops (their delegates stay null).
- On iOS the extension manager is already excluded from the build, so auto-discovery never runs there regardless of the flag — the property is documented accordingly. AOT-friendly manual registration on iOS is future work.

Verified with a local desktop build (`net10.0`, 0 errors).

## What's next in the sequence
- **PR 2:** iOS public texture loading (`GetOrLoadTexture`/`TryGetTexture`/`DeleteTexture` via the Metal backend + ImageSharp) — the demo shows images and this was deferred from Task 6.
- **PR 3:** `ImGuiAppDemo` iOS target — app bundle + native-cimgui embedding + graceful degradation for the absent extensions/node-editor, plus an AOT pass.

https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG

---
_Generated by [Claude Code](https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG)_