### PR TITLE
[patch] Use WCAG relative luminance to pick contrasting text color

### DIFF
--- a/ImGui.Styler/Theme.cs
+++ b/ImGui.Styler/Theme.cs
@@ -523,12 +523,8 @@ public static class Theme
 				);
 			}
 
-			// Calculate contrasting text color for the surface
-			Vector4 surfaceVec = surfaceColor.Value;
-			float luminance = (0.299f * surfaceVec.X) + (0.587f * surfaceVec.Y) + (0.114f * surfaceVec.Z);
-			uint textColor = luminance > 0.5f ?
-				new Srgb(0.0f, 0.0f, 0.0f).ToImGuiU32(1.0f) : // Dark text on light surface
-				new Srgb(1.0f, 1.0f, 1.0f).ToImGuiU32(1.0f);   // Light text on dark surface
+			// Calculate contrasting text color for the surface using WCAG relative luminance
+			uint textColor = surfaceColor.MostReadableTextColor().ToImGuiU32();
 
 			// Draw theme name text over the surface area (below title bar)
 			Vector2 textPos = new(
@@ -668,12 +664,8 @@ public static class Theme
 				);
 			}
 
-			// Calculate contrasting text color for the surface
-			Vector4 surfaceVec = surfaceColor.Value;
-			float luminance = (0.299f * surfaceVec.X) + (0.587f * surfaceVec.Y) + (0.114f * surfaceVec.Z);
-			uint textColor = luminance > 0.5f ?
-				new Srgb(0.0f, 0.0f, 0.0f).ToImGuiU32(1.0f) : // Dark text on light surface
-				new Srgb(1.0f, 1.0f, 1.0f).ToImGuiU32(1.0f);   // Light text on dark surface
+			// Calculate contrasting text color for the surface using WCAG relative luminance
+			uint textColor = surfaceColor.MostReadableTextColor().ToImGuiU32();
 
 			// Draw family name text over the surface area (below title bar)
 			Vector2 textPos = new(
@@ -861,12 +853,8 @@ public static class Theme
 				);
 			}
 
-			// Calculate contrasting text color for the surface
-			Vector4 surfaceVec = surfaceColor.Value;
-			float luminance = (0.299f * surfaceVec.X) + (0.587f * surfaceVec.Y) + (0.114f * surfaceVec.Z);
-			uint textColor = luminance > 0.5f ?
-				new Srgb(0.0f, 0.0f, 0.0f).ToImGuiU32(1.0f) : // Dark text on light surface
-				new Srgb(1.0f, 1.0f, 1.0f).ToImGuiU32(1.0f);   // Light text on dark surface
+			// Calculate contrasting text color for the surface using WCAG relative luminance
+			uint textColor = surfaceColor.MostReadableTextColor().ToImGuiU32();
 
 			// Draw group name text centered over the surface area (below title bar)
 			Vector2 textPos = new(

--- a/ImGui.Widgets/Avatar.cs
+++ b/ImGui.Widgets/Avatar.cs
@@ -116,7 +116,7 @@ public static partial class ImGuiWidgets
 				drawList.AddCircleFilled(center, radius, background.ToImGuiU32(), 0);
 
 				string initials = Initials(displayName);
-				ImColor textColor = Luminance(background.Value) > 0.55f ? new Srgb(0f, 0f, 0f).ToImColor(1f) : new Srgb(1f, 1f, 1f).ToImColor(1f);
+				ImColor textColor = background.MostReadableTextColor();
 				Vector2 textSize = ImGui.CalcTextSize(initials);
 				Vector2 textPos = new(center.X - (textSize.X * 0.5f), center.Y - (textSize.Y * 0.5f));
 				drawList.AddText(textPos, textColor.ToImGuiU32(), initials);
@@ -164,7 +164,5 @@ public static partial class ImGuiWidgets
 			float hueDegrees = hash % 360u;
 			return new Hsl(hueDegrees, 0.55f, 0.55f).ToSrgb().ToImColor();
 		}
-
-		private static float Luminance(Vector4 color) => (0.2126f * color.X) + (0.7152f * color.Y) + (0.0722f * color.Z);
 	}
 }


### PR DESCRIPTION
## Summary

Fixes color-correctness bugs found in a linear/sRGB audit. Two spots chose black/white text over a background from luma computed on **gamma-encoded** sRGB with a midpoint threshold, which biases toward the wrong text color on mid-tone surfaces:

- **`ImGui.Styler/Theme.cs`** (3 identical sites) used NTSC/Rec.601 coefficients `0.299/0.587/0.114` and a `> 0.5` threshold.
- **`ImGui.Widgets/Avatar.cs`** used the correct WCAG coefficients but applied them to gamma sRGB (no `sRGB→linear` step) with a `> 0.55` threshold.

Both now use the existing `MostReadableTextColor()` helper, which linearizes channels and picks by the WCAG contrast ratio `(L1+0.05)/(L2+0.05)`. The now-unused private `Avatar.Luminance` helper was removed.

The correct pattern was already used elsewhere in the same code (`ScopedThemeColor.cs`, `ThemeCard.cs`), so this is a consistency fix.

## Verification

- `ImGui.sln` builds with 0 warnings / 0 errors (warnings-as-errors).
- Full test suite passes, including `ImGui.Color.Tests` which covers `MostReadableTextColor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)