### PR TITLE
[patch] Fix SonarCloud security gate and a misbound suppression in the demos

### DIFF
--- a/examples/ImGuiAppDemo/ImGuiAppDemo.cs
+++ b/examples/ImGuiAppDemo/ImGuiAppDemo.cs
@@ -2,6 +2,8 @@
 
 namespace ktsu.ImGui.Examples.App;
 
+using System.Diagnostics.CodeAnalysis;
+
 using Hexa.NET.ImGui;
 using ktsu.ImGui.App;
 using ktsu.ImGui.Examples.App.Demos;
@@ -86,6 +88,7 @@ internal static class ImGuiAppDemo
 	// actually rasterized. Registering it from OnStart instead is too late: OnStart runs after the
 	// atlas has already finished building for this frame, so a font merged there is silently never
 	// rasterized (no compile error, no exception — just missing glyphs).
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "FontHelper.GetMaterialIconRanges() returns a uint* that ImGui owns for the lifetime of the atlas; the pointer is passed straight through and never dereferenced or retained here.")]
 	private static void OnConfigureFonts()
 	{
 		// Material Icons lives in the Unicode Private Use Area (U+E000-U+F8FF), which overlaps the

--- a/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
+++ b/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
@@ -127,14 +127,13 @@ internal static class ImGuiWidgetsDemo
 	private static string RegexSearchTerm = string.Empty;
 	private static SearchBoxOptions RegexSearchOptions = new(Label: "##RegexSearch", FilterType: TextFilterType.Regex);
 
-#pragma warning disable CA5394 //Do not use insecure randomness - Random is used only for generating visual demo data; no security or cryptographic use.
-	[SuppressMessage("Security Hotspot", "S2245:Make sure that using this pseudorandom number generator is safe here", Justification = "Random is used only for generating visual demo data; no security or cryptographic use.")]
 	// The Hexa-backed DatePicker, FileTreeView and IconTreeNode draw Material Icons glyphs, so this
 	// demo needs the same font registration as ImGuiAppDemo -- otherwise the widgets the "Hexa
 	// Widgets" pane exists to evaluate render as placeholder boxes. The font is not checked into the
 	// repo; drop MaterialIcons-Regular.ttf next to the binary and this picks it up. OnConfigureFonts
 	// is the only hook that works: it runs after the configured fonts are added but before the atlas
 	// is built, whereas OnStart runs after the atlas has already been built.
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "FontHelper.GetMaterialIconRanges() returns a uint* that ImGui owns for the lifetime of the atlas; the pointer is passed straight through and never dereferenced or retained here.")]
 	private static void OnConfigureFonts()
 	{
 		AbsoluteFilePath materialIconsPath =
@@ -151,6 +150,8 @@ internal static class ImGuiWidgetsDemo
 		}
 	}
 
+#pragma warning disable CA5394 //Do not use insecure randomness - Random is used only for generating visual demo data; no security or cryptographic use.
+	[SuppressMessage("Security Hotspot", "S2245:Make sure that using this pseudorandom number generator is safe here", Justification = "Random is used only for generating visual demo data; no security or cryptographic use.")]
 	private static void OnStart()
 	{
 		// Create main layout with dedicated demo sections


### PR DESCRIPTION
Follow-up to #299, which merged before these two fixes could land on it. Both affect files that PR touched.

## 1. SonarCloud quality gate — `new_security_rating`

#299 failed the gate at rating **3** (threshold 1) on two `S6640` findings, one per demo `OnConfigureFonts` handler:

- `examples/ImGuiAppDemo/ImGuiAppDemo.cs:107`
- `examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs:147`

The `unsafe` context is unavoidable — `FontHelper.GetMaterialIconRanges()` returns `uint*` and there is no non-pointer overload — so this adds the same targeted, justified `[SuppressMessage]` the library already uses for exactly this call shape in `Icon.cs`, `Avatar.cs`, `ImageAlign.cs` and `FlameGraph.cs`. No global suppression, no `.editorconfig` change.

Since #299 merged as-is, **main currently fails this gate too**; this restores it.

## 2. An attribute silently bound to the wrong method

Adding `OnConfigureFonts` to `ImGuiWidgetsDemo.cs` inserted it between the `CA5394` pragma / `S2245` attribute pair and the method they were written for:

```csharp
#pragma warning disable CA5394
[SuppressMessage(..., "S2245:...pseudorandom number generator...")]
private static void OnConfigureFonts()   // <-- attribute landed here
...
private static void OnStart()            // <-- the Random usage it was meant for
{
    Random random = new();
```

C# attributes bind to the next declaration, so `OnStart`'s `Random` lost its suppression while `OnConfigureFonts` — which has no randomness — gained one. The local build never caught it because `S2245` is a Sonar-only security-hotspot rule with no Roslyn analyzer behind it. `OnConfigureFonts` now sits above the pragma block and `S2245` is adjacent to `OnStart` again.

Worth noting as a general hazard: inserting a method immediately before an existing one can silently steal its attributes, and the compiler will not complain.

## Not addressed here

The gate's other failing condition is `new_coverage` at **13.2%** against an 80% threshold. That is not fixable by a code change — the Tier 1 widgets are thin wrappers over an immediate-mode API, and the design spec deliberately rules out standing up an ImGui context in tests, so only the pure helpers (`FlattenCaptions`, `ResolveFlameGraphSelection`, `ResolveSplitterMetrics`, `EnumComboNames`) are reachable. Deciding between a coverage exclusion for widget wrappers, a lower new-code threshold, or investing in a headless ImGui test harness is a policy call, not a fix.

## Verification

Solution builds at 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaexEpkpKEKbJgSBnVnjM7
