### PR TITLE
Add embedded-window hosting (StartEmbedded) and audio widgets

### DIFF
--- a/ImGui.App/IImGuiAppSession.cs
+++ b/ImGui.App/IImGuiAppSession.cs
@@ -22,22 +22,22 @@ public interface IImGuiAppSession : IDisposable
 	/// </summary>
 	/// <param name="width">The new width, in pixels.</param>
 	/// <param name="height">The new height, in pixels.</param>
-	void Resize(int width, int height);
+	public void Resize(int width, int height);
 
 	/// <summary>
 	/// Forwards a focus change from the host.
 	/// </summary>
 	/// <param name="focused"><see langword="true"/> if the host gave the editor focus; otherwise <see langword="false"/>.</param>
-	void Focus(bool focused);
+	public void Focus(bool focused);
 
 	/// <summary>
 	/// Gets the native handle of the session's own window (the child reparented under the host), or
 	/// <c>0</c> if it has not been created yet.
 	/// </summary>
-	nint NativeHandle { get; }
+	public nint NativeHandle { get; }
 
 	/// <summary>
 	/// Gets a value indicating whether the session's render loop is currently running.
 	/// </summary>
-	bool IsRunning { get; }
+	public bool IsRunning { get; }
 }

--- a/ImGui.App/IImGuiAppSession.cs
+++ b/ImGui.App/IImGuiAppSession.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.App;
+
+/// <summary>
+/// A handle to a non-blocking <see cref="ImGuiApp"/> session started with
+/// <see cref="ImGuiApp.StartEmbedded(ImGuiAppConfig)"/>.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="ImGuiApp.Start(ImGuiAppConfig)"/>, which runs a blocking render loop on the calling
+/// thread, an embedded session runs its loop on a dedicated UI thread that it owns. The host drives the
+/// session through this interface — forwarding resize and focus changes and disposing it to tear the
+/// window down — while requests are marshalled onto the UI thread. Disposing the session stops the loop,
+/// detaches the window from its host, and releases the render resources.
+/// </remarks>
+public interface IImGuiAppSession : IDisposable
+{
+	/// <summary>
+	/// Forwards a new size from the host so the embedded window and its viewport can follow.
+	/// </summary>
+	/// <param name="width">The new width, in pixels.</param>
+	/// <param name="height">The new height, in pixels.</param>
+	void Resize(int width, int height);
+
+	/// <summary>
+	/// Forwards a focus change from the host.
+	/// </summary>
+	/// <param name="focused"><see langword="true"/> if the host gave the editor focus; otherwise <see langword="false"/>.</param>
+	void Focus(bool focused);
+
+	/// <summary>
+	/// Gets the native handle of the session's own window (the child reparented under the host), or
+	/// <c>0</c> if it has not been created yet.
+	/// </summary>
+	nint NativeHandle { get; }
+
+	/// <summary>
+	/// Gets a value indicating whether the session's render loop is currently running.
+	/// </summary>
+	bool IsRunning { get; }
+}

--- a/ImGui.App/ImGui.App.csproj
+++ b/ImGui.App/ImGui.App.csproj
@@ -42,6 +42,9 @@
 
   <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
     <Compile Remove="ImGuiApp.cs" />
+    <!-- Embedded/non-blocking hosting reparents a Silk.NET window via Win32 NativeMethods; the iOS
+         stub (ImGuiApp.iOS.cs) provides a throwing StartEmbedded instead, so this partial is excluded. -->
+    <Compile Remove="ImGuiApp.Embedded.cs" />
     <!-- Per-region blend modes drive the desktop OpenGL renderer (ImGuiController.SetBlendMode);
          the iOS stub has no such backend, so this partial is excluded like ImGuiApp.cs above. -->
     <Compile Remove="ImGuiAppBlend.cs" />

