### PR TITLE
feat(ios): curated ImGuiAppDemo.iOS showcase + simulator CI (Task 8, part 3)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -242,15 +242,17 @@ jobs:
         run: dotnet build ImGui.App/ImGui.App.csproj -c Release -p:TargetFrameworks=net10.0-ios -p:RuntimeIdentifiers= -p:EnforceCodeStyleInBuild=false --no-restore
 
   ios-simulator:
-    # Runtime verification: build the headless smoke app for the iOS simulator, boot a sim,
-    # launch it, and assert the lifecycle ticks (the app prints a marker and exits after N frames
-    # via the IMGUIAPP_IOS_SMOKE_FRAMES hook). Runs in parallel; does not gate release.
+    # Runtime verification: build the headless smoke app AND the curated ImGuiAppDemo.iOS for the
+    # simulator, boot a sim, launch each, and assert the lifecycle ticks (the app prints a marker and
+    # exits after N frames via the IMGUIAPP_IOS_SMOKE_FRAMES hook). Runs in parallel; does not gate
+    # release. Building+launching two apps after a cold cimgui cache approaches the old 30-min cap, so
+    # the budget is 50 min (a warm-cache run is ~20).
     name: iOS Simulator Smoke Test
     # The .NET 10 iOS workload (Microsoft.iOS 26.5) requires Xcode 26.5 to build a runnable .app.
     # macos-15 only carries up to Xcode 26.3; macos-26 (Tahoe) ships the matching Xcode 26.5+.
     # (The compile-only ios-build job needs no Xcode, so it stays on macos-14.)
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 50
     # HARD GATE: the .NET 10 + Xcode 26 symlinked-developer-dir bug that broke native linking
     # (`xcodebuild -find` -> errno=Invalid argument) is worked around by the "Resolve and pin the
     # real Xcode" step below (readlink -f + xcode-select/DEVELOPER_DIR pin; dotnet/macios#21762), so

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -397,6 +397,39 @@ jobs:
             xcrun simctl launch --console-pty --terminate-running-process "$SIM_UDID" dev.ktsu.imguiapp.smoketest 2>&1 | tee /tmp/smoke.log
           grep -q "IMGUIAPP_IOS_SMOKE_OK" /tmp/smoke.log
 
+      # --- Curated iOS demo (examples/ImGuiAppDemo.iOS) ---
+      # A richer showcase than the headless smoke app: widgets, Unicode/emoji, a GPU texture, animation,
+      # and the input/IO surface, all using the iOS-safe non-variadic ImGui subset. It reuses this job's
+      # booted simulator, cimgui dylib, and the IMGUIAPP_IOS_SMOKE_FRAMES hook (baked into ImGui.App's
+      # view controller), so the same minimal SDK + restore flags as the smoke app apply.
+      - name: Restore demo app (net10.0-ios, simulator RID)
+        run: dotnet restore examples/ImGuiAppDemo.iOS/ImGuiAppDemo.iOS.csproj -p:TargetFrameworks=net10.0-ios -p:RuntimeIdentifiers= -p:RuntimeFrameworkVersion= -p:UseFloatingTargetPlatformVersion=true -r iossimulator-arm64
+
+      - name: Build demo app (.app for simulator)
+        run: dotnet build examples/ImGuiAppDemo.iOS/ImGuiAppDemo.iOS.csproj -c Release -f net10.0-ios -r iossimulator-arm64 -p:RuntimeIdentifiers= -p:RuntimeFrameworkVersion= -p:UseFloatingTargetPlatformVersion=true -p:EnforceCodeStyleInBuild=false --no-restore
+
+      - name: Locate built demo .app bundle
+        id: finddemo
+        run: |
+          set -euxo pipefail
+          APP=$(find examples/ImGuiAppDemo.iOS/bin -type d -name "*.app" | head -1)
+          test -n "$APP"
+          echo "app=$APP" >> "$GITHUB_OUTPUT"
+
+      - name: Embed cimgui.dylib into the demo .app bundle
+        run: cp "$RUNNER_TEMP/cimgui.dylib" "${{ steps.finddemo.outputs.app }}/cimgui.dylib"
+
+      - name: Install, launch, and assert the demo ticked + uploaded its texture
+        run: |
+          set -euxo pipefail
+          xcrun simctl install "$SIM_UDID" "${{ steps.finddemo.outputs.app }}"
+          SIMCTL_CHILD_IMGUIAPP_IOS_SMOKE_FRAMES=30 \
+            xcrun simctl launch --console-pty --terminate-running-process "$SIM_UDID" dev.ktsu.imguiapp.demo 2>&1 | tee /tmp/demo.log
+          # The lifecycle ticked N frames without crashing in the Metal pipeline...
+          grep -q "IMGUIAPP_IOS_SMOKE_OK" /tmp/demo.log
+          # ...and the bundled image decoded (ImageSharp) + uploaded on Metal — PR-2 textures end-to-end.
+          grep -q "IMGUIAPP_DEMO logo loaded" /tmp/demo.log
+
       - name: Cleanup simulator
         if: always()
         run: xcrun simctl delete "${SIM_UDID:-imguiapp-smoke}" || true

