### PR TITLE
Fix rendering and window geometry under tiling/Wayland compositors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ This is the **ktsu ImGui Suite**, a collection of .NET libraries for building De
 - `ImGui.App/FontMemoryGuard.cs` - GPU memory management for font atlases
 - `ImGui.App/FontHelper.cs` - Unicode, emoji, and Nerd Font character range support
 - `ImGui.App/ForceDpiAware.cs` - Multi-platform DPI detection
+- `ImGui.App/WindowingEnvironment.cs` - Wayland / tiling window manager detection driving `ImGuiAppConfig.WindowGeometry`
 - `ImGui.App/ImGuiExtensionManager.cs` - Auto-detection of ImGuizmo, ImNodes, ImPlot
 - `ImGui.Widgets/DividerZone.cs` - Resizable split pane layout
 - `ImGui.Widgets/TabPanel.cs` - Tabbed interface with drag-and-drop

--- a/ImGui.App/ImGuiApp.cs
+++ b/ImGui.App/ImGuiApp.cs
@@ -78,6 +78,24 @@ public static partial class ImGuiApp
 		};
 	}
 
+	/// <summary>
+	/// Gets a value indicating whether the window manager owns the window's position and size.
+	/// </summary>
+	/// <remarks>
+	/// Resolved from <see cref="ImGuiAppConfig.WindowGeometry"/>, falling back to
+	/// <see cref="WindowingEnvironment.CompositorOwnsGeometry"/> when that is
+	/// <see cref="WindowGeometryMode.Auto"/>. When true the application neither moves nor resizes
+	/// its own window, and does not record the reported window position — under Wayland and tiling
+	/// window managers that position is a placeholder, and writing it back would persist garbage
+	/// geometry and fight the tiler.
+	/// </remarks>
+	public static bool CompositorOwnsWindowGeometry => Config.WindowGeometry switch
+	{
+		WindowGeometryMode.Application => false,
+		WindowGeometryMode.Compositor => true,
+		_ => WindowingEnvironment.CompositorOwnsGeometry,
+	};
+
 	internal static ConcurrentDictionary<string, int> FontIndices { get; } = [];
 	[SuppressMessage("Major Code Smell", "S2223:Non-constant static fields should not be visible", Justification = "Mutable static app-lifecycle state; single-instance by design, accessed via InternalsVisibleTo.")]
 	internal static float lastFontScaleFactor;
@@ -225,7 +243,13 @@ public static partial class ImGuiApp
 		{
 			Title = config.Title,
 			Size = new((int)config.InitialWindowState.Size.X, (int)config.InitialWindowState.Size.Y),
-			Position = new((int)config.InitialWindowState.Pos.X, (int)config.InitialWindowState.Pos.Y),
+			// The saved position is only meaningful when the application owns geometry. Under a
+			// tiling window manager (or any Wayland session) the request is ignored, and the
+			// default state's deliberately off-screen sentinel would otherwise make the window
+			// look mispositioned for the frames before the compositor claims it.
+			Position = CompositorOwnsWindowGeometry
+				? WindowOptions.Default.Position
+				: new((int)config.InitialWindowState.Pos.X, (int)config.InitialWindowState.Pos.Y),
 			WindowState = Silk.NET.Windowing.WindowState.Normal,
 			IsVisible = !config.StartHidden, // Tray apps can start hidden; the loop still runs
 			VSync = false, // Disable VSync to allow PID frame limiter to control frame rate
@@ -920,7 +944,13 @@ public static partial class ImGuiApp
 			LastNormalWindowState = new()
 			{
 				Size = new(window.Size.X, window.Size.Y),
-				Pos = new(window.Position.X, window.Position.Y),
+				// A Wayland client cannot query where it is, and a tiling window manager moves the
+				// window whenever the layout changes. Recording the reported position there would
+				// overwrite the caller's saved geometry with a placeholder (typically 0,0) that
+				// then gets persisted and restored on the next launch, so keep what we already had.
+				Pos = CompositorOwnsWindowGeometry
+					? LastNormalWindowState.Pos
+					: new(window.Position.X, window.Position.Y),
 				LayoutState = Silk.NET.Windowing.WindowState.Normal
 			};
 		}
@@ -988,6 +1018,32 @@ public static partial class ImGuiApp
 	private static Silk.NET.Maths.Vector2D<int>? lastCheckedWindowPosition;
 	private static Silk.NET.Maths.Vector2D<int>? lastCheckedWindowSize;
 	private static bool needsPositionValidation = true;
