### PR TITLE
chore: update ktsu.Sdk to 2.21.1 [patch]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,9 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 tab_width = 4
-end_of_line = crlf
+# LF on every platform, matching the `* text=auto eol=lf` default in .gitattributes.
+# Overrides below must stay in step with the eol pins in that file.
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
@@ -17,7 +19,7 @@ trim_trailing_whitespace = true
 [*.{cs,csx,cake,fs,fsx,vb,vbx}]
 indent_style = tab
 
-file_header_template = Copyright (c) ktsu.dev\nAll rights reserved.\nLicensed under the MIT license.
+file_header_template = Copyright (c) 2023-2026 ktsu-dev contributors
 
 # Default severity for all .NET Code Style rules
 dotnet_analyzer_diagnostic.severity = error
@@ -504,3 +506,8 @@ indent_style = tab
 [*.sh]
 end_of_line = lf
 indent_size = 2
+
+# Windows batch scripts and Visual Studio solution files keep CRLF on every platform.
+# These match the eol=crlf pins in .gitattributes.
+[*.{cmd,bat,sln}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,20 +4,25 @@
 # Git Line Endings            #
 ###############################
 
-# Set default behaviour to automatically normalize line endings.
-* text=auto
+# Normalize all text files to LF in the repository, and check them out as LF on every
+# platform. The explicit eol overrides each machine's core.autocrlf, so the working tree
+# is byte-identical on Windows, Linux and macOS. This must stay in step with the
+# end_of_line settings in .editorconfig.
+* text=auto eol=lf
 
-# csharp files to match .editorconfig
-*.cs text eol=crlf
+# Force bash scripts to always use LF line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work. Redundant with the
+# default above, kept explicit because these files break outright with CRLF.
+*.sh text eol=lf
 
 # Force batch scripts to always use CRLF line endings so that if a repo is accessed
 # in Windows via a file share from Linux, the scripts will work.
-*.{cmd,[cC][mM][dD]} text eol=crlf
-*.{bat,[bB][aA][tT]} text eol=crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
 
-# Force bash scripts to always use LF line endings so that if a repo is accessed
-# in Unix via a file share from Windows, the scripts will work.
-*.sh text eol=lf
+# Visual Studio rewrites solution files with CRLF regardless of the checkout, so pin
+# them to avoid a spurious whole-file diff every time the solution is opened.
+*.sln text eol=crlf
 
 ###############################
 # Git Large File System (LFS) #

--- a/.runsettings
+++ b/.runsettings
@@ -1,25 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
-  <!-- Specify a deterministic output directory -->
   <RunConfiguration>
-    <ResultsDirectory>.\coverage</ResultsDirectory>
+    <ResultsDirectory>TestResults</ResultsDirectory>
   </RunConfiguration>
-  <!-- Specify a deterministic output directory -->
-  <RunConfiguration>
-    <ResultsDirectory>.\coverage</ResultsDirectory>
-  </RunConfiguration>
-
-  <!-- Configuration for coverlet data collector -->
-  <DataCollectionRunSettings>
-    <DataCollectors>
-      <DataCollector friendlyName="XPlat Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="coverlet.collector.DataCollectors.CoverletInProcDataCollector, coverlet.collector, Version=6.0.4.0, Culture=neutral, PublicKeyToken=null">
-        <Configuration>
-          <Format>opencover</Format>
-          <OutputPath>coverage.opencover.xml</OutputPath>
-          <Exclude>[*Test*]*,[*Tests*]*</Exclude>
-          <ExcludeByFile>**/obj/**/*</ExcludeByFile>
-        </Configuration>
-      </DataCollector>
-    </DataCollectors>
-  </DataCollectionRunSettings>
 </RunSettings>

--- a/ForceDirectedLayout.Native/AssemblyInfo.cs
+++ b/ForceDirectedLayout.Native/AssemblyInfo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // This assembly is a thin AOT publish wrapper around ktsu.ForceDirectedLayout.
 // Its only purpose is to be `dotnet publish -r <rid> /p:PublishAot=true /p:NativeLib=Shared`-ed

--- a/ForceDirectedLayout/BodyAccessor.cs
+++ b/ForceDirectedLayout/BodyAccessor.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ForceDirectedLayout;
 

--- a/ForceDirectedLayout/BodyState.cs
+++ b/ForceDirectedLayout/BodyState.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ForceDirectedLayout;
 

--- a/ForceDirectedLayout/EdgeAccessor.cs
+++ b/ForceDirectedLayout/EdgeAccessor.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ForceDirectedLayout;
 

--- a/ForceDirectedLayout/ForceDirectedLayout.cs
+++ b/ForceDirectedLayout/ForceDirectedLayout.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ForceDirectedLayout;
 

--- a/ForceDirectedLayout/ForceLayout.cs
+++ b/ForceDirectedLayout/ForceLayout.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ForceDirectedLayout;
 

--- a/ForceDirectedLayout/LayoutCore.cs
+++ b/ForceDirectedLayout/LayoutCore.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ForceDirectedLayout;
 

--- a/ForceDirectedLayout/LayoutSettings.cs
+++ b/ForceDirectedLayout/LayoutSettings.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ForceDirectedLayout;
 

--- a/ForceDirectedLayout/NativeExports.cs
+++ b/ForceDirectedLayout/NativeExports.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ForceDirectedLayout;
 

--- a/ForceDirectedLayout/PhysicsSettings.cs
+++ b/ForceDirectedLayout/PhysicsSettings.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ForceDirectedLayout;
 

--- a/ForceDirectedLayout/Vec2D.cs
+++ b/ForceDirectedLayout/Vec2D.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ForceDirectedLayout;
 

--- a/ImGui.App/DebugLogger.cs
+++ b/ImGui.App/DebugLogger.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/FontAppearance.cs
+++ b/ImGui.App/FontAppearance.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/FontHelper.cs
+++ b/ImGui.App/FontHelper.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/FontMemoryGuard.cs
+++ b/ImGui.App/FontMemoryGuard.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/ForceDpiAware.cs
+++ b/ImGui.App/ForceDpiAware.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #pragma warning disable IDE0078 // Use pattern matching
 

--- a/ImGui.App/GdiPlusHelper.cs
+++ b/ImGui.App/GdiPlusHelper.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/IImGuiAppSession.cs
+++ b/ImGui.App/IImGuiAppSession.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/IRendererBackend.cs
+++ b/ImGui.App/IRendererBackend.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/ImGuiApp.Embedded.cs
+++ b/ImGui.App/ImGuiApp.Embedded.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/ImGuiApp.cs
+++ b/ImGui.App/ImGuiApp.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/ImGuiAppBlend.cs
+++ b/ImGui.App/ImGuiAppBlend.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/ImGuiAppConfig.cs
+++ b/ImGui.App/ImGuiAppConfig.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/ImGuiAppPerformanceSettings.cs
+++ b/ImGui.App/ImGuiAppPerformanceSettings.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/ImGuiAppTextureInfo.cs
+++ b/ImGui.App/ImGuiAppTextureInfo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/ImGuiAppWindowHost.cs
+++ b/ImGui.App/ImGuiAppWindowHost.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/ImGuiAppWindowState.cs
+++ b/ImGui.App/ImGuiAppWindowState.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/ImGuiController/GLWrapper.cs
+++ b/ImGui.App/ImGuiController/GLWrapper.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.ImGuiController;
 

--- a/ImGui.App/ImGuiController/IGL.cs
+++ b/ImGui.App/ImGuiController/IGL.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.ImGuiController;
 

--- a/ImGui.App/ImGuiController/IOpenGLFactory.cs
+++ b/ImGui.App/ImGuiController/IOpenGLFactory.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.ImGuiController;
 

--- a/ImGui.App/ImGuiController/IOpenGLProvider.cs
+++ b/ImGui.App/ImGuiController/IOpenGLProvider.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.ImGuiController;
 

--- a/ImGui.App/ImGuiController/ImGuiController.cs
+++ b/ImGui.App/ImGuiController/ImGuiController.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.ImGuiController;
 

--- a/ImGui.App/ImGuiController/ImGuiFontConfig.cs
+++ b/ImGui.App/ImGuiController/ImGuiFontConfig.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.ImGuiController;
 

--- a/ImGui.App/ImGuiController/OpenGLProvider.cs
+++ b/ImGui.App/ImGuiController/OpenGLProvider.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.ImGuiController;
 

--- a/ImGui.App/ImGuiController/Shader.cs
+++ b/ImGui.App/ImGuiController/Shader.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.ImGuiController;
 

--- a/ImGui.App/ImGuiController/Texture.cs
+++ b/ImGui.App/ImGuiController/Texture.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.ImGuiController;
 

--- a/ImGui.App/ImGuiController/Util.cs
+++ b/ImGui.App/ImGuiController/Util.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.ImGuiController;
 

--- a/ImGui.App/ImGuiController/WindowOpenGLFactory.cs
+++ b/ImGui.App/ImGuiController/WindowOpenGLFactory.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.ImGuiController;
 

--- a/ImGui.App/ImGuiExtensionManager.cs
+++ b/ImGui.App/ImGuiExtensionManager.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/NativeMethods.cs
+++ b/ImGui.App/NativeMethods.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/OverlayWindow.cs
+++ b/ImGui.App/OverlayWindow.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/PidFrameLimiter.cs
+++ b/ImGui.App/PidFrameLimiter.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/Platform/iOS/IOSKeyMap.cs
+++ b/ImGui.App/Platform/iOS/IOSKeyMap.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #if IOS
 

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.Input.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.Input.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #if IOS
 

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.NoOps.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.NoOps.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #if IOS
 

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.Render.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.Render.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #if IOS
 

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.Textures.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.Textures.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #if IOS
 

--- a/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
+++ b/ImGui.App/Platform/iOS/ImGuiApp.iOS.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #if IOS
 

--- a/ImGui.App/Platform/iOS/ImGuiAppDelegate.cs
+++ b/ImGui.App/Platform/iOS/ImGuiAppDelegate.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #if IOS
 

--- a/ImGui.App/Platform/iOS/ImGuiAppViewController.cs
+++ b/ImGui.App/Platform/iOS/ImGuiAppViewController.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #if IOS
 

--- a/ImGui.App/Platform/iOS/MetalRendererBackend.cs
+++ b/ImGui.App/Platform/iOS/MetalRendererBackend.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #if IOS
 

--- a/ImGui.App/Platform/iOS/MetalView.cs
+++ b/ImGui.App/Platform/iOS/MetalView.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #if IOS
 

--- a/ImGui.App/Platform/iOS/SoftKeyboardView.cs
+++ b/ImGui.App/Platform/iOS/SoftKeyboardView.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #if IOS
 

--- a/ImGui.App/UIScaler.cs
+++ b/ImGui.App/UIScaler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/WindowGeometryMode.cs
+++ b/ImGui.App/WindowGeometryMode.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.App/WindowingEnvironment.cs
+++ b/ImGui.App/WindowingEnvironment.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App;
 

--- a/ImGui.Color/ColorImGuiExtensions.cs
+++ b/ImGui.Color/ColorImGuiExtensions.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Color;
 

--- a/ImGui.Color/ImColorExtensions.cs
+++ b/ImGui.Color/ImColorExtensions.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Color;
 

--- a/ImGui.Color/ImGuiVector4.cs
+++ b/ImGui.Color/ImGuiVector4.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Color;
 

--- a/ImGui.Color/SrgbImGuiExtensions.cs
+++ b/ImGui.Color/SrgbImGuiExtensions.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Color;
 

--- a/ImGui.Markdown/ImGuiMarkdown.cs
+++ b/ImGui.Markdown/ImGuiMarkdown.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+﻿// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/InlineLayout.cs
+++ b/ImGui.Markdown/InlineLayout.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/LinkPolicy.cs
+++ b/ImGui.Markdown/LinkPolicy.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/MarkdownConfig.cs
+++ b/ImGui.Markdown/MarkdownConfig.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/MarkdownDocument.cs
+++ b/ImGui.Markdown/MarkdownDocument.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+﻿// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/MarkdownParser.cs
+++ b/ImGui.Markdown/MarkdownParser.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+﻿// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/Rendering/BlockRenderer.cs
+++ b/ImGui.Markdown/Rendering/BlockRenderer.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+﻿// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/Rendering/InlineBuilder.cs
+++ b/ImGui.Markdown/Rendering/InlineBuilder.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+﻿// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/Rendering/InlineRenderer.cs
+++ b/ImGui.Markdown/Rendering/InlineRenderer.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+﻿// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/Rendering/ListMarker.cs
+++ b/ImGui.Markdown/Rendering/ListMarker.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/Rendering/MarkdownColors.cs
+++ b/ImGui.Markdown/Rendering/MarkdownColors.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/Rendering/MarkdownSizing.cs
+++ b/ImGui.Markdown/Rendering/MarkdownSizing.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Markdown/Rendering/ScopedMarkdownFont.cs
+++ b/ImGui.Markdown/Rendering/ScopedMarkdownFont.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown;
 

--- a/ImGui.Popups/FilesystemBrowser.cs
+++ b/ImGui.Popups/FilesystemBrowser.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Popups;
 

--- a/ImGui.Popups/Input.cs
+++ b/ImGui.Popups/Input.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Popups;
 

--- a/ImGui.Popups/MessageOK.cs
+++ b/ImGui.Popups/MessageOK.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Popups;
 

--- a/ImGui.Popups/Modal.cs
+++ b/ImGui.Popups/Modal.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Popups;
 

--- a/ImGui.Popups/Prompt.cs
+++ b/ImGui.Popups/Prompt.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Popups;
 

--- a/ImGui.Popups/SearchableList.cs
+++ b/ImGui.Popups/SearchableList.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Popups;
 

--- a/ImGui.Styler/Alignment.cs
+++ b/ImGui.Styler/Alignment.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/Button.cs
+++ b/ImGui.Styler/Button.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/Indent.cs
+++ b/ImGui.Styler/Indent.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/Palette.cs
+++ b/ImGui.Styler/Palette.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/ScopedColor.cs
+++ b/ImGui.Styler/ScopedColor.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/ScopedStyleVar.cs
+++ b/ImGui.Styler/ScopedStyleVar.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/ScopedTextColor.cs
+++ b/ImGui.Styler/ScopedTextColor.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/ScopedTheme.cs
+++ b/ImGui.Styler/ScopedTheme.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/ScopedThemeColor.cs
+++ b/ImGui.Styler/ScopedThemeColor.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/Text.cs
+++ b/ImGui.Styler/Text.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/Theme.cs
+++ b/ImGui.Styler/Theme.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/ThemeBrowser.cs
+++ b/ImGui.Styler/ThemeBrowser.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Styler/ThemeCard.cs
+++ b/ImGui.Styler/ThemeCard.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Styler;
 

--- a/ImGui.Widgets/Animation/Easing.cs
+++ b/ImGui.Widgets/Animation/Easing.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Animation;
 

--- a/ImGui.Widgets/Animation/Spring.cs
+++ b/ImGui.Widgets/Animation/Spring.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Animation;
 

--- a/ImGui.Widgets/Animation/Tween.cs
+++ b/ImGui.Widgets/Animation/Tween.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Animation;
 

--- a/ImGui.Widgets/Avatar.cs
+++ b/ImGui.Widgets/Avatar.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Badge.cs
+++ b/ImGui.Widgets/Badge.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Card.cs
+++ b/ImGui.Widgets/Card.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Chip.cs
+++ b/ImGui.Widgets/Chip.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/ColorIndicator.cs
+++ b/ImGui.Widgets/ColorIndicator.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Combo.cs
+++ b/ImGui.Widgets/Combo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/DbMeter.cs
+++ b/ImGui.Widgets/DbMeter.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/DividerContainer.cs
+++ b/ImGui.Widgets/DividerContainer.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/DividerZone.cs
+++ b/ImGui.Widgets/DividerZone.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Gestures/GestureDetector.cs
+++ b/ImGui.Widgets/Gestures/GestureDetector.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Gestures/GestureFlags.cs
+++ b/ImGui.Widgets/Gestures/GestureFlags.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Gestures;
 

--- a/ImGui.Widgets/Gestures/GestureMachine.cs
+++ b/ImGui.Widgets/Gestures/GestureMachine.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Gestures;
 

--- a/ImGui.Widgets/Gestures/GestureResult.cs
+++ b/ImGui.Widgets/Gestures/GestureResult.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Gestures;
 

--- a/ImGui.Widgets/Gestures/GestureSettings.cs
+++ b/ImGui.Widgets/Gestures/GestureSettings.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Gestures;
 

--- a/ImGui.Widgets/Grid.cs
+++ b/ImGui.Widgets/Grid.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Icon.cs
+++ b/ImGui.Widgets/Icon.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Image.cs
+++ b/ImGui.Widgets/Image.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Knob.cs
+++ b/ImGui.Widgets/Knob.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Overlays/OverlayHost.cs
+++ b/ImGui.Widgets/Overlays/OverlayHost.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Overlays;
 

--- a/ImGui.Widgets/Overlays/OverlayLayer.cs
+++ b/ImGui.Widgets/Overlays/OverlayLayer.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Overlays;
 

--- a/ImGui.Widgets/PageIndicator.cs
+++ b/ImGui.Widgets/PageIndicator.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/PinInput.cs
+++ b/ImGui.Widgets/PinInput.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/RadialProgressBar.cs
+++ b/ImGui.Widgets/RadialProgressBar.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/RangeSlider.cs
+++ b/ImGui.Widgets/RangeSlider.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Rating.cs
+++ b/ImGui.Widgets/Rating.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Scope.cs
+++ b/ImGui.Widgets/Scope.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/ScopedDisable.cs
+++ b/ImGui.Widgets/ScopedDisable.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/ScopedId.cs
+++ b/ImGui.Widgets/ScopedId.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Scroll/InertialScroll.cs
+++ b/ImGui.Widgets/Scroll/InertialScroll.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Scroll;
 

--- a/ImGui.Widgets/SearchBox.cs
+++ b/ImGui.Widgets/SearchBox.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/SegmentedControl.cs
+++ b/ImGui.Widgets/SegmentedControl.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/SkeletonLoader.cs
+++ b/ImGui.Widgets/SkeletonLoader.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Stepper.cs
+++ b/ImGui.Widgets/Stepper.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Switch.cs
+++ b/ImGui.Widgets/Switch.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/TabPanel.cs
+++ b/ImGui.Widgets/TabPanel.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Text.cs
+++ b/ImGui.Widgets/Text.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/Tree.cs
+++ b/ImGui.Widgets/Tree.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/WidgetLabel.cs
+++ b/ImGui.Widgets/WidgetLabel.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGui.Widgets/XYPad.cs
+++ b/ImGui.Widgets/XYPad.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets;
 

--- a/ImGuiNodeEditor/AttributeBasedNodeFactory.cs
+++ b/ImGuiNodeEditor/AttributeBasedNodeFactory.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGuiNodeEditor;
 

--- a/ImGuiNodeEditor/DomainModels.cs
+++ b/ImGuiNodeEditor/DomainModels.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGuiNodeEditor;
 

--- a/ImGuiNodeEditor/NodeDefinition.cs
+++ b/ImGuiNodeEditor/NodeDefinition.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGuiNodeEditor;
 

--- a/ImGuiNodeEditor/NodeEditorEngine.cs
+++ b/ImGuiNodeEditor/NodeEditorEngine.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGuiNodeEditor;
 

--- a/ImGuiNodeEditor/NodeEditorInputHandler.cs
+++ b/ImGuiNodeEditor/NodeEditorInputHandler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGuiNodeEditor;
 

--- a/ImGuiNodeEditor/NodeEditorRenderer.cs
+++ b/ImGuiNodeEditor/NodeEditorRenderer.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGuiNodeEditor;
 

--- a/NodeGraph/ExecutionPinAttributes.cs
+++ b/NodeGraph/ExecutionPinAttributes.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph;
 

--- a/NodeGraph/InstancePinExamples.cs
+++ b/NodeGraph/InstancePinExamples.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Examples demonstrating automatic instance pin behavior for classes and structs.
 

--- a/NodeGraph/Library/Operations/CollectionOperations.cs
+++ b/NodeGraph/Library/Operations/CollectionOperations.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Collection and array operations as static method nodes.
 

--- a/NodeGraph/Library/Operations/DateTimeOperations.cs
+++ b/NodeGraph/Library/Operations/DateTimeOperations.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Date and time operations as static method nodes.
 

--- a/NodeGraph/Library/Operations/LogicOperations.cs
+++ b/NodeGraph/Library/Operations/LogicOperations.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Logic operations including type conversions and comparisons.
 

--- a/NodeGraph/Library/Operations/MathOperations.cs
+++ b/NodeGraph/Library/Operations/MathOperations.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Mathematical operations as static method nodes.
 

--- a/NodeGraph/Library/Operations/StringOperations.cs
+++ b/NodeGraph/Library/Operations/StringOperations.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // String manipulation operations as static method nodes.
 

--- a/NodeGraph/Library/Primitives/BooleanTypes.cs
+++ b/NodeGraph/Library/Primitives/BooleanTypes.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Boolean data types and their Make/Split/Set node implementations.
 

--- a/NodeGraph/Library/Primitives/NumberTypes.cs
+++ b/NodeGraph/Library/Primitives/NumberTypes.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Number data types and their Make/Split/Set node implementations.
 

--- a/NodeGraph/Library/Primitives/StringTypes.cs
+++ b/NodeGraph/Library/Primitives/StringTypes.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // String data types and their Make/Split/Set node implementations.
 

--- a/NodeGraph/Library/Primitives/VectorTypes.cs
+++ b/NodeGraph/Library/Primitives/VectorTypes.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Vector data types and their Make/Split/Set node implementations.
 

--- a/NodeGraph/Library/Utilities/Calculators.cs
+++ b/NodeGraph/Library/Utilities/Calculators.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Calculator utility nodes with instance methods.
 

--- a/NodeGraph/Library/Utilities/ControlFlow.cs
+++ b/NodeGraph/Library/Utilities/ControlFlow.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Control flow utility nodes.
 

--- a/NodeGraph/Library/Utilities/Counters.cs
+++ b/NodeGraph/Library/Utilities/Counters.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Counter utility nodes.
 

--- a/NodeGraph/Library/Utilities/Generators.cs
+++ b/NodeGraph/Library/Utilities/Generators.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Data generator utility nodes.
 

--- a/NodeGraph/Library/Utilities/Geometry.cs
+++ b/NodeGraph/Library/Utilities/Geometry.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Geometric utility nodes.
 

--- a/NodeGraph/Library/Utilities/Processors.cs
+++ b/NodeGraph/Library/Utilities/Processors.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 // Data processor utility nodes.
 

--- a/NodeGraph/NodeAttribute.cs
+++ b/NodeGraph/NodeAttribute.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph;
 

--- a/NodeGraph/NodeBehaviorAttributes.cs
+++ b/NodeGraph/NodeBehaviorAttributes.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph;
 

--- a/NodeGraph/PinAttributes.cs
+++ b/NodeGraph/PinAttributes.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph;
 

--- a/NodeGraph/PinTypeAttributes.cs
+++ b/NodeGraph/PinTypeAttributes.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph;
 

--- a/examples/ImGuiAppDemo.iOS/Program.cs
+++ b/examples/ImGuiAppDemo.iOS/Program.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 using System.Numerics;
 

--- a/examples/ImGuiAppDemo/DemoImages.cs
+++ b/examples/ImGuiAppDemo/DemoImages.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App;
 

--- a/examples/ImGuiAppDemo/Demos/AdvancedWidgetsDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/AdvancedWidgetsDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/AnimationDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/AnimationDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/BasicWidgetsDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/BasicWidgetsDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/CleanImNodesDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/CleanImNodesDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/DataVisualizationDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/DataVisualizationDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/GraphicsDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/GraphicsDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/IDemoTab.cs
+++ b/examples/ImGuiAppDemo/Demos/IDemoTab.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/ImGuizmoDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/ImGuizmoDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/ImNodesDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/ImNodesDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/ImPlotDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/ImPlotDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/InputHandlingDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/InputHandlingDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/LayoutDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/LayoutDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/NerdFontDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/NerdFontDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/UnicodeDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/UnicodeDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/Demos/UtilityDemo.cs
+++ b/examples/ImGuiAppDemo/Demos/UtilityDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App.Demos;
 

--- a/examples/ImGuiAppDemo/ImGuiAppDemo.cs
+++ b/examples/ImGuiAppDemo/ImGuiAppDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.App;
 

--- a/examples/ImGuiMarkdownDemo/ImGuiMarkdownDemo.cs
+++ b/examples/ImGuiMarkdownDemo/ImGuiMarkdownDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.Markdown;
 

--- a/examples/ImGuiPopupsDemo/ImGuiPopupsDemo.cs
+++ b/examples/ImGuiPopupsDemo/ImGuiPopupsDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.Popups;
 

--- a/examples/ImGuiStylerDemo/ImGuiStylerDemo.cs
+++ b/examples/ImGuiStylerDemo/ImGuiStylerDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.Styler;
 

--- a/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
+++ b/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Examples.Widgets;
 

--- a/global.json
+++ b/global.json
@@ -5,15 +5,15 @@
   },
   "msbuild-sdks": {
     "MSTest.Sdk": "4.3.3",
-    "ktsu.Sdk": "2.18.0",
-    "ktsu.Sdk.ConsoleApp": "2.18.0",
-    "ktsu.Sdk.Tool": "2.18.0",
-    "ktsu.Sdk.App": "2.18.0",
-    "ktsu.Sdk.Windows": "2.18.0",
-    "ktsu.Sdk.Linux": "2.18.0",
-    "ktsu.Sdk.macOS": "2.18.0",
-    "ktsu.Sdk.iOS": "2.18.0",
-    "ktsu.Sdk.Android": "2.18.0"
+    "ktsu.Sdk": "2.21.1",
+    "ktsu.Sdk.ConsoleApp": "2.21.1",
+    "ktsu.Sdk.Tool": "2.21.1",
+    "ktsu.Sdk.App": "2.21.1",
+    "ktsu.Sdk.Windows": "2.21.1",
+    "ktsu.Sdk.Linux": "2.21.1",
+    "ktsu.Sdk.macOS": "2.21.1",
+    "ktsu.Sdk.iOS": "2.21.1",
+    "ktsu.Sdk.Android": "2.21.1"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/tests/ForceDirectedLayout.Tests/ForceLayoutTests.cs
+++ b/tests/ForceDirectedLayout.Tests/ForceLayoutTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ForceDirectedLayout.Tests;
 

--- a/tests/ImGui.App.Tests/AdvancedCoverageTests.cs
+++ b/tests/ImGui.App.Tests/AdvancedCoverageTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/EmbeddedSessionTests.cs
+++ b/tests/ImGui.App.Tests/EmbeddedSessionTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/ErrorHandlingAndEdgeCaseTests.cs
+++ b/tests/ImGui.App.Tests/ErrorHandlingAndEdgeCaseTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/FontAndUITests.cs
+++ b/tests/ImGui.App.Tests/FontAndUITests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/FontMemoryGuardTests.cs
+++ b/tests/ImGui.App.Tests/FontMemoryGuardTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/ForceDpiAwareTests.cs
+++ b/tests/ImGui.App.Tests/ForceDpiAwareTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/GlobalScaleTests.cs
+++ b/tests/ImGui.App.Tests/GlobalScaleTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/ImGuiAppCoreTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppCoreTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/ImGuiAppDataStructureTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppDataStructureTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/ImGuiAppTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 [assembly: DoNotParallelize]
 

--- a/tests/ImGui.App.Tests/ImGuiAppWindowManagementTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppWindowManagementTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/ImGuiControllerComponentTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiControllerComponentTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/ImGuiExtensionManagerTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiExtensionManagerTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/MockGL.cs
+++ b/tests/ImGui.App.Tests/MockGL.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/PidFrameLimiterTests.cs
+++ b/tests/ImGui.App.Tests/PidFrameLimiterTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/PlatformSpecificTests.cs
+++ b/tests/ImGui.App.Tests/PlatformSpecificTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/TestGL.cs
+++ b/tests/ImGui.App.Tests/TestGL.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/TestHelpers.cs
+++ b/tests/ImGui.App.Tests/TestHelpers.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/TestOpenGLProvider.cs
+++ b/tests/ImGui.App.Tests/TestOpenGLProvider.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.Tests/WindowingEnvironmentTests.cs
+++ b/tests/ImGui.App.Tests/WindowingEnvironmentTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.App.Tests;
 

--- a/tests/ImGui.App.iOS.SmokeTest/Program.cs
+++ b/tests/ImGui.App.iOS.SmokeTest/Program.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 using Hexa.NET.ImGui;
 

--- a/tests/ImGui.Color.Tests/ColorImGuiAdapterTests.cs
+++ b/tests/ImGui.Color.Tests/ColorImGuiAdapterTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Color.Tests;
 

--- a/tests/ImGui.Color.Tests/ImColorAdaptorTests.cs
+++ b/tests/ImGui.Color.Tests/ImColorAdaptorTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Color.Tests;
 

--- a/tests/ImGui.Markdown.Tests/HarnessSmokeTest.cs
+++ b/tests/ImGui.Markdown.Tests/HarnessSmokeTest.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown.Tests;
 

--- a/tests/ImGui.Markdown.Tests/InlineBuilderTests.cs
+++ b/tests/ImGui.Markdown.Tests/InlineBuilderTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+﻿// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown.Tests;
 

--- a/tests/ImGui.Markdown.Tests/InlineLayoutTests.cs
+++ b/tests/ImGui.Markdown.Tests/InlineLayoutTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown.Tests;
 

--- a/tests/ImGui.Markdown.Tests/LinkPolicyTests.cs
+++ b/tests/ImGui.Markdown.Tests/LinkPolicyTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown.Tests;
 

--- a/tests/ImGui.Markdown.Tests/ListMarkerTests.cs
+++ b/tests/ImGui.Markdown.Tests/ListMarkerTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown.Tests;
 

--- a/tests/ImGui.Markdown.Tests/MarkdownConfigTests.cs
+++ b/tests/ImGui.Markdown.Tests/MarkdownConfigTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown.Tests;
 

--- a/tests/ImGui.Markdown.Tests/MarkdownParserTests.cs
+++ b/tests/ImGui.Markdown.Tests/MarkdownParserTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+﻿// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown.Tests;
 

--- a/tests/ImGui.Markdown.Tests/MarkdownSizingTests.cs
+++ b/tests/ImGui.Markdown.Tests/MarkdownSizingTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Markdown.Tests;
 

--- a/tests/ImGui.Popups.Tests/FilesystemBrowserDriveTests.cs
+++ b/tests/ImGui.Popups.Tests/FilesystemBrowserDriveTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Popups.Tests;
 

--- a/tests/ImGui.Popups.Tests/FilesystemBrowserSortTests.cs
+++ b/tests/ImGui.Popups.Tests/FilesystemBrowserSortTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Popups.Tests;
 

--- a/tests/ImGui.Widgets.Tests/ContainerWidgetTests.cs
+++ b/tests/ImGui.Widgets.Tests/ContainerWidgetTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Tests;
 

--- a/tests/ImGui.Widgets.Tests/DecoratorWidgetTests.cs
+++ b/tests/ImGui.Widgets.Tests/DecoratorWidgetTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Tests;
 

--- a/tests/ImGui.Widgets.Tests/EasingTests.cs
+++ b/tests/ImGui.Widgets.Tests/EasingTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Tests;
 

--- a/tests/ImGui.Widgets.Tests/GestureMachineTests.cs
+++ b/tests/ImGui.Widgets.Tests/GestureMachineTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Tests;
 

--- a/tests/ImGui.Widgets.Tests/IconTests.cs
+++ b/tests/ImGui.Widgets.Tests/IconTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Tests;
 

--- a/tests/ImGui.Widgets.Tests/InertialScrollTests.cs
+++ b/tests/ImGui.Widgets.Tests/InertialScrollTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Tests;
 

--- a/tests/ImGui.Widgets.Tests/OverlayHostTests.cs
+++ b/tests/ImGui.Widgets.Tests/OverlayHostTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Tests;
 

--- a/tests/ImGui.Widgets.Tests/SpringTests.cs
+++ b/tests/ImGui.Widgets.Tests/SpringTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Tests;
 

--- a/tests/ImGui.Widgets.Tests/TweenTests.cs
+++ b/tests/ImGui.Widgets.Tests/TweenTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.ImGui.Widgets.Tests;
 

--- a/tests/NodeGraph.Tests/ComprehensiveTypeSystemTests.cs
+++ b/tests/NodeGraph.Tests/ComprehensiveTypeSystemTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph.Tests;
 

--- a/tests/NodeGraph.Tests/EdgeCaseTests.cs
+++ b/tests/NodeGraph.Tests/EdgeCaseTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph.Tests;
 

--- a/tests/NodeGraph.Tests/ExecutionPinTests.cs
+++ b/tests/NodeGraph.Tests/ExecutionPinTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph.Tests;
 

--- a/tests/NodeGraph.Tests/NodeAttributeTests.cs
+++ b/tests/NodeGraph.Tests/NodeAttributeTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph.Tests;
 

--- a/tests/NodeGraph.Tests/NodeBehaviorTests.cs
+++ b/tests/NodeGraph.Tests/NodeBehaviorTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph.Tests;
 

--- a/tests/NodeGraph.Tests/PinAttributeTests.cs
+++ b/tests/NodeGraph.Tests/PinAttributeTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph.Tests;
 

--- a/tests/NodeGraph.Tests/PinTypeUtilitiesTests.cs
+++ b/tests/NodeGraph.Tests/PinTypeUtilitiesTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph.Tests;
 

--- a/tests/NodeGraph.Tests/PinValidationTests.cs
+++ b/tests/NodeGraph.Tests/PinValidationTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph.Tests;
 

--- a/tests/NodeGraph.Tests/WildcardPinTests.cs
+++ b/tests/NodeGraph.Tests/WildcardPinTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.NodeGraph.Tests;
 


### PR DESCRIPTION
Bumps ktsu.Sdk and its variants to 2.21.1 in global.json.  File headers are migrated to the single line from COPYRIGHT.md, which is what the SDK writes into .editorconfig as file_header_template and IDE0073 enforces.  

Generated with [Claude Code](https://claude.com/claude-code)