--- a/ImGui.App/ImGuiApp.Embedded.cs
+++ b/ImGui.App/ImGuiApp.Embedded.cs
@@ -1,0 +1,219 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.App;
+
+using System.Threading;
+using Silk.NET.Windowing;
+
+/// <summary>
+/// Embedded / non-blocking hosting support for <see cref="ImGuiApp"/>.
+/// </summary>
+public static partial class ImGuiApp
+{
+	/// <summary>
+	/// Starts the ImGui application without blocking the calling thread, returning a session the host can
+	/// drive.
+	/// </summary>
+	/// <param name="config">The configuration settings for the ImGui application.</param>
+	/// <returns>An <see cref="IImGuiAppSession"/> controlling the running session.</returns>
+	/// <remarks>
+	/// The render loop runs on a dedicated UI thread owned by the session rather than on the caller, which
+	/// is what allows a plugin host to keep control of its own thread. With
+	/// <see cref="ImGuiAppConfig.WindowHost"/> set to <see cref="ImGuiAppWindowHost.Standalone"/> this is a
+	/// non-blocking floating window; with <see cref="ImGuiAppWindowHost.EmbeddedChild"/> the window is
+	/// reparented under <see cref="ImGuiAppConfig.ParentWindowHandle"/> so it renders as a docked child.
+	/// Embedded hosting is currently implemented on Windows; the existing <see cref="Start(ImGuiAppConfig)"/>
+	/// behaviour is unchanged.
+	/// </remarks>
+	/// <exception cref="ArgumentException">Thrown when <see cref="ImGuiAppConfig.WindowHost"/> is <see cref="ImGuiAppWindowHost.EmbeddedChild"/> but no <see cref="ImGuiAppConfig.ParentWindowHandle"/> was supplied.</exception>
+	/// <exception cref="InvalidOperationException">Thrown when an application is already running.</exception>
+	/// <exception cref="PlatformNotSupportedException">Thrown when embedded hosting is requested on a platform where it is not yet implemented.</exception>
+	public static IImGuiAppSession StartEmbedded(ImGuiAppConfig config)
+	{
+		Ensure.NotNull(config);
+
+		if (window != null)
+		{
+			throw new InvalidOperationException("Application is already running.");
+		}
+
+		if (config.WindowHost == ImGuiAppWindowHost.EmbeddedChild)
+		{
+			if (config.ParentWindowHandle == 0)
+			{
+				throw new ArgumentException("ParentWindowHandle must be set when WindowHost is EmbeddedChild.", nameof(config));
+			}
+
+			if (!OperatingSystem.IsWindows())
+			{
+				throw new PlatformNotSupportedException("Embedded window hosting is currently implemented on Windows only.");
+			}
+		}
+
+		EmbeddedSession session = new(config);
+		session.Start();
+		return session;
+	}
+
+	/// <summary>
+	/// Reparents the freshly created window under the host's parent window and strips its decorations.
+	/// </summary>
+	/// <param name="config">The configuration whose <see cref="ImGuiAppConfig.ParentWindowHandle"/> to embed under.</param>
+	private static void ReparentToHost(ImGuiAppConfig config)
+	{
+		if (config.WindowHost != ImGuiAppWindowHost.EmbeddedChild || !OperatingSystem.IsWindows())
+		{
+			return;
+		}
+
+		nint child = TryGetWindowHandle();
+		if (child == 0 || window == null)
+		{
+			return;
+		}
+
+		// Convert the top-level window into a borderless child of the host window.
+		long style = NativeMethods.GetWindowLongPtr(child, NativeMethods.GWL_STYLE);
+		style &= ~(NativeMethods.WS_POPUP | NativeMethods.WS_CAPTION | NativeMethods.WS_THICKFRAME | NativeMethods.WS_SYSMENU);
+		style |= NativeMethods.WS_CHILD;
+		_ = NativeMethods.SetWindowLongPtr(child, NativeMethods.GWL_STYLE, (nint)style);
+
+		_ = NativeMethods.SetParent(child, config.ParentWindowHandle);
+
+		_ = NativeMethods.SetWindowPos(
+			child,
+			0,
+			0,
+			0,
+			window.Size.X,
+			window.Size.Y,
+			NativeMethods.SWP_FRAMECHANGED | NativeMethods.SWP_NOZORDER | NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_SHOWWINDOW);
+	}
+
+	/// <summary>
+	/// A non-blocking <see cref="ImGuiApp"/> session that owns its render loop on a dedicated UI thread.
+	/// </summary>
+	private sealed class EmbeddedSession : IImGuiAppSession
+	{
+		private readonly ImGuiAppConfig sessionConfig;
+		private readonly Thread uiThread;
+		private readonly ManualResetEventSlim windowReady = new(false);
+		private volatile bool running;
+		private bool disposed;
+
+		internal EmbeddedSession(ImGuiAppConfig config)
+		{
+			sessionConfig = config;
+			uiThread = new Thread(RunLoop)
+			{
+				IsBackground = true,
+				Name = "ImGuiApp Embedded UI",
+			};
+		}
+
+		/// <inheritdoc/>
+		public bool IsRunning => running;
+
+		/// <inheritdoc/>
+		public nint NativeHandle => TryGetWindowHandle();
+
+		/// <summary>
+		/// Starts the UI thread and waits until the window has been created (or creation has failed).
+		/// </summary>
+		internal void Start()
+		{
+			uiThread.Start();
+			// Wait, with a generous timeout, so the caller sees a valid NativeHandle on return without
+			// hanging forever if window creation fails.
+			windowReady.Wait(TimeSpan.FromSeconds(10));
+		}
+
+		/// <inheritdoc/>
+		public void Resize(int width, int height)
+		{
+			if (!running)
+			{
+				return;
+			}
+
+			_ = Invoker?.InvokeAsync(() =>
+			{
+				if (window != null)
+				{
+					window.Size = new(width, height);
+				}
+			});
+		}
+
+		/// <inheritdoc/>
+		public void Focus(bool focused)
+		{
+			if (!running)
+			{
+				return;
+			}
+
+			_ = Invoker?.InvokeAsync(() => IsFocused = focused);
+		}
+
+		/// <inheritdoc/>
+		public void Dispose()
+		{
+			if (disposed)
+			{
+				return;
+			}
+
+			disposed = true;
+
+			if (running)
+			{
+				_ = Invoker?.InvokeAsync(() => window?.Close());
+				_ = uiThread.Join(TimeSpan.FromSeconds(5));
+			}
+
+			windowReady.Dispose();
+			GC.SuppressFinalize(this);
+		}
+
+		private void RunLoop()
+		{
+			try
+			{
+				Invoker = new();
+				Config = sessionConfig;
+				AdjustConfigForStartup(sessionConfig);
+				ValidateConfig(sessionConfig);
+				ForceDpiAware.Windows();
+				InitializeWindow(sessionConfig);
+				SetupWindowLoadHandler(sessionConfig);
+				SetupWindowResizeHandler(sessionConfig);
+				SetupWindowMoveHandler(sessionConfig);
+				SetupWindowUpdateHandler(sessionConfig);
+				SetupWindowRenderHandler(sessionConfig);
+				SetupWindowClosingHandler();
+
+				window!.FocusChanged += focused => IsFocused = focused;
+				window.Load += OnWindowLoaded;
+
+				running = true;
+				window.Run();
+			}
+			finally
+			{
+				running = false;
+				windowReady.Set();
+				window?.Dispose();
+				window = null;
+			}
+		}
+
+		private void OnWindowLoaded()
+		{
+			ReparentToHost(sessionConfig);
+			windowReady.Set();
+		}
+	}
+}