+	private static bool loggedCompositorOwnedGeometry;
+
+	/// <summary>
+	/// Gets the number of physical framebuffer pixels per window unit, per axis.
+	/// </summary>
+	/// <remarks>
+	/// One on platforms that report the window in pixels (Windows, unscaled X11). Greater than one
+	/// where the window is reported in logical units and the surface is scaled up: a Wayland
+	/// surface under fractional or integer scaling, or a Retina display. ImGui works in framebuffer
+	/// pixels, so anything the backend hands over in window units is multiplied by this.
+	/// </remarks>
+	internal static System.Numerics.Vector2 WindowToFramebufferScale
+	{
+		get
+		{
+			if (window is null || window.Size.X <= 0 || window.Size.Y <= 0)
+			{
+				return System.Numerics.Vector2.One;
+			}
+
+			Silk.NET.Maths.Vector2D<int> framebuffer = window.FramebufferSize;
+			return framebuffer.X <= 0 || framebuffer.Y <= 0
+				? System.Numerics.Vector2.One
+				: new((float)framebuffer.X / window.Size.X, (float)framebuffer.Y / window.Size.Y);
+		}
+	}
 
 	/// <summary>
 	/// Ensures the window is positioned on a visible monitor. This method provides improved
@@ -999,6 +1055,20 @@ public static partial class ImGuiApp
 		// Early exit for invalid states
 		if (window is null || window.WindowState == Silk.NET.Windowing.WindowState.Minimized)
 		{
+			return;
+		}
+
+		// The window manager decides where windows live: it has already placed this one somewhere
+		// visible, the position we would read back is a placeholder, and moving or resizing the
+		// window ourselves either does nothing (Wayland) or fights the tiler into a resize storm.
+		if (CompositorOwnsWindowGeometry)
+		{
+			if (!loggedCompositorOwnedGeometry)
+			{
+				loggedCompositorOwnedGeometry = true;
+				DebugLogger.Log("EnsureWindowPositionIsValid: Window manager owns geometry, skipping position validation");
+			}
+
 			return;
 		}
 
