### PR TITLE
Upgrade to ktsu.Semantics 2.8.0 and simplify path access

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,10 +6,10 @@
     <PackageVersion Include="ktsu.Extensions" Version="1.5.31" />
     <PackageVersion Include="ktsu.ThemeProvider" Version="2.0.20" />
     <PackageVersion Include="ktsu.ThemeProvider.ImGui" Version="2.0.20" />
-    <PackageVersion Include="ktsu.Semantics.Color" Version="2.7.10" />
-    <PackageVersion Include="ktsu.Semantics.Paths" Version="2.7.10" />
-    <PackageVersion Include="ktsu.Semantics.Strings" Version="2.7.10" />
-    <PackageVersion Include="ktsu.Semantics.Quantities" Version="2.7.10" />
+    <PackageVersion Include="ktsu.Semantics.Color" Version="2.8.0" />
+    <PackageVersion Include="ktsu.Semantics.Paths" Version="2.8.0" />
+    <PackageVersion Include="ktsu.Semantics.Strings" Version="2.8.0" />
+    <PackageVersion Include="ktsu.Semantics.Quantities" Version="2.8.0" />
     <PackageVersion Include="ktsu.CaseConverter" Version="1.3.22" />
     <PackageVersion Include="Hexa.NET.ImGui" Version="2.2.9" />
     <PackageVersion Include="Hexa.NET.ImGuizmo" Version="2.2.9" />

--- a/ImGui.Popups/FilesystemBrowser.cs
+++ b/ImGui.Popups/FilesystemBrowser.cs
@@ -346,18 +346,20 @@ public partial class ImGuiPopups
 		/// <param name="contents">The filesystem entries to order.</param>
 		/// <returns>The ordered entries.</returns>
 		/// <remarks>
-		/// The secondary sort key is the entry's string value rather than the entry itself because
-		/// <see cref="IAbsolutePath"/> does not implement <see cref="IComparable{T}"/>. Sorting by the entry
-		/// would make LINQ fall back to <see cref="Comparer{T}.Default"/>, which calls the non-generic
-		/// <see cref="IComparable.CompareTo(object)"/> on the underlying semantic string, which throws
-		/// <see cref="ArgumentException"/> when handed a path object in ktsu.Semantics.Strings 2.7.10 and
-		/// earlier. Sorting on the string value also gives case-insensitive display order.
+		/// The secondary sort key is the entry's string value rather than the entry itself. Sorting by the
+		/// entry makes LINQ fall back to <see cref="Comparer{T}.Default"/>, because <see cref="IAbsolutePath"/>
+		/// implements neither <see cref="IComparable{T}"/> of itself nor of <see cref="IPath"/> — the
+		/// <see cref="IComparable{T}"/> that ktsu.Semantics.Paths declares on <see cref="IPath"/> only helps
+		/// collections typed as <see cref="IPath"/> exactly. Every comparison would therefore box through the
+		/// non-generic <see cref="IComparable.CompareTo(object)"/>, which additionally threw
+		/// <see cref="ArgumentException"/> before ktsu.Semantics.Strings 2.7.11 (ktsu-dev/ImGuiApp#273).
+		/// Sorting on the string value also gives case-insensitive display order.
 		/// </remarks>
 		internal static Collection<IAbsolutePath> SortContents(IEnumerable<IAbsolutePath> contents) =>
 			contents
 				.OrderBy(p => p is not AbsoluteDirectoryPath)
-				.ThenBy(p => p.ToString(), StringComparer.OrdinalIgnoreCase)
-				.ThenBy(p => p.ToString(), StringComparer.Ordinal)
+				.ThenBy(p => p.WeakString, StringComparer.OrdinalIgnoreCase)
+				.ThenBy(p => p.WeakString, StringComparer.Ordinal)
 				.ToCollection();
 
 		/// <summary>
@@ -390,8 +392,7 @@ public partial class ImGuiPopups
 			ImGui.TableNextColumn();
 			AbsoluteDirectoryPath? directory = path as AbsoluteDirectoryPath;
 			AbsoluteFilePath? file = path as AbsoluteFilePath;