--- a/ImGui.App/ImGuiApp.Embedded.cs
+++ b/ImGui.App/ImGuiApp.Embedded.cs
@@ -140,10 +140,13 @@ public static partial class ImGuiApp
 
 			_ = Invoker?.InvokeAsync(() =>
 			{
-				if (window != null)
+				IWindow? target = window;
+				if (target is null)
 				{
-					window.Size = new(width, height);
+					return;
 				}
+
+				target.Size = new(width, height);
 			});
 		}
 

--- a/ImGui.App/ImGuiApp.cs
+++ b/ImGui.App/ImGuiApp.cs
@@ -244,6 +244,18 @@ public static partial class ImGuiApp
 			PreferredStencilBufferBits = 8
 		};
 
+		if (config.WindowHost == ImGuiAppWindowHost.EmbeddedChild)
+		{
+			// Embedded editors render into a borderless window that is reparented under the host once
+			// it has been created (see ReparentToHost). Position at the origin of the eventual parent.
+			silkWindowOptions = silkWindowOptions with
+			{
+				WindowBorder = WindowBorder.Hidden,
+				Position = new(0, 0),
+				IsVisible = true,
+			};
+		}
+
 		LastNormalWindowState = config.InitialWindowState;
 		LastNormalWindowState.LayoutState = Silk.NET.Windowing.WindowState.Normal;
 

--- a/ImGui.App/ImGuiAppConfig.cs
+++ b/ImGui.App/ImGuiAppConfig.cs
@@ -39,6 +39,28 @@ public class ImGuiAppConfig
 	public string Title { get; init; } = nameof(ImGuiApp);
 
 	/// <summary>