--- a/examples/ImGuiAppDemo.iOS/ImGuiAppDemo.iOS.csproj
+++ b/examples/ImGuiAppDemo.iOS/ImGuiAppDemo.iOS.csproj
@@ -1,0 +1,52 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <EnableSourceLink>false</EnableSourceLink>
+    <RootNamespace>ktsu.ImGui.Examples.App.iOS</RootNamespace>
+    <AssemblyName>ImGuiAppDemoiOS</AssemblyName>
+
+    <!-- Like the smoke app: this is an iOS application only on macOS (where the iOS workload exists).
+         On any other OS it degrades to a plain net10.0 console exe so the Windows CI pipeline can still
+         restore/build it without the iOS workload. The simulator job always builds -f net10.0-ios.
+         We deliberately use the plain Microsoft.NET.Sdk (not ktsu.Sdk.App) because the desktop-app SDK
+         forces a RID matrix that fights the iOS build; the smoke app proved this minimal SDK works. -->
+    <TargetFramework Condition="$([MSBuild]::IsOSPlatform('OSX'))">net10.0-ios</TargetFramework>
+    <TargetFramework Condition="!$([MSBuild]::IsOSPlatform('OSX'))">net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
+    <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+    <ApplicationTitle>ImGuiApp iOS Demo</ApplicationTitle>
+    <ApplicationId>dev.ktsu.imguiapp.demo</ApplicationId>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ImGui.App\ImGui.App.csproj" />
+    <!-- For string.As<AbsoluteFilePath>() when resolving the bundled image path at runtime. -->
+    <PackageReference Include="ktsu.Semantics.Paths" />
+    <PackageReference Include="ktsu.Semantics.Strings" />
+  </ItemGroup>
+
+  <!-- The texture showcase loads this image at runtime via ImGuiApp.GetOrLoadTexture. On iOS a
+       BundleResource lands in the .app root, which is AppContext.BaseDirectory, so the same path
+       resolution the desktop demo uses works here. On other OSes copy it next to the exe. -->
+  <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
+    <BundleResource Include="icon.png" />
+  </ItemGroup>
+  <ItemGroup Condition="!$(TargetFramework.Contains('-ios'))">
+    <Content Include="icon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <!-- Note: as with the smoke app, the cimgui dylib is NOT linked via a NativeReference (silently
+       ignored by Microsoft.NET.Sdk apps). The simulator CI job copies cimgui.dylib into the built
+       .app bundle and the iOS native-library resolver dlopens it by absolute bundle path. -->
+
+</Project>