@@ -1482,6 +1552,17 @@ public static partial class ImGuiApp
 	{
 		float newScaleFactor = (float)ForceDpiAware.GetWindowScaleFactor();
 
+		// A surface the platform scales for us states its scale directly, and that is more
+		// authoritative than any desktop setting we can probe: a Wayland compositor may apply a
+		// fractional scale that no gsettings key mentions. ImGui lays out in framebuffer pixels, so
+		// this is the factor that keeps the UI at the right physical size.
+		System.Numerics.Vector2 surfaceScale = WindowToFramebufferScale;
+		float uniformSurfaceScale = Math.Min(surfaceScale.X, surfaceScale.Y);
+		if (uniformSurfaceScale > 1.01f)
+		{
+			newScaleFactor = uniformSurfaceScale;
+		}
+
 		// Only update if the scale factor changed significantly (more than 1% difference)
 		if (Math.Abs(ScaleFactor - newScaleFactor) > 0.01f)
 		{
@@ -1941,6 +2022,7 @@ public static partial class ImGuiApp
 		originalWindowProc = 0;
 		LastNormalWindowState = new();
 		preOverlayWindowState = null;
+		loggedCompositorOwnedGeometry = false;
 		FontIndices.Clear();
 		lastFontScaleFactor = 0;
 		currentPinnedFontData.Clear();

--- a/ImGui.App/ImGuiAppConfig.cs
+++ b/ImGui.App/ImGuiAppConfig.cs
@@ -71,6 +71,17 @@ public class ImGuiAppConfig
 	public ImGuiAppWindowState InitialWindowState { get; init; } = new();
 
 	/// <summary>
+	/// Gets or sets who owns the window's position and size.
+	/// </summary>
+	/// <remarks>
+	/// Defaults to <see cref="WindowGeometryMode.Auto"/>, which detects Wayland sessions and
+	/// tiling window managers and hands geometry to them. Override this when the detection is
+	/// wrong for your setup — for example to force <see cref="WindowGeometryMode.Application"/>
+	/// on an X11 desktop that is misidentified as tiling.
+	/// </remarks>
+	public WindowGeometryMode WindowGeometry { get; init; } = WindowGeometryMode.Auto;
+
+	/// <summary>
 	/// Gets or sets a value indicating whether the window is created hidden.
 	/// When true, the window starts invisible and must be shown with <c>ImGuiApp.Show</c>
 	/// (typically from a system tray icon). The render loop still runs while hidden.

--- a/ImGui.App/ImGuiController/ImGuiController.cs
+++ b/ImGui.App/ImGuiController/ImGuiController.cs
@@ -222,7 +222,11 @@ internal sealed class ImGuiController : IRendererBackend
 	{
 		ImGuiApp.OnUserInput();
 		ImGuiIOPtr io = ImGui.GetIO();
-		io.AddMousePosEvent(position.X, position.Y);
+
+		// The backend reports the cursor in window units; ImGui works in framebuffer pixels, which
+		// differ on a scaled surface (Wayland fractional scaling, Retina).
+		Vector2 scale = ImGuiApp.WindowToFramebufferScale;
+		io.AddMousePosEvent(position.X * scale.X, position.Y * scale.Y);
 	}
 
 	/// <summary>
@@ -328,22 +332,18 @@ internal sealed class ImGuiController : IRendererBackend
 	internal void SetPerFrameImGuiData(float deltaSeconds)
 	{
 		ImGuiIOPtr io = ImGui.GetIO();
-		io.DisplaySize = new Vector2(_windowWidth, _windowHeight);
 
-		if (_windowWidth > 0 && _windowHeight > 0 && _view is not null)
-		{
-			// Force framebuffer scale to 1.0 on Linux to prevent blurry text rendering
-			// WSL and Linux often have framebuffer scaling issues that cause blur
-			if (OperatingSystem.IsLinux())
-			{
-				io.DisplayFramebufferScale = Vector2.One;
-			}
-			else
-			{
-				io.DisplayFramebufferScale = new Vector2(_view.FramebufferSize.X / _windowWidth,
-					_view.FramebufferSize.Y / _windowHeight);
-			}
-		}
+		// ImGui's coordinate space is physical framebuffer pixels, so the display size is the
+		// framebuffer and the framebuffer scale is always 1. On a platform that reports the window
+		// in logical units — a scaled Wayland surface, a Retina display — the two differ, and
+		// ImGuiApp.ScaleFactor carries that ratio so the UI is laid out at the right physical size
+		// with glyphs rasterized to match. Anything arriving in logical units (mouse position) is
+		// converted on the way in; see ImGuiApp.WindowToFramebufferScale.
+		Vector2D<int> framebufferSize = _view?.FramebufferSize ?? new Vector2D<int>(_windowWidth, _windowHeight);
+		io.DisplaySize = framebufferSize.X > 0 && framebufferSize.Y > 0
+			? new Vector2(framebufferSize.X, framebufferSize.Y)
+			: new Vector2(_windowWidth, _windowHeight);
+		io.DisplayFramebufferScale = Vector2.One;
 
 		io.DeltaTime = deltaSeconds; // DeltaTime is in seconds.
 	}
@@ -542,6 +542,12 @@ internal sealed class ImGuiController : IRendererBackend
 		{
 			return;
 		}
+
+		// Set the viewport from the draw data every frame rather than relying on a resize event to
+		// have set it. Some backends never raise one — a Wayland surface can be sized by the
+		// compositor before the handler is attached — which would leave the viewport at whatever
+		// size the drawable had when the context was created, and the UI drawn into a corner.
+		_gl.Viewport(0, 0, (uint)framebufferWidth, (uint)framebufferHeight);
 
 		// Setup render state: alpha-blending enabled, no face culling, no depth testing, scissor enabled, polygon fill
 		_gl.Enable(GLEnum.Blend);

--- a/ImGui.App/README.md
+++ b/ImGui.App/README.md
@@ -371,6 +371,7 @@ The main entry point for creating and managing ImGui applications.
 | `IsVisible` | `bool` | Gets whether the application window is visible |
 | `IsIdle` | `bool` | Gets whether the application is currently idle |
 | `ScaleFactor` | `float` | Gets the current DPI scale factor |
+| `CompositorOwnsWindowGeometry` | `bool` | Gets whether the window manager, rather than the application, owns window position and size |
 
 #### Methods
 
@@ -400,6 +401,7 @@ Configuration for the ImGui application.
 | `Title` | `string` | `"ImGuiApp"` | The window title |
 | `IconPath` | `string` | `""` | The file path to the application window icon |
 | `InitialWindowState` | `ImGuiAppWindowState` | `new()` | The initial state of the application window |
+| `WindowGeometry` | `WindowGeometryMode` | `Auto` | Who owns window position and size (see [Tiling window managers](#tiling-window-managers-and-wayland)) |
 | `Fonts` | `Dictionary<string, byte[]>` | `[]` | Font name to font data mapping |
 | `EnableUnicodeSupport` | `bool` | `true` | Whether to enable Unicode and emoji support |
 | `SaveIniSettings` | `bool` | `true` | Whether ImGui should save window settings to imgui.ini |
@@ -485,6 +487,30 @@ Represents the state of the application window.
 | `Size` | `Vector2` | The size of the window |
 | `Pos` | `Vector2` | The position of the window |
 | `LayoutState` | `WindowState` | The layout state of the window (Normal, Maximized, etc.) |
+
+## Tiling window managers and Wayland
+
+Under a tiling window manager (i3, sway, niri, Hyprland, dwm, …) or any Wayland session, the window
+manager — not the client — decides where windows go and how big they are. A Wayland client cannot
+even read its own position: the backend reports a placeholder. Applications that place and track
+their own window in those environments end up fighting the tiler and persisting garbage geometry.
+
+`ImGuiAppConfig.WindowGeometry` selects who is in charge:
+
+| Value | Behaviour |
+|-------|-----------|
+| `Auto` (default) | Detects Wayland sessions and known tiling window managers, and hands geometry to them; everything else keeps the application in charge |
+| `Application` | The application places its own window: the requested position is honoured, off-screen windows are relocated, and the live position is recorded in `ImGuiApp.WindowState` |
+| `Compositor` | The application never moves or resizes its own window, and never records the reported position |
+
+```csharp
+ImGuiApp.Start(new ImGuiAppConfig
+{
+    Title = "My App",
+    // Override only if auto-detection is wrong for your setup
+    WindowGeometry = WindowGeometryMode.Application,
+});
+```
 
 ## Debug Features
 

--- a/ImGui.App/WindowGeometryMode.cs
+++ b/ImGui.App/WindowGeometryMode.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.App;
+
+/// <summary>
+/// Controls who owns the application window's position and size.
+/// </summary>
+public enum WindowGeometryMode
+{
+	/// <summary>
+	/// Detect at startup: a Wayland session or a known tiling window manager is treated as
+	/// <see cref="Compositor"/>, everything else as <see cref="Application"/>.
+	/// See <see cref="WindowingEnvironment.CompositorOwnsGeometry"/>.
+	/// </summary>
+	Auto,
+
+	/// <summary>
+	/// The application places and sizes its own window: the requested position is honoured at
+	/// startup, the window is relocated when it lands off-screen, and the live position is
+	/// persisted as part of <see cref="ImGuiApp.WindowState"/>.
+	/// </summary>
+	Application,
+
+	/// <summary>
+	/// The window manager owns geometry. The application never moves or resizes its own window
+	/// and never records the reported position, because that position is either meaningless
+	/// (Wayland clients cannot query where they are) or immediately overridden by the tiler.
+	/// </summary>
+	Compositor,
+}

--- a/ImGui.App/WindowingEnvironment.cs
+++ b/ImGui.App/WindowingEnvironment.cs
@@ -1,0 +1,130 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.App;
+
+/// <summary>
+/// Detects whether the host window manager owns window geometry, so the application can stop
+/// placing, sizing, and tracking its own window where doing so is meaningless or actively harmful.
+/// </summary>
+/// <remarks>
+/// Two environments take geometry away from the client:
+/// <list type="bullet">
+/// <item><description>
+/// Wayland. A Wayland client has no way to read or set its own surface position — the backend
+/// reports a placeholder (usually 0,0) and position requests are dropped on the floor.
+/// </description></item>
+/// <item><description>
+/// Tiling window managers (i3, sway, niri, Hyprland, dwm, …). The window manager assigns every
+/// window a slot; a client that resizes or moves itself is either ignored or fights the tiler,
+/// which shows up as flicker and repeated resize storms.
+/// </description></item>
+/// </list>
+/// Detection is cached for the process lifetime because the answer cannot change without a new
+/// session.
+/// </remarks>
+public static class WindowingEnvironment
+{
+	/// <summary>
+	/// Window manager and desktop names that tile. Matched case-insensitively against the
+	/// XDG desktop environment variables, which may hold a colon-separated list.
+	/// </summary>
+	private static readonly HashSet<string> TilingDesktopNames = new(StringComparer.OrdinalIgnoreCase)
+	{
+		"awesome", "bspwm", "cwm", "dk", "dwm", "herbstluftwm", "hyprland", "i3", "leftwm",
+		"niri", "notion", "qtile", "ratpoison", "river", "spectrwm", "stumpwm", "sway",
+		"wayfire", "wmii", "xmonad",
+	};
+
+	/// <summary>
+	/// Environment variables whose mere presence identifies a running tiling window manager,
+	/// used as a backstop for sessions that do not advertise themselves via the XDG variables.
+	/// </summary>
+	private static readonly string[] TilingSessionMarkers =
+	[
+		"SWAYSOCK",
+		"NIRI_SOCKET",
+		"HYPRLAND_INSTANCE_SIGNATURE",
+		"I3SOCK",
+		"RIVER_SOCKET",
+	];
+
+	/// <summary>
+	/// Environment variables that name the running desktop or window manager. The value may be a
+	/// colon-separated list, such as <c>wlroots:sway</c>.
+	/// </summary>
+	private static readonly string[] DesktopNameVariables =
+	[
+		"XDG_CURRENT_DESKTOP",
+		"XDG_SESSION_DESKTOP",
+		"DESKTOP_SESSION",
+	];
+
+	private static Lazy<bool> detection = CreateDetection();
+
+	/// <summary>
+	/// Gets a value indicating whether the window manager — rather than the application — owns
+	/// window position and size.
+	/// </summary>
+	public static bool CompositorOwnsGeometry => detection.Value;
+
+	/// <summary>
+	/// Determines whether the described session hands window geometry to the window manager.
+	/// </summary>
+	/// <param name="readEnvironmentVariable">Reads an environment variable by name; injected for testing.</param>
+	/// <returns>True when the window manager owns geometry.</returns>
+	internal static bool Detect(Func<string, string?> readEnvironmentVariable)
+	{
+		Ensure.NotNull(readEnvironmentVariable);
+
+		// Windows and macOS place windows on the client's behalf but honour client-requested
+		// geometry, so the application stays in charge there.
+		if (!OperatingSystem.IsLinux() && !OperatingSystem.IsFreeBSD())
+		{
+			return false;
+		}
+
+		// Any Wayland session, tiling or not: the protocol has no concept of a client-visible
+		// window position at all.
+		if (string.Equals(readEnvironmentVariable("XDG_SESSION_TYPE"), "wayland", StringComparison.OrdinalIgnoreCase) ||
+			!string.IsNullOrEmpty(readEnvironmentVariable("WAYLAND_DISPLAY")))
+		{
+			return true;
+		}
+
+		foreach (string marker in TilingSessionMarkers)
+		{
+			if (!string.IsNullOrEmpty(readEnvironmentVariable(marker)))
+			{
+				return true;
+			}
+		}
+
+		foreach (string variable in DesktopNameVariables)
+		{
+			string? value = readEnvironmentVariable(variable);
+			if (string.IsNullOrEmpty(value))
+			{
+				continue;
+			}
+
+			foreach (string name in value.Split(':', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+			{
+				if (TilingDesktopNames.Contains(name))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Clears the cached detection result so the next query re-reads the environment.
+	/// </summary>
+	internal static void ResetCache() => detection = CreateDetection();
+
+	private static Lazy<bool> CreateDetection() => new(() => Detect(Environment.GetEnvironmentVariable));
+}

--- a/tests/ImGui.App.Tests/ImGuiAppTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppTests.cs
@@ -64,6 +64,11 @@ public sealed class ImGuiAppTests : IDisposable
 	private static void ResetState()
 	{
 		ImGuiApp.Reset();
+
+		// These tests assert on application-driven window placement, so pin the geometry mode
+		// instead of letting it be decided by whichever session the test host happens to run in
+		// (auto-detection hands geometry to the compositor under Wayland and tiling WMs).
+		ImGuiApp.Config = new ImGuiAppConfig { WindowGeometry = WindowGeometryMode.Application };
 	}
 
 	[TestMethod]

--- a/tests/ImGui.App.Tests/ImGuiAppWindowManagementTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppWindowManagementTests.cs
@@ -20,6 +20,11 @@ public sealed class ImGuiAppWindowManagementTests
 	public void Setup()
 	{
 		ImGuiApp.Reset();
+
+		// These tests assert on application-driven window placement, so pin the geometry mode
+		// instead of letting it be decided by whichever session the test host happens to run in
+		// (auto-detection hands geometry to the compositor under Wayland and tiling WMs).
+		ImGuiApp.Config = new ImGuiAppConfig { WindowGeometry = WindowGeometryMode.Application };
 	}
 
 	[TestCleanup]
@@ -265,9 +270,52 @@ public sealed class ImGuiAppWindowManagementTests
 		ImGuiApp.DisableOverlay();
 	}
 
+	[TestMethod]
+	public void CaptureWindowNormalState_WhenCompositorOwnsGeometry_KeepsSavedPosition()
+	{
+		// Wayland and tiling window managers report a placeholder position. Recording it would
+		// overwrite the caller's saved geometry with garbage that is then persisted and restored.
+		ImGuiApp.Config = new ImGuiAppConfig { WindowGeometry = WindowGeometryMode.Compositor };
+		ImGuiApp.LastNormalWindowState = new ImGuiAppWindowState { Size = new Vector2(800, 600), Pos = new Vector2(300, 200) };
+
+		Mock<IWindow> mockWindow = TestHelpers.CreateMockWindow();
+		mockWindow.Setup(w => w.WindowState).Returns(WindowState.Normal);
+		mockWindow.Setup(w => w.Size).Returns(new Silk.NET.Maths.Vector2D<int>(1024, 768));
+		mockWindow.Setup(w => w.Position).Returns(new Silk.NET.Maths.Vector2D<int>(0, 0));
+		ImGuiApp.window = mockWindow.Object;
+
+		ImGuiApp.CaptureWindowNormalState();
+
+		Assert.AreEqual(new Vector2(1024, 768), ImGuiApp.LastNormalWindowState.Size, "The compositor-assigned size is still worth recording.");
+		Assert.AreEqual(new Vector2(300, 200), ImGuiApp.LastNormalWindowState.Pos, "The reported position is meaningless here and must not overwrite the saved one.");
+	}
+
 	#endregion
 
 	#region Window Position Validation Tests
+
+	[TestMethod]
+	public void EnsureWindowPositionIsValid_WhenCompositorOwnsGeometry_LeavesWindowAlone()
+	{
+		// The window is entirely outside the monitor, which would normally trigger a relocation.
+		// Under a tiling window manager that relocation is either ignored or fights the tiler.
+		ImGuiApp.Config = new ImGuiAppConfig { WindowGeometry = WindowGeometryMode.Compositor };
+
+		Mock<IWindow> mockWindow = TestHelpers.CreateMockWindow();
+		Mock<IMonitor> mockMonitor = new();
+		mockMonitor.Setup(m => m.Bounds).Returns(new Silk.NET.Maths.Rectangle<int>(0, 0, 1920, 1080));
+		mockWindow.Setup(w => w.Monitor).Returns(mockMonitor.Object);
+		mockWindow.Setup(w => w.WindowState).Returns(WindowState.Normal);
+		mockWindow.Setup(w => w.Size).Returns(new Silk.NET.Maths.Vector2D<int>(1280, 720));
+		mockWindow.Setup(w => w.Position).Returns(new Silk.NET.Maths.Vector2D<int>(30000, 30000));
+		ImGuiApp.window = mockWindow.Object;
+
+		ImGuiApp.ForceWindowPositionValidation();
+		ImGuiApp.EnsureWindowPositionIsValid();
+
+		mockWindow.VerifySet(w => w.Position = It.IsAny<Silk.NET.Maths.Vector2D<int>>(), Times.Never());
+		mockWindow.VerifySet(w => w.Size = It.IsAny<Silk.NET.Maths.Vector2D<int>>(), Times.Never());
+	}
 
 	[TestMethod]
 	public void EnsureWindowPositionIsValid_WithNullWindow_DoesNotThrow()

--- a/tests/ImGui.App.Tests/WindowingEnvironmentTests.cs
+++ b/tests/ImGui.App.Tests/WindowingEnvironmentTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.ImGui.App.Tests;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Tests for tiling / Wayland window manager detection and the geometry-ownership decision it feeds.
+/// </summary>
+[TestClass]
+public sealed class WindowingEnvironmentTests
+{
+	/// <summary>Builds an environment reader over a fixed set of variables.</summary>
+	private static Func<string, string?> EnvironmentReader(params (string Name, string Value)[] variables) =>
+		name => variables.FirstOrDefault(v => v.Name == name).Value;
+
+	[TestMethod]
+	public void Detect_WithWaylandSessionType_ReportsCompositorOwnership()
+	{
+		if (!OperatingSystem.IsLinux() && !OperatingSystem.IsFreeBSD())
+		{
+			Assert.Inconclusive("Detection only inspects the environment on Linux and FreeBSD.");
+		}
+
+		bool result = WindowingEnvironment.Detect(EnvironmentReader(("XDG_SESSION_TYPE", "wayland")));
+
+		Assert.IsTrue(result, "A Wayland client cannot query or set its own position, so the compositor owns geometry.");
+	}
+
+	[TestMethod]
+	public void Detect_WithWaylandDisplayOnly_ReportsCompositorOwnership()
+	{
+		if (!OperatingSystem.IsLinux() && !OperatingSystem.IsFreeBSD())
+		{
+			Assert.Inconclusive("Detection only inspects the environment on Linux and FreeBSD.");
+		}
+
+		bool result = WindowingEnvironment.Detect(EnvironmentReader(("WAYLAND_DISPLAY", "wayland-1")));
+
+		Assert.IsTrue(result, "WAYLAND_DISPLAY alone identifies a Wayland session.");
+	}
+
+	[TestMethod]
+	public void Detect_WithTilingDesktopName_ReportsCompositorOwnership()
+	{
+		if (!OperatingSystem.IsLinux() && !OperatingSystem.IsFreeBSD())
+		{
+			Assert.Inconclusive("Detection only inspects the environment on Linux and FreeBSD.");
+		}
+
+		bool result = WindowingEnvironment.Detect(EnvironmentReader(
+			("XDG_SESSION_TYPE", "x11"),
+			("XDG_CURRENT_DESKTOP", "i3")));
+
+		Assert.IsTrue(result, "A tiling window manager on X11 owns geometry even though X11 clients can request positions.");
+	}
+
+	[TestMethod]
+	public void Detect_WithColonSeparatedDesktopList_MatchesAnyEntry()
+	{
+		if (!OperatingSystem.IsLinux() && !OperatingSystem.IsFreeBSD())
+		{
+			Assert.Inconclusive("Detection only inspects the environment on Linux and FreeBSD.");
+		}
+
+		bool result = WindowingEnvironment.Detect(EnvironmentReader(
+			("XDG_SESSION_TYPE", "x11"),
+			("XDG_CURRENT_DESKTOP", "wlroots:sway")));
+
+		Assert.IsTrue(result, "XDG_CURRENT_DESKTOP may hold a colon-separated list; any tiling entry counts.");
+	}
+
+	[TestMethod]
+	public void Detect_WithTilingSessionMarker_ReportsCompositorOwnership()
+	{
+		if (!OperatingSystem.IsLinux() && !OperatingSystem.IsFreeBSD())
+		{
+			Assert.Inconclusive("Detection only inspects the environment on Linux and FreeBSD.");
+		}
+
+		bool result = WindowingEnvironment.Detect(EnvironmentReader(
+			("XDG_SESSION_TYPE", "x11"),
+			("I3SOCK", "/run/user/1000/i3/ipc.sock")));
+
+		Assert.IsTrue(result, "A window manager's IPC socket identifies it even when the XDG variables are unset.");
+	}
+
+	[TestMethod]
+	public void Detect_WithFloatingX11Desktop_ReportsApplicationOwnership()
+	{
+		bool result = WindowingEnvironment.Detect(EnvironmentReader(
+			("XDG_SESSION_TYPE", "x11"),
+			("XDG_CURRENT_DESKTOP", "GNOME")));
+
+		Assert.IsFalse(result, "A floating X11 desktop honours client-requested geometry.");
+	}
+
+	[TestMethod]
+	public void Detect_WithEmptyEnvironment_ReportsApplicationOwnership()
+	{
+		bool result = WindowingEnvironment.Detect(EnvironmentReader());
+
+		Assert.IsFalse(result, "With nothing to go on, the application keeps its existing placement behaviour.");
+	}
+
+	[TestMethod]
+	public void Detect_WithNullReader_Throws() =>
+		Assert.ThrowsExactly<ArgumentNullException>(() => WindowingEnvironment.Detect(null!));
+
+	[TestMethod]
+	public void CompositorOwnsWindowGeometry_WithApplicationMode_IgnoresDetection()
+	{
+		ImGuiApp.Reset();
+		ImGuiApp.Config = new ImGuiAppConfig { WindowGeometry = WindowGeometryMode.Application };
+
+		Assert.IsFalse(ImGuiApp.CompositorOwnsWindowGeometry, "An explicit mode must override auto-detection.");
+
+		ImGuiApp.Reset();
+	}
+
+	[TestMethod]
+	public void CompositorOwnsWindowGeometry_WithCompositorMode_IgnoresDetection()
+	{
+		ImGuiApp.Reset();
+		ImGuiApp.Config = new ImGuiAppConfig { WindowGeometry = WindowGeometryMode.Compositor };
+
+		Assert.IsTrue(ImGuiApp.CompositorOwnsWindowGeometry, "An explicit mode must override auto-detection.");
+
+		ImGuiApp.Reset();
+	}
+
+	[TestMethod]
+	public void CompositorOwnsGeometry_IsStableAcrossQueriesAndCacheResets()
+	{
+		bool first = WindowingEnvironment.CompositorOwnsGeometry;
+
+		Assert.AreEqual(first, WindowingEnvironment.CompositorOwnsGeometry, "The cached result must not change between queries.");
+
+		WindowingEnvironment.ResetCache();
+
+		Assert.AreEqual(first, WindowingEnvironment.CompositorOwnsGeometry, "Re-probing the same environment must reach the same conclusion.");
+	}
+
+	[TestMethod]
+	public void CompositorOwnsWindowGeometry_WithAutoMode_FollowsDetection()
+	{
+		ImGuiApp.Reset();
+
+		Assert.AreEqual(WindowGeometryMode.Auto, ImGuiApp.Config.WindowGeometry);
+		Assert.AreEqual(WindowingEnvironment.CompositorOwnsGeometry, ImGuiApp.CompositorOwnsWindowGeometry);
+	}
+}


### PR DESCRIPTION
## Problem

Running any ImGuiApp under a tiling Wayland compositor (reported on [niri](https://github.com/YaLTeR/niri)) drew the UI into the bottom-left corner of the window, with the rest left as clear color. Saved layouts also degraded on every launch, and the app fought the tiler over window placement.

## Root cause

Two independent bugs, both only visible where the compositor owns geometry.

**1. Viewport / display-size mismatch.** ImGui's coordinate space is framebuffer pixels, but `SetPerFrameImGuiData` set `DisplaySize` to the window's *logical* size while hard-coding `DisplayFramebufferScale = 1` on Linux. Under niri at fractional scale 1.75 that is a 707x805 viewport inside a 1237x1408 framebuffer:

```
DIAG: size=<707, 805> fb=<1237, 1408> display=<707, 805> fbscale=<1, 1> scale=1
```

That same mismatch is what corrupted saved layouts — ImGui clamped every window into a viewport smaller than the real one, then wrote the squashed result back to `imgui.ini`, collapsing positions a little more each launch.

The viewport was also only ever set from `FramebufferResize`, which is never raised for the *initial* size when the compositor sizes the surface before the handler is attached — leaving it at whatever the drawable was when the context was created.

**2. Fighting the window manager.** `EnsureWindowPositionIsValid` relocates a window it believes is off-screen, but a Wayland client cannot read its own position, so the placeholder it gets back is meaningless. `CaptureWindowNormalState` then persisted that placeholder as the caller's saved geometry.

## Changes

- `SetPerFrameImGuiData`: `DisplaySize` is the framebuffer, framebuffer scale is 1, on every platform. Linux special case removed.
- `SetupRenderState`: set `glViewport` from the draw data each frame, as upstream's backend does.
- `UpdateDpiScale`: take the scale from the surface ratio when the platform scales for us — authoritative where no desktop setting mentions the compositor's fractional scale. This is why text stays crisp rather than upscaled.
- `OnMouseMove`: convert the cursor from window units to framebuffer pixels to match.
- New `WindowingEnvironment` + `ImGuiAppConfig.WindowGeometry` (`Auto` / `Application` / `Compositor`): under Wayland or a detected tiling WM, skip position validation, don't request a startup position, and don't record the reported position.

## Testing

591 tests pass. Window geometry tests now pin `WindowGeometryMode.Application` so they no longer depend on the session the test host runs in.

Verified interactively on niri: the demo fills its tile, reflows correctly across a live `niri msg action set-column-width` resize, and the layout survives restarts.

**Not verified:** no input-injection tool available on the test machine, so pointer motion was never generated — the mouse conversion follows the same ratio `imgui_impl_sdl2` uses, but hover/click alignment is worth an interactive check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)