+	/// Gets or sets how the application window is hosted.
+	/// </summary>
+	/// <remarks>
+	/// Defaults to <see cref="ImGuiAppWindowHost.Standalone"/>, which preserves the classic behaviour of
+	/// <see cref="ImGuiApp.Start(ImGuiAppConfig)"/> (a top-level window owning a blocking loop). Set this to
+	/// <see cref="ImGuiAppWindowHost.EmbeddedChild"/> together with <see cref="ParentWindowHandle"/> and
+	/// start via <see cref="ImGuiApp.StartEmbedded(ImGuiAppConfig)"/> to render as a child of a
+	/// host-provided window (for example a VST3 plugin editor).
+	/// </remarks>
+	public ImGuiAppWindowHost WindowHost { get; init; } = ImGuiAppWindowHost.Standalone;
+
+	/// <summary>
+	/// Gets or sets the native handle of the parent window to embed into.
+	/// </summary>
+	/// <remarks>
+	/// Only consulted when <see cref="WindowHost"/> is <see cref="ImGuiAppWindowHost.EmbeddedChild"/>. The
+	/// value is a platform-native window handle: an <c>HWND</c> on Windows, an <c>NSView*</c> on macOS, or
+	/// an X11 <c>Window</c> on Linux.
+	/// </remarks>
+	public nint ParentWindowHandle { get; init; }
+
+	/// <summary>
 	/// Gets or sets the file path to the application window icon.
 	/// </summary>
 	public string IconPath { get; init; } = string.Empty;

--- a/ImGui.App/ImGuiAppWindowHost.cs
+++ b/ImGui.App/ImGuiAppWindowHost.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.App;
+
+/// <summary>
+/// Describes how an <see cref="ImGuiApp"/> window is hosted by the operating system.
+/// </summary>
+public enum ImGuiAppWindowHost
+{
+	/// <summary>
+	/// The application creates and owns its own top-level window. This is the default and matches the
+	/// behaviour of <see cref="ImGuiApp.Start(ImGuiAppConfig)"/>.
+	/// </summary>
+	Standalone,
+
+	/// <summary>
+	/// The application renders into a borderless window reparented under a host-provided
+	/// <see cref="ImGuiAppConfig.ParentWindowHandle"/>, for example a VST3 plugin editor's parent window.
+	/// Use <see cref="ImGuiApp.StartEmbedded(ImGuiAppConfig)"/> with this mode.
+	/// </summary>
+	EmbeddedChild,
+}

--- a/ImGui.App/NativeMethods.cs
+++ b/ImGui.App/NativeMethods.cs
@@ -61,6 +61,11 @@ internal static partial class NativeMethods
 	[return: MarshalAs(UnmanagedType.Bool)]
 	internal static partial bool GetMonitorInfo(nint hMonitor, ref MONITORINFO lpmi);
 
+	/// <summary>Changes the parent of a child window (used to embed our window under a host editor window).</summary>
+	[LibraryImport("user32.dll")]
+	[DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+	internal static partial nint SetParent(nint hWndChild, nint hWndNewParent);
+
 	/// <summary>A rectangle defined by its edges, matching the Win32 RECT structure.</summary>
 	[StructLayout(LayoutKind.Sequential)]
 	[SuppressMessage("Major Code Smell", "S101:Types should be named in PascalCase", Justification = "Name matches the native Win32 RECT structure for interop clarity.")]
@@ -96,6 +101,20 @@ internal static partial class NativeMethods
 	internal const int SW_HIDE = 0;
 	internal const int SW_SHOW = 5;
 	internal const int SW_RESTORE = 9;
+
+	// Window style manipulation used when reparenting our window into a host (embedded editor) window.
+	internal const int GWL_STYLE = -16;
+	internal const long WS_CHILD = 0x40000000L;
+	internal const long WS_POPUP = 0x80000000L;
+	internal const long WS_CAPTION = 0x00C00000L;
+	internal const long WS_THICKFRAME = 0x00040000L;
+	internal const long WS_SYSMENU = 0x00080000L;
+
+	// SetWindowPos flags.
+	internal const uint SWP_NOZORDER = 0x0004;
+	internal const uint SWP_NOACTIVATE = 0x0010;
+	internal const uint SWP_FRAMECHANGED = 0x0020;
+	internal const uint SWP_SHOWWINDOW = 0x0040;
 
 	/// <summary>
 	/// Sets the process as DPI-Aware on Windows.

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
@@ -115,6 +115,17 @@ public static partial class ImGuiApp
 	}
 
 	/// <summary>
+	/// Not supported on iOS. The embedded / non-blocking host model reparents a desktop window under a
+	/// foreign native handle, which has no analogue in the iOS application lifecycle (UIKit owns the
+	/// window). Present iOS UI through the standard <see cref="Start(ImGuiAppConfig)"/> path instead.
+	/// </summary>
+	/// <param name="config">The application configuration. Ignored.</param>
+	/// <returns>This method never returns; it always throws.</returns>
+	/// <exception cref="PlatformNotSupportedException">Always thrown on iOS.</exception>
+	public static IImGuiAppSession StartEmbedded(ImGuiAppConfig config) =>
+		throw new PlatformNotSupportedException("Embedded window hosting is not available on iOS; use Start(ImGuiAppConfig).");
+
+	/// <summary>
 	/// Requests application shutdown. iOS applications are not meant to self-terminate (the OS owns
 	/// the lifecycle), so this logs a warning, pauses rendering, and asks UIKit to exit.
 	/// </summary>

