### PR TITLE
[patch] Disable the iOS simulator smoke test on automatic triggers

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -80,6 +80,23 @@ jobs:
     # exits after N frames via the IMGUIAPP_IOS_SMOKE_FRAMES hook). Runs independently; does not gate
     # release. Building+launching two apps after a cold cimgui cache approaches the old 30-min cap, so
     # the budget is 50 min (a warm-cache run is ~20).
+    #
+    # DISABLED on automatic triggers: manual dispatch only.
+    #
+    # The 50-minute budget is not reliably enough. Cold-cache runs build native cimgui, the smoke app
+    # and the full demo app in one job, and have overrun the cap repeatedly -- the job is then
+    # *cancelled* mid-build, which surfaces as a red X indistinguishable from a genuine failure and
+    # blocks unrelated PRs. Observed twice in eight runs (PR #300 at 50m28s, and a dependabot run).
+    #
+    # Note this disables real coverage, not just noise: the smoke assertion itself has been passing,
+    # and it is the only thing that exercises the iOS runtime path (including the
+    # ImGuiAppConfig.OnConfigureFonts hook added in #299). The compile-only ios-build job below does
+    # not launch anything.
+    #
+    # To re-enable, delete the `if:` line. Doing that alone will reproduce the timeouts -- the
+    # underlying fix is to split the demo-app build into its own job, or raise the budget past the
+    # cold-cache worst case.
+    if: github.event_name == 'workflow_dispatch'
     name: iOS Simulator Smoke Test
     # The .NET 10 iOS workload requires a matching Xcode to build a runnable .app, and the required
     # version tracks whatever Microsoft ships in the latest `dotnet workload install ios` (e.g.
@@ -89,10 +106,11 @@ jobs:
     # (The compile-only ios-build job needs no Xcode, so it stays on macos-14.)
     runs-on: macos-26
     timeout-minutes: 50
-    # HARD GATE: the .NET 10 + Xcode 26 symlinked-developer-dir bug that broke native linking
+    # The .NET 10 + Xcode 26 symlinked-developer-dir bug that broke native linking
     # (`xcodebuild -find` -> errno=Invalid argument) is worked around by the "Resolve and pin the
-    # real Xcode" step below (readlink -f + xcode-select/DEVELOPER_DIR pin; dotnet/macios#21762), so
-    # this runtime smoke test now reliably passes and gates the PR like any other required check.
+    # real Xcode" step below (readlink -f + xcode-select/DEVELOPER_DIR pin; dotnet/macios#21762).
+    # That workaround still holds -- the smoke assertion passes when the job gets to run. What no
+    # longer holds is the claim that it gates the PR: see the `if:` above.
     permissions:
       contents: read
 


### PR DESCRIPTION
Gates the `ios-simulator` job (`iOS Simulator Smoke Test`) to `workflow_dispatch`, so it no longer runs on pull requests, pushes, or the nightly schedule.

The compile-only `ios-build` job is untouched — it finishes in ~38s and continues to run on every PR.

## Why

The job's `timeout-minutes: 50` is not reliably enough. A cold-cache run builds native cimgui, the headless smoke app, **and** the full `ImGuiAppDemo.iOS` in a single job. When it overruns, the job is *cancelled* mid-build, which surfaces as a red X that is indistinguishable from a genuine failure and blocks unrelated PRs.

Observed twice in the last eight runs:

- PR #300 — cancelled at **50m28s**, during "Build demo app (.app for simulator)"
- an earlier dependabot run — cancelled the same way

In the #300 case every step through "Install, launch, and assert lifecycle ticked" had already **passed**; only the second app build ran out of budget.

## What this costs

Worth being explicit that this disables real coverage, not just noise:

- The smoke assertion itself **has been passing** — this is a timeout problem, not a broken test.
- It is the only thing that exercises the iOS **runtime** path, including the `ImGuiAppConfig.OnConfigureFonts` hook added in #299. `ios-build` compiles but never launches anything.

So while this is disabled, an iOS runtime regression will not be caught by CI.

## Re-enabling

Delete the `if:` line. Doing only that will reproduce the timeouts — the underlying fix is to split the demo-app build into its own job, or raise the budget past the cold-cache worst case. I've left both notes inline at the job so whoever picks it up has the context.

I also corrected a now-false comment on the job claiming it "gates the PR like any other required check".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaexEpkpKEKbJgSBnVnjM7
