### PR TITLE
[patch] Fix crash navigating to the parent directory in the filesystem browser

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,10 +6,10 @@
     <PackageVersion Include="ktsu.Extensions" Version="1.5.31" />
     <PackageVersion Include="ktsu.ThemeProvider" Version="2.0.23" />
     <PackageVersion Include="ktsu.ThemeProvider.ImGui" Version="2.0.23" />
-    <PackageVersion Include="ktsu.Semantics.Color" Version="2.8.1" />
-    <PackageVersion Include="ktsu.Semantics.Paths" Version="2.8.1" />
-    <PackageVersion Include="ktsu.Semantics.Strings" Version="2.8.1" />
-    <PackageVersion Include="ktsu.Semantics.Quantities" Version="2.8.1" />
+    <PackageVersion Include="ktsu.Semantics.Color" Version="2.9.0" />
+    <PackageVersion Include="ktsu.Semantics.Paths" Version="2.9.0" />
+    <PackageVersion Include="ktsu.Semantics.Strings" Version="2.9.0" />
+    <PackageVersion Include="ktsu.Semantics.Quantities" Version="2.9.0" />
     <PackageVersion Include="ktsu.CaseConverter" Version="1.3.23" />
     <PackageVersion Include="Hexa.NET.ImGui" Version="2.2.9" />
     <PackageVersion Include="Hexa.NET.ImGuizmo" Version="2.2.9" />

--- a/ImGui.Popups/FilesystemBrowser.cs
+++ b/ImGui.Popups/FilesystemBrowser.cs
@@ -372,12 +372,12 @@ public partial class ImGuiPopups
 			ImGui.TableNextColumn();
 			if (ImGui.Selectable("..", false, flags) && ImGui.IsMouseDoubleClicked(0))
 			{
-				string? newPath = Path.GetDirectoryName(CurrentDirectory.WeakString.Trim(Path.DirectorySeparatorChar));
-				if (newPath is not null)
-				{
-					CurrentDirectory = newPath.As<AbsoluteDirectoryPath>();
-					RefreshContents();
-				}
+				// Take the parent from the path type rather than trimming separators off the string: trimming
+				// also removes the leading separator, which is the root itself on Unix, so the "parent" came
+				// back relative and failed AbsoluteDirectoryPath validation (ktsu-dev/ImGuiApp#281). A root is
+				// its own parent, so this stays put once there is nowhere left to go.
+				CurrentDirectory = CurrentDirectory.Parent;
+				RefreshContents();
 			}
 		}
 


### PR DESCRIPTION
Fixes #281.

## Problem

Double-clicking `..` in the filesystem browser crashed on Linux:

```
System.ArgumentException: Cannot convert "home" to AbsoluteDirectoryPath
   at ktsu.Semantics.Strings.SemanticString`1.PerformValidation[TDest](TDest value)
   at ktsu.ImGui.Popups.ImGuiPopups.FilesystemBrowser.DrawFileTable()
```

The handler took the parent by trimming directory separators off the path string:

```csharp
Path.GetDirectoryName(CurrentDirectory.WeakString.Trim(Path.DirectorySeparatorChar))
```

`Trim` strips separators from **both** ends. On Unix the leading `/` *is* the root, so `/home/lsma` became `home/lsma`, whose parent `home` is relative and fails `AbsoluteDirectoryPath` validation. Windows drive paths start with `C:\` rather than a separator, which is why only Linux saw it — but UNC paths (`\server\share\…`) hit the identical bug on Windows, and that reproduced locally as `Cannot convert "server\share\folder" to AbsoluteDirectoryPath`.

A second, quieter bug came from the same line: going up from `/home` produced an **empty** path, so the browser silently showed no contents instead of landing on `/`.

## Change

Take the parent from the path type instead of doing string math:

```csharp
CurrentDirectory = CurrentDirectory.Parent;
RefreshContents();
```

No guard is needed because ktsu-dev/Semantics#144 made a root its own parent, so `..` simply stays put once there is nowhere left to go. That shipped as **ktsu.Semantics 2.9.0**, which this PR bumps to (all four `ktsu.Semantics.*` packages together — one repo, one version).

The root-cause fix living in Semantics is why there is no `ParentOf` helper here and no regression test in this repo: the behaviour under test is `AbsoluteDirectoryPath.Parent`, and it is covered by 7 new tests in `Semantics.Test/Paths/AbsoluteDirectoryPathParentTests.cs` (parent chains, root-is-its-own-parent, UNC share roots, never returning an empty or relative path while walking up, termination at the fixed point, `GetAncestors` behaviour), written so the Unix cases execute on Linux CI rather than skipping.

## Verification

- `dotnet build ImGui.sln` against 2.9.0: clean, **0 warnings** (warnings-as-errors, so the Semantics behaviour change introduced no new diagnostics).
- `dotnet test ImGui.sln`: **604 total, 0 failed**, 8 OS-skipped.
- Ran the `..` walk on real Linux (WSL) against `ktsu.Semantics.Paths` **2.9.0 from nuget.org**, no patched binaries: `/home/matt/parenttest → /home/matt → /home → /`, then stays at `/`. The exact exception from the issue no longer occurs.
- Semantics side: full suite 1079 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)