--- a/ImGui.Widgets/DbMeter.cs
+++ b/ImGui.Widgets/DbMeter.cs
@@ -1,0 +1,79 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Draws a vertical audio level meter calibrated in decibels, with an optional peak-hold marker.
+	/// </summary>
+	/// <param name="label">A unique identifier for the meter (used to size and reserve layout space).</param>
+	/// <param name="db">The current level, in decibels (for example dBFS).</param>
+	/// <param name="size">The meter size in pixels. Non-positive components fall back to sensible defaults.</param>
+	/// <param name="minDb">The level mapped to the bottom of the meter.</param>
+	/// <param name="maxDb">The level mapped to the top of the meter.</param>
+	/// <param name="peakDb">An optional peak-hold level to mark; pass <see cref="float.NegativeInfinity"/> to hide it.</param>
+	/// <remarks>
+	/// The fill is coloured green below -6 dB, amber up to 0 dB, and red above 0 dB, the conventional
+	/// nominal/peak zones of a digital meter.
+	/// </remarks>
+	public static void DbMeter(string label, float db, Vector2 size, float minDb = -60f, float maxDb = 6f, float peakDb = float.NegativeInfinity)
+	{
+		float lineHeight = ImGui.GetTextLineHeight();
+		Vector2 meterSize = new(
+			size.X > 0 ? size.X : lineHeight * 1.5f,
+			size.Y > 0 ? size.Y : lineHeight * 8.0f);
+
+		Vector2 cursorPos = ImGui.GetCursorScreenPos();
+		ImGui.Dummy(meterSize);
+
+		ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+		Span<Vector4> colors = ImGui.GetStyle().Colors;
+		Vector2 min = cursorPos;
+		Vector2 max = new(cursorPos.X + meterSize.X, cursorPos.Y + meterSize.Y);
+
+		// Background and border.
+		drawList.AddRectFilled(min, max, ImGui.GetColorU32(colors[(int)ImGuiCol.FrameBg]));
+
+		float range = maxDb - minDb;
+		float fill = range > 0 ? Math.Clamp((db - minDb) / range, 0.0f, 1.0f) : 0.0f;
+		float fillTop = max.Y - (fill * meterSize.Y);
+
+		if (fill > 0.0f)
+		{
+			drawList.AddRectFilled(new Vector2(min.X, fillTop), max, ImGui.GetColorU32(ZoneColor(db)));
+		}
+
+		// Peak-hold marker.
+		if (float.IsFinite(peakDb) && range > 0)
+		{
+			float peak = Math.Clamp((peakDb - minDb) / range, 0.0f, 1.0f);
+			float peakY = max.Y - (peak * meterSize.Y);
+			drawList.AddLine(new Vector2(min.X, peakY), new Vector2(max.X, peakY), ImGui.GetColorU32(ZoneColor(peakDb)), 2.0f);
+		}
+
+		drawList.AddRect(min, max, ImGui.GetColorU32(colors[(int)ImGuiCol.Border]));
+	}
+
+	/// <summary>
+	/// Returns the conventional meter colour for a level in decibels.
+	/// </summary>
+	/// <param name="db">The level, in decibels.</param>
+	/// <returns>Green below -6 dB, amber up to 0 dB, otherwise red.</returns>
+	private static Vector4 ZoneColor(float db) => db switch
+	{
+		> 0.0f => new Vector4(0.90f, 0.20f, 0.20f, 1.0f),
+		> -6.0f => new Vector4(0.90f, 0.78f, 0.20f, 1.0f),
+		_ => new Vector4(0.25f, 0.80f, 0.35f, 1.0f),
+	};
+}

--- a/ImGui.Widgets/DbMeter.cs
+++ b/ImGui.Widgets/DbMeter.cs
@@ -29,6 +29,7 @@ public static partial class ImGuiWidgets
 	/// </remarks>
 	public static void DbMeter(string label, float db, Vector2 size, float minDb = -60f, float maxDb = 6f, float peakDb = float.NegativeInfinity)
 	{
+		ImGui.PushID(label);
 		float lineHeight = ImGui.GetTextLineHeight();
 		Vector2 meterSize = new(
 			size.X > 0 ? size.X : lineHeight * 1.5f,
@@ -63,6 +64,7 @@ public static partial class ImGuiWidgets
 		}
 
 		drawList.AddRect(min, max, ImGui.GetColorU32(colors[(int)ImGuiCol.Border]));
+		ImGui.PopID();
 	}
 
 	/// <summary>