--- a/examples/ImGuiAppDemo.iOS/Info.plist
+++ b/examples/ImGuiAppDemo.iOS/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>ImGuiAppDemo</string>
+	<key>CFBundleDisplayName</key>
+	<string>ImGuiApp iOS Demo</string>
+	<key>CFBundleIdentifier</key>
+	<string>dev.ktsu.imguiapp.demo</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>15.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/examples/ImGuiAppDemo.iOS/Program.cs
+++ b/examples/ImGuiAppDemo.iOS/Program.cs
@@ -1,0 +1,206 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+using ktsu.ImGui.App;
+using ktsu.Semantics.Paths;
+using ktsu.Semantics.Strings;
+
+// A curated iOS showcase for ImGui.App. Unlike the full desktop ImGuiAppDemo (whose ImGuizmo/ImNodes/
+// ImPlot tabs and overlay window are desktop-only, and whose ~200 ImGui.Text/BulletText/TextColored
+// calls map to variadic cimgui entry points that crash on the Apple ARM64 ABI), this app sticks to the
+// iOS-safe subset and demonstrates what does work on-device: widgets, Unicode/emoji glyphs, GPU textures
+// (validating ImGuiApp.GetOrLoadTexture on Metal), animation, and the input/IO surface.
+//
+// THE GOLDEN RULE for iOS text: never call the variadic formatters (ImGui.Text, TextColored, TextWrapped,
+// BulletText, SetTooltip, ...). Format with C# string interpolation and pass the result to the
+// non-variadic ImGui.TextUnformatted. For color/wrapping, push the relevant state and TextUnformatted.
+
+// --- Captured demo state (top-level locals are hoisted into the OnRender closure) ---
+float elapsed = 0f;
+int clickCount = 0;
+bool checkboxValue = true;
+float sliderValue = 0.4f;
+Vector3 tint = new(0.26f, 0.59f, 0.98f);
+int comboIndex = 1;
+int radioIndex = 0;
+long frameCount = 0;
+
+// The bundled logo texture, loaded lazily on the first frame (guarded so a missing asset degrades
+// gracefully instead of crashing the showcase).
+ImGuiAppTextureInfo? logo = null;
+bool logoTried = false;
+
+ImGuiApp.Start(new ImGuiAppConfig
+{
+	Title = "ImGuiApp iOS Demo",
+	// Auto-discovery reflects over assemblies for ImGuizmo/ImNodes/ImPlot — there are no native
+	// extensions on iOS, so opt out (it is also a no-op there, but this documents intent).
+	AutoDiscoverExtensions = false,
+
+	OnRender = dt =>
+	{
+		elapsed += dt;
+		frameCount++;
+
+		// Load the logo on the first frame. On iOS the BundleResource lands in the .app root, which is
+		// AppContext.BaseDirectory, so the desktop demo's path resolution works unchanged.
+		if (!logoTried)
+		{
+			logoTried = true;
+			AbsoluteFilePath logoPath = AppContext.BaseDirectory.As<AbsoluteDirectoryPath>() / "icon.png".As<FileName>();
+			if (File.Exists(logoPath))
+			{
+				// ImageSharp decode + Metal upload. If iOS trimming/AOT breaks the decode path this throws,
+				// which surfaces the full stacktrace in the CI launch log and fails the "logo loaded"
+				// assert below — the signal we want, rather than silently shipping a broken texture path.
+				logo = ImGuiApp.GetOrLoadTexture(logoPath);
+				Console.WriteLine($"IMGUIAPP_DEMO logo loaded {logo.Width}x{logo.Height}");
+			}
+			else
+			{
+				Console.WriteLine("IMGUIAPP_DEMO logo asset not found in bundle");
+			}
+		}
+
+		// Fill the viewport so it reads like a real app rather than a floating window.
+		ImGuiViewportPtr viewport = ImGui.GetMainViewport();
+		ImGui.SetNextWindowPos(viewport.WorkPos);
+		ImGui.SetNextWindowSize(viewport.WorkSize);
+		ImGui.Begin("ImGuiApp iOS Demo",
+			ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoBringToFrontOnFocus);
+
+		// Draw the logo as an always-visible header thumbnail (not hidden behind an inactive tab) so the
+		// ImGui.Image user-texture draw path is exercised every frame, including in the headless CI run.
+		if (logo is not null)
+		{
+			ImGui.Image(logo.TextureRef, new Vector2(24f, 24f));
+			ImGui.SameLine();
+		}
+
+		ImGui.TextUnformatted("Dear ImGui on iOS \U0001F4F1  —  Metal renderer + ktsu.ImGui.App");
+		ImGui.Separator();
+
+		if (ImGui.BeginTabBar("DemoTabs"))
+		{
+			if (ImGui.BeginTabItem("Widgets"))
+			{
+				if (ImGui.Button("Tap me"))
+				{
+					clickCount++;
+				}
+
+				ImGui.SameLine();
+				ImGui.TextUnformatted($"clicked {clickCount}x");
+
+				_ = ImGui.Checkbox("Enable feature", ref checkboxValue);
+				_ = ImGui.SliderFloat("Amount", ref sliderValue, 0f, 1f, "%.2f");
+				_ = ImGui.ColorEdit3("Tint", ref tint);
+				_ = ImGui.Combo("Mode", ref comboIndex, "Off\0Balanced\0Performance\0");
+
+				ImGui.TextUnformatted("Quality:");
+				ImGui.SameLine();
+				if (ImGui.RadioButton("Low", radioIndex == 0)) { radioIndex = 0; }
+				ImGui.SameLine();
+				if (ImGui.RadioButton("Medium", radioIndex == 1)) { radioIndex = 1; }
+				ImGui.SameLine();
+				if (ImGui.RadioButton("High", radioIndex == 2)) { radioIndex = 2; }
+
+				ImGui.EndTabItem();
+			}
+
+			if (ImGui.BeginTabItem("Text"))
+			{
+				ImGui.SeparatorText("Unicode & emoji");
+				ImGui.TextUnformatted("Accented Latin: café  naïve  jalapeño  Zürich");
+				ImGui.TextUnformatted("Symbols: → ★ ± ∞ € £ ¥");
+				ImGui.TextUnformatted("Emoji: \U0001F600 \U0001F389 \U0001F680 \U0001F4A1 \U0001F525");
+
+				ImGui.SeparatorText("Wrapped & colored (the iOS-safe way)");
+				// TextWrapped is variadic; push a wrap position and use TextUnformatted instead.
+				ImGui.PushTextWrapPos(ImGui.GetCursorPos().X + ImGui.GetContentRegionAvail().X);
+				ImGui.TextUnformatted(
+					"This paragraph wraps without ImGui.TextWrapped. The same trick applies to color: " +
+					"push ImGuiCol.Text, draw TextUnformatted, then pop — avoiding the variadic TextColored.");
+				ImGui.PopTextWrapPos();
+
+				// TextColored is variadic; emulate it with a pushed text color + TextUnformatted.
+				ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(tint.X, tint.Y, tint.Z, 1f));
+				ImGui.TextUnformatted("This line is tinted by the Widgets-tab color picker.");
+				ImGui.PopStyleColor();
+
+				ImGui.EndTabItem();
+			}
+
+			if (ImGui.BeginTabItem("Image"))
+			{
+				if (logo is not null)
+				{
+					ImGui.TextUnformatted($"GPU texture {logo.Width}x{logo.Height} uploaded via the Metal backend:");
+					float side = MathF.Min(192f, ImGui.GetContentRegionAvail().X);
+					ImGui.Image(logo.TextureRef, new Vector2(side, side));
+				}
+				else
+				{
+					ImGui.TextUnformatted("Logo texture is not available (asset missing from bundle).");
+				}
+
+				ImGui.EndTabItem();
+			}
+
+			if (ImGui.BeginTabItem("Animation"))
+			{
+				float pulse = (MathF.Sin(elapsed * 2f) + 1f) * 0.5f;
+				ImGui.TextUnformatted($"t = {elapsed:F1}s");
+				ImGui.ProgressBar(pulse, new Vector2(-1f, 0f), $"{pulse * 100f:F0}%");
+
+				// A pulsing button: hue cycles with time, all via non-variadic style pushes.
+				Vector4 hue = HsvToRgb(elapsed * 0.15f % 1f, 0.6f, 0.9f);
+				ImGui.PushStyleColor(ImGuiCol.Button, hue);
+				ImGui.Button("Animated", new Vector2(-1f, 40f));
+				ImGui.PopStyleColor();
+
+				ImGui.EndTabItem();
+			}
+
+			if (ImGui.BeginTabItem("Input / IO"))
+			{
+				ImGuiIOPtr io = ImGui.GetIO();
+				ImGui.TextUnformatted($"Display: {io.DisplaySize.X:F0} x {io.DisplaySize.Y:F0}");
+				ImGui.TextUnformatted($"Mouse / touch: {io.MousePos.X:F0}, {io.MousePos.Y:F0}");
+				ImGui.TextUnformatted($"Frame: {frameCount}");
+				ImGui.TextUnformatted($"Framerate: {io.Framerate:F1} FPS");
+				ImGui.TextUnformatted("Touch and drag anywhere to drive the mouse IO above.");
+
+				ImGui.EndTabItem();
+			}
+
+			ImGui.EndTabBar();
+		}
+
+		ImGui.End();
+	},
+});
+
+// Minimal HSV->RGB for the animated button tint, avoiding any extra dependency.
+static Vector4 HsvToRgb(float h, float s, float v)
+{
+	float i = MathF.Floor(h * 6f);
+	float f = (h * 6f) - i;
+	float p = v * (1f - s);
+	float q = v * (1f - (f * s));
+	float t = v * (1f - ((1f - f) * s));
+	return ((int)i % 6) switch
+	{
+		0 => new Vector4(v, t, p, 1f),
+		1 => new Vector4(q, v, p, 1f),
+		2 => new Vector4(p, v, t, 1f),
+		3 => new Vector4(p, q, v, 1f),
+		4 => new Vector4(t, p, v, 1f),
+		_ => new Vector4(v, p, q, 1f),
+	};
+}