-			string displayPath = directory?.WeakString ?? file?.WeakString ?? string.Empty;
-			displayPath = displayPath.RemovePrefix(CurrentDirectory.WeakString).Trim(Path.DirectorySeparatorChar);
+			string displayPath = path.WeakString.RemovePrefix(CurrentDirectory.WeakString).Trim(Path.DirectorySeparatorChar);
 
 			if (directory is not null)
 			{

--- a/tests/ImGui.Popups.Tests/FilesystemBrowserSortTests.cs
+++ b/tests/ImGui.Popups.Tests/FilesystemBrowserSortTests.cs
@@ -55,7 +55,7 @@ public sealed class FilesystemBrowserSortTests
 			MakeDirectory("alpha"),
 		];
 
-		List<string> sorted = [.. ImGuiPopups.FilesystemBrowser.SortContents(contents).Select(p => Path.GetFileName(p.ToString()!))];
+		List<string> sorted = [.. ImGuiPopups.FilesystemBrowser.SortContents(contents).Select(p => Path.GetFileName(p.WeakString))];
 
 		CollectionAssert.AreEqual(new List<string> { "alpha", "zebra", "a.txt", "b.txt" }, sorted);
 	}
@@ -70,7 +70,7 @@ public sealed class FilesystemBrowserSortTests
 			MakeFile("Banana.txt"),
 		];
 
-		List<string> sorted = [.. ImGuiPopups.FilesystemBrowser.SortContents(contents).Select(p => Path.GetFileName(p.ToString()!))];
+		List<string> sorted = [.. ImGuiPopups.FilesystemBrowser.SortContents(contents).Select(p => Path.GetFileName(p.WeakString))];
 
 		CollectionAssert.AreEqual(new List<string> { "apple.txt", "Banana.txt", "Zebra.txt" }, sorted);
 	}
@@ -90,8 +90,8 @@ public sealed class FilesystemBrowserSortTests
 			MakeFile("b.txt"),
 		];
 
-		List<string> sorted = [.. ImGuiPopups.FilesystemBrowser.SortContents(contents).Select(p => p.ToString()!)];
-		List<string> sortedReversed = [.. ImGuiPopups.FilesystemBrowser.SortContents(reversed).Select(p => p.ToString()!)];
+		List<string> sorted = [.. ImGuiPopups.FilesystemBrowser.SortContents(contents).Select(p => p.WeakString)];
+		List<string> sortedReversed = [.. ImGuiPopups.FilesystemBrowser.SortContents(reversed).Select(p => p.WeakString)];
 
 		CollectionAssert.AreEqual(sorted, sortedReversed);
 	}


### PR DESCRIPTION
Follow-up to #279.

## What 2.8.0 brings

ktsu-dev/Semantics#140 fixed `SemanticString<T>.CompareTo(object)` so it unwraps `ISemanticString` instead of handing another semantic string to `string.CompareTo(object)` — the root cause of #273 — and added `WeakString` to `IPath`, `IFileName`, `IFileExtension` and `IDirectoryName`.

## Nothing here was required

I verified this before writing any of it: ImGuiApp implements none of those interfaces, so the added interface members break nothing, and the existing code **builds and passes all 604 tests against 2.8.0 untouched**. Everything below is optional cleanup the new surface makes possible.

- **`DrawContentRow`** read the display path by testing for two concrete types and falling back to `string.Empty` — a branch that could never legitimately be reached, since every entry is one of the two:
  ```csharp
  AbsoluteDirectoryPath? directory = path as AbsoluteDirectoryPath;
  AbsoluteFilePath? file = path as AbsoluteFilePath;
  string displayPath = directory?.WeakString ?? file?.WeakString ?? string.Empty;
  ```
  `IAbsolutePath` now carries `WeakString` directly. (The `directory` cast stays — it still drives the trailing-separator and navigation branches.)
- **`SortContents` and its tests** used `ToString()`, which returns `string?` and cost a null-forgiving operator at each of four call sites.

## What deliberately did not change

`SortContents` still sorts on the string value rather than the entry itself. The `IComparable<IPath>` added in 2.8.0 only helps collections typed as `IPath` **exactly** — `CurrentContents` is a `Collection<IAbsolutePath>`, which implements `IComparable<T>` of neither itself nor `IPath`, so `.ThenBy(p => p)` would still box through the non-generic `CompareTo(object)`. It would no longer throw, but it would be slower and would lose the case-insensitive display order. The `<remarks>` on the method now records this.

All four Semantics packages move together, since that repo versions in lockstep.

## Verification

Restored, built and tested against the real `ktsu.Semantics.*` 2.8.0 from nuget.org (not a local build): 603 passed, 1 skipped (the Windows-only drive assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFRwYRHhEmVMGvrH2BbtbW