--- a/ImGui.Widgets/Scope.cs
+++ b/ImGui.Widgets/Scope.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Draws an oscilloscope-style waveform of a block of audio samples.
+	/// </summary>
+	/// <param name="label">A unique identifier for the scope (used to size and reserve layout space).</param>
+	/// <param name="samples">The samples to plot, expected in the range <c>[-1, 1]</c>.</param>
+	/// <param name="size">The scope size in pixels. Non-positive components fall back to sensible defaults.</param>
+	/// <param name="amplitude">A vertical scale applied to the samples before plotting.</param>
+	/// <remarks>
+	/// Samples are drawn left to right with the zero line through the vertical centre; values are clamped
+	/// to the plot area so out-of-range peaks do not draw outside the widget.
+	/// </remarks>
+	public static void Scope(string label, ReadOnlySpan<float> samples, Vector2 size, float amplitude = 1.0f)
+	{
+		float lineHeight = ImGui.GetTextLineHeight();
+		Vector2 scopeSize = new(
+			size.X > 0 ? size.X : lineHeight * 12.0f,
+			size.Y > 0 ? size.Y : lineHeight * 5.0f);
+
+		Vector2 cursorPos = ImGui.GetCursorScreenPos();
+		ImGui.Dummy(scopeSize);
+
+		ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+		Span<Vector4> colors = ImGui.GetStyle().Colors;
+		Vector2 min = cursorPos;
+		Vector2 max = new(cursorPos.X + scopeSize.X, cursorPos.Y + scopeSize.Y);
+		float midY = cursorPos.Y + (scopeSize.Y * 0.5f);
+		float halfHeight = scopeSize.Y * 0.5f;
+
+		drawList.AddRectFilled(min, max, ImGui.GetColorU32(colors[(int)ImGuiCol.FrameBg]));
+
+		// Zero line.
+		drawList.AddLine(new Vector2(min.X, midY), new Vector2(max.X, midY), ImGui.GetColorU32(colors[(int)ImGuiCol.Border]));
+
+		if (samples.Length >= 2)
+		{
+			uint waveColor = ImGui.GetColorU32(colors[(int)ImGuiCol.PlotLines]);
+			float step = scopeSize.X / (samples.Length - 1);
+
+			for (int i = 0; i < samples.Length - 1; i++)
+			{
+				float v0 = Math.Clamp(samples[i] * amplitude, -1.0f, 1.0f);
+				float v1 = Math.Clamp(samples[i + 1] * amplitude, -1.0f, 1.0f);
+
+				Vector2 p0 = new(min.X + (i * step), midY - (v0 * halfHeight));
+				Vector2 p1 = new(min.X + ((i + 1) * step), midY - (v1 * halfHeight));
+				drawList.AddLine(p0, p1, waveColor);
+			}
+		}
+
+		drawList.AddRect(min, max, ImGui.GetColorU32(colors[(int)ImGuiCol.Border]));
+	}
+}

--- a/ImGui.Widgets/Scope.cs
+++ b/ImGui.Widgets/Scope.cs
@@ -27,6 +27,7 @@ public static partial class ImGuiWidgets
 	/// </remarks>
 	public static void Scope(string label, ReadOnlySpan<float> samples, Vector2 size, float amplitude = 1.0f)
 	{
+		ImGui.PushID(label);
 		float lineHeight = ImGui.GetTextLineHeight();
 		Vector2 scopeSize = new(
 			size.X > 0 ? size.X : lineHeight * 12.0f,
@@ -64,5 +65,6 @@ public static partial class ImGuiWidgets
 		}
 
 		drawList.AddRect(min, max, ImGui.GetColorU32(colors[(int)ImGuiCol.Border]));
+		ImGui.PopID();
 	}
 }