--- a/examples/ImGuiAppDemo.iOS/icon.png
+++ b/examples/ImGuiAppDemo.iOS/icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4e44138de3ba76f7cb223da53de6bee3e72b9df281bec812b86b2da6f1aaf37
+size 16069


### PR DESCRIPTION
## Summary

Task 8, part 3 — lands **"the demo runs on iOS"** as a purpose-built example (the option you picked), leaving the desktop `ImGuiAppDemo` untouched.

The full desktop demo can't run on iOS as-is: its ImGuizmo/ImNodes/ImPlot tabs and overlay window are desktop-only, and **~200 of its `ImGui.Text`/`BulletText`/`TextColored` calls map to variadic cimgui entry points that crash on the Apple ARM64 ABI**. A faithful port would mean rewriting all those call sites — deferred.

Instead, `examples/ImGuiAppDemo.iOS` is a focused showcase of what *works* on-device, using only the iOS-safe non-variadic ImGui subset:

- **Widgets** — button / checkbox / slider / color picker / combo / radio
- **Text** — Unicode + emoji glyphs; wrapped & colored text done the safe way (pushed wrap-pos / `PushStyleColor` + `TextUnformatted`, never the variadic `TextWrapped`/`TextColored`)
- **Image** — a GPU texture loaded from a bundled PNG → validates `GetOrLoadTexture` + `ImGui.Image` **end-to-end on Metal** (exercises PR #212), drawn as an always-visible header thumbnail so it runs even headless
- **Animation** — time-driven progress bar + hue-cycling button
- **Input / IO** — display size, touch position, frame count, FPS

> The golden rule, enforced throughout: format with C# interpolation → `ImGui.TextUnformatted`; push state for color/wrap. No variadic formatters.

It uses the plain `Microsoft.NET.Sdk` (the smoke app's proven pattern, avoiding `ktsu.Sdk.App`'s RID matrix) and sets `AutoDiscoverExtensions = false` (PR #211).

## CI
The existing **iOS Simulator** job now also builds the demo `.app`, embeds `cimgui.dylib`, and launches it via the `IMGUIAPP_IOS_SMOKE_FRAMES` hook — asserting both the lifecycle marker **and** an `IMGUIAPP_DEMO logo loaded` marker (the texture path). Reuses the same booted simulator + cimgui build (no native double-build). The project is left out of `ImGui.sln` (like the smoke app) so the Windows pipeline ignores it.

## Verification
Degraded `net10.0` build compiles locally (0 errors), which validates every ImGui/texture/`.As` call against the real `ImGui.App`. The iOS build + simulator run are validated by CI — this is where the AOT/trimming-of-ImageSharp risk (if any) surfaces; the texture load deliberately propagates so a failure shows the stacktrace and fails the marker assert rather than shipping silently.

Builds on #211 (flag) and #212 (textures), both merged.

https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG

---
_Generated by [Claude Code](https://claude.ai/code/session_015Bcao5k9N7bsUeoiHRuKZG)_