### PR TITLE
Mark Polyfill as private in library csproj

### DIFF
--- a/ForceDirectedLayout/ForceDirectedLayout.csproj
+++ b/ForceDirectedLayout/ForceDirectedLayout.csproj
@@ -30,6 +30,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Polyfill" />
+    <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/ImGui.App/ImGui.App.csproj
+++ b/ImGui.App/ImGui.App.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="ktsu.Semantics.Paths" />
     <PackageReference Include="ktsu.Semantics.Strings" />
     <PackageReference Include="SixLabors.ImageSharp" />
-    <PackageReference Include="Polyfill" />
+    <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="!$(TargetFramework.Contains('-ios'))">

--- a/ImGui.Color/ImGui.Color.csproj
+++ b/ImGui.Color/ImGui.Color.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Hexa.NET.ImGui" />
     <PackageReference Include="ktsu.Semantics.Color" />
-    <PackageReference Include="Polyfill" />
+    <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/ImGui.Markdown/ImGui.Markdown.csproj
+++ b/ImGui.Markdown/ImGui.Markdown.csproj
@@ -16,6 +16,6 @@
     <PackageReference Include="Markdig" />
     <PackageReference Include="ktsu.Semantics.Color" />
     <ProjectReference Include="..\ImGui.Color\ImGui.Color.csproj" />
-    <PackageReference Include="Polyfill" />
+    <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/ImGui.Popups/ImGui.Popups.csproj
+++ b/ImGui.Popups/ImGui.Popups.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="ktsu.Semantics.Strings" />
     <PackageReference Include="ktsu.Semantics.Paths" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
-    <PackageReference Include="Polyfill" />
+    <PackageReference Include="Polyfill" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 

--- a/ImGui.Styler/ImGui.Styler.csproj
+++ b/ImGui.Styler/ImGui.Styler.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="ktsu.ThemeProvider.ImGui" />
     <ProjectReference Include="..\ImGui.Color\ImGui.Color.csproj" />
     <ProjectReference Include="..\ImGui.Popups\ImGui.Popups.csproj" />
-    <PackageReference Include="Polyfill" />
+    <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/ImGui.Widgets/ImGui.Widgets.csproj
+++ b/ImGui.Widgets/ImGui.Widgets.csproj
@@ -18,6 +18,6 @@
     <PackageReference Include="ktsu.TextFilter" />
     <ProjectReference Include="..\ImGui.Color\ImGui.Color.csproj" />
     <ProjectReference Include="..\ImGui.Styler\ImGui.Styler.csproj" />
-    <PackageReference Include="Polyfill" />
+    <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/ImGuiNodeEditor/ImGuiNodeEditor.csproj
+++ b/ImGuiNodeEditor/ImGuiNodeEditor.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Hexa.NET.ImGui" />
     <PackageReference Include="Hexa.NET.ImNodes" />
     <PackageReference Include="ktsu.Semantics.Quantities" />
-    <PackageReference Include="Polyfill" />
+    <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds `PrivateAssets="all"` to `Polyfill` package references across the library projects so Polyfill is used only at build/compile time within this repo and is not exposed as a transitive dependency to downstream consumers.