--- a/ImGui.Widgets/XYPad.cs
+++ b/ImGui.Widgets/XYPad.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Draws an interactive XY pad that edits two normalized parameters at once.
+	/// </summary>
+	/// <param name="label">A unique identifier for the pad.</param>
+	/// <param name="x">The horizontal value in the range <c>[0, 1]</c>, updated while dragging.</param>
+	/// <param name="y">The vertical value in the range <c>[0, 1]</c> (increasing upward), updated while dragging.</param>
+	/// <param name="size">The pad size in pixels. Non-positive components fall back to a square default.</param>
+	/// <returns><see langword="true"/> if the value changed this frame; otherwise <see langword="false"/>.</returns>
+	/// <remarks>
+	/// XY pads are the natural control for paired parameters such as a filter's cutoff and resonance or a
+	/// panner's position. The handle tracks the pointer while the control is active.
+	/// </remarks>
+	public static bool XYPad(string label, ref float x, ref float y, Vector2 size)
+	{
+		float lineHeight = ImGui.GetTextLineHeight();
+		float side = lineHeight * 8.0f;
+		Vector2 padSize = new(
+			size.X > 0 ? size.X : side,
+			size.Y > 0 ? size.Y : side);
+
+		Vector2 cursorPos = ImGui.GetCursorScreenPos();
+		ImGui.InvisibleButton(label, padSize);
+
+		bool changed = false;
+		if (ImGui.IsItemActive() && padSize.X > 0 && padSize.Y > 0)
+		{
+			Vector2 mouse = ImGui.GetMousePos();
+			float nx = Math.Clamp((mouse.X - cursorPos.X) / padSize.X, 0.0f, 1.0f);
+			// Screen Y grows downward; invert so the value increases upward.
+			float ny = Math.Clamp(1.0f - ((mouse.Y - cursorPos.Y) / padSize.Y), 0.0f, 1.0f);
+
+			if (nx != x || ny != y)
+			{
+				x = nx;
+				y = ny;
+				changed = true;
+			}
+		}
+
+		ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+		Span<Vector4> colors = ImGui.GetStyle().Colors;
+		Vector2 min = cursorPos;
+		Vector2 max = new(cursorPos.X + padSize.X, cursorPos.Y + padSize.Y);
+
+		drawList.AddRectFilled(min, max, ImGui.GetColorU32(colors[(int)ImGuiCol.FrameBg]));
+
+		// Crosshair at the current value.
+		float clampedX = Math.Clamp(x, 0.0f, 1.0f);
+		float clampedY = Math.Clamp(y, 0.0f, 1.0f);
+		Vector2 handle = new(min.X + (clampedX * padSize.X), max.Y - (clampedY * padSize.Y));
+		uint guideColor = ImGui.GetColorU32(colors[(int)ImGuiCol.Border]);
+		drawList.AddLine(new Vector2(min.X, handle.Y), new Vector2(max.X, handle.Y), guideColor);
+		drawList.AddLine(new Vector2(handle.X, min.Y), new Vector2(handle.X, max.Y), guideColor);
+		drawList.AddCircleFilled(handle, MathF.Max(4.0f, lineHeight * 0.25f), ImGui.GetColorU32(colors[(int)ImGuiCol.SliderGrabActive]));
+
+		drawList.AddRect(min, max, guideColor);
+		return changed;
+	}
+}

--- a/ImGui.Widgets/XYPad.cs
+++ b/ImGui.Widgets/XYPad.cs
@@ -41,16 +41,11 @@ public static partial class ImGuiWidgets
 		if (ImGui.IsItemActive() && padSize.X > 0 && padSize.Y > 0)
 		{
 			Vector2 mouse = ImGui.GetMousePos();
-			float nx = Math.Clamp((mouse.X - cursorPos.X) / padSize.X, 0.0f, 1.0f);
-			// Screen Y grows downward; invert so the value increases upward.
-			float ny = Math.Clamp(1.0f - ((mouse.Y - cursorPos.Y) / padSize.Y), 0.0f, 1.0f);
-
-			if (nx != x || ny != y)
-			{
-				x = nx;
-				y = ny;
-				changed = true;
-			}
+			// While the pad is being dragged, track the pointer and report an edit each frame, matching
+			// how immediate-mode sliders behave. Screen Y grows downward, so invert it for an upward axis.
+			x = Math.Clamp((mouse.X - cursorPos.X) / padSize.X, 0.0f, 1.0f);
+			y = Math.Clamp(1.0f - ((mouse.Y - cursorPos.Y) / padSize.Y), 0.0f, 1.0f);
+			changed = true;
 		}
 
 		ImDrawListPtr drawList = ImGui.GetWindowDrawList();

