### PR TITLE
[patch] Fix FilesystemBrowser crash on open

### DIFF
--- a/ImGui.Popups/FilesystemBrowser.cs
+++ b/ImGui.Popups/FilesystemBrowser.cs
@@ -358,17 +358,18 @@ public partial class ImGuiPopups
 			CurrentContents.Clear();
 			CurrentDirectory.GetContents().ForEach(p =>
 			{
-				if (BrowserTarget == FilesystemBrowserTarget.File || (BrowserTarget == FilesystemBrowserTarget.Directory && p is AbsoluteDirectoryPath))
+				switch (p)
 				{
-					if (p is not AbsolutePath absolutePath)
-					{
-						throw new InvalidOperationException("Path is not an absolute path.");
-					}
+					case AbsoluteDirectoryPath directory:
+						CurrentContents.Add(directory);
+						break;
 
-					if (absolutePath.IsDirectory || Matcher.Match(Path.GetFileName(absolutePath.WeakString)).HasMatches)
-					{
-						CurrentContents.Add(absolutePath);
-					}
+					case AbsoluteFilePath file when BrowserTarget == FilesystemBrowserTarget.File && Matcher.Match(file.FileName).HasMatches:
+						CurrentContents.Add(file);
+						break;
+
+					default:
+						break;
 				}
 			});
 		}


### PR DESCRIPTION
## Problem

Opening any file open/save or directory browser crashed immediately with:

```
System.InvalidOperationException: Path is not an absolute path.
   at ...FilesystemBrowser.<RefreshContents>b__60_0(IPath p)
```

## Root cause

`RefreshContents()` guarded each entry with `p is not AbsolutePath`. But `AbsoluteDirectoryPath.GetContents()` only ever yields `AbsoluteFilePath` and `AbsoluteDirectoryPath` instances, and in the current `ktsu.Semantics.Paths` those are independent `sealed record`s that do **not** derive from `AbsolutePath` (they share only the empty `IAbsolutePath`/`IPath` marker interfaces). So the guard failed on the first entry and threw.

The outer guard in the same lambda already matched `AbsoluteDirectoryPath` correctly, which confirms the inner `AbsolutePath` check was a stale assumption from when `AbsolutePath` was a shared base type.

## Fix

Match the concrete types `GetContents()` actually produces, preserving the original behavior:
- Directories are always listed (navigation in File mode, selection in Directory mode).
- Files appear only in File mode when they match the glob.

The previously-unreachable `throw` is removed.

## Verification

`dotnet build ImGui.Popups -c Release` succeeds across net8.0/net9.0/net10.0 with warnings-as-errors and zero warnings. Reported by a downstream consumer (SchemaEditor) whose file-open dialog crashed on launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)