--- a/tests/ImGui.App.Tests/EmbeddedSessionTests.cs
+++ b/tests/ImGui.App.Tests/EmbeddedSessionTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.App.Tests;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Tests for the additive embedded/non-blocking hosting surface. These cover the configuration defaults
+/// and the synchronous validation that runs before any window is created, so they do not require a GPU.
+/// </summary>
+[TestClass]
+public class EmbeddedSessionTests
+{
+	[TestInitialize]
+	public void Setup()
+	{
+		ImGuiApp.Reset();
+	}
+
+	[TestMethod]
+	public void WindowHost_DefaultsToStandalone()
+	{
+		ImGuiAppConfig config = new();
+		Assert.AreEqual(ImGuiAppWindowHost.Standalone, config.WindowHost, "Default host must preserve standalone behaviour.");
+		Assert.AreEqual(0, config.ParentWindowHandle);
+	}
+
+	[TestMethod]
+	public void StartEmbedded_NullConfig_Throws()
+	{
+		Assert.ThrowsExactly<ArgumentNullException>(() => ImGuiApp.StartEmbedded(null!));
+	}
+
+	[TestMethod]
+	public void StartEmbedded_EmbeddedChildWithoutHandle_Throws()
+	{
+		ImGuiAppConfig config = new()
+		{
+			WindowHost = ImGuiAppWindowHost.EmbeddedChild,
+			// ParentWindowHandle deliberately left at its default of 0.
+		};
+
+		Assert.ThrowsExactly<ArgumentException>(() => ImGuiApp.StartEmbedded(config));
+	}
+}


### PR DESCRIPTION
## Summary

Implements the two **ImGuiApp-side** items from the .NET VST3 effects host plan in one PR (same repo): **embedded/provided-window support (roadmap #1)** and **audio widgets (roadmap #6)**. Both are additive — existing standalone behaviour is unchanged.

### Embedded / non-blocking hosting (`ImGui.App`)
The crux of the plan: let ImGuiApp render into a host-provided window instead of only owning its own top-level window.

- **`ImGuiAppConfig`** gains `WindowHost` (`ImGuiAppWindowHost.Standalone` by default) and `ParentWindowHandle`. `Standalone` preserves the exact current behaviour and blocking `Start` — no break for existing apps.
- **`ImGuiApp.StartEmbedded(config)`** → **`IImGuiAppSession`**: a non-blocking start that runs the render loop on a **dedicated UI thread it owns**, exposing `Resize` / `Focus` / `NativeHandle` / `IsRunning` and tearing the window down on `Dispose`. Host-thread requests (resize/focus/close) are marshalled onto the UI thread via the existing `Invoker`.
- **`EmbeddedChild`** reparents the borderless Silk.NET window under `ParentWindowHandle` — Windows implemented (`SetParent` + `WS_CHILD` style swap + `SetWindowPos`). Other desktop platforms throw `PlatformNotSupportedException` for now, matching the plan's *"prove Windows first"* sequencing (M4/M5).
- iOS provides a throwing `StartEmbedded` stub and excludes the desktop partial, keeping the shared config surface consistent.

This covers both **Option A** (floating window: `StartEmbedded` + `Standalone`) and the groundwork for **Option B** (docked editor: `EmbeddedChild`).

### Audio widgets (`ImGui.Widgets`)
- **`DbMeter`** — vertical dB level meter with green/amber/red zones and an optional peak-hold marker.
- **`Scope`** — oscilloscope-style waveform plot of a `ReadOnlySpan<float>` sample block.
- **`XYPad`** — interactive 2D pad editing two normalized `[0,1]` parameters (e.g. cutoff/resonance).

## Testing

- Added `EmbeddedSessionTests` covering config defaults and the synchronous `StartEmbedded` validation paths (null config, `EmbeddedChild` without a handle) — no GPU required.
- Full `ImGui.App` suite green: **287/287** locally (`net10.0`); libraries also build clean on `net8.0`.

## Honest scope notes / follow-ups
- **Live reparenting is not runtime-verified here** — the sandbox has no GPU/host. The Windows reparenting path is implemented and compiles, but actually docking inside a real VST3 host (and the macOS `NSView` / Linux `XReparentWindow` paths) is the explicit M5 follow-up that needs a real plugin host to validate.
- Widget rendering follows the existing immediate-mode widget pattern; like the other widgets in this repo it isn't unit-tested (requires a live ImGui frame) — wire into a demo for visual verification.

> Note: the sandbox's .NET SDK (10.0.108) predates the Roslyn the pinned `ktsu.Sdk` analyzers (2.8.0) require, so builds/tests were run against `net10.0`/`net8.0` with the standard runner. CI runs the full multi-target build (incl. `net10.0-ios` on macOS) with analyzers and style enforcement.

🤖 Part of the ktsu VST plugin upstream-enablement work.

https://claude.ai/code/session_01JQ3bQMuSYuumAnQZaYUKP7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ3bQMuSYuumAnQZaYUKP7)_