### PR TITLE
[patch] Fix ToggleSwitch rendering inverted after its first click

### DIFF
--- a/ImGui.Widgets/HexaAnimationPump.cs
+++ b/ImGui.Widgets/HexaAnimationPump.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.ImGui.Widgets;
+
+using Hexa.NET.ImGui;
+
+using HexaAnimationManager = Hexa.NET.ImGui.Widgets.AnimationManager;
+
+/// <summary>
+/// Advances Hexa's animation clock once per frame.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Hexa's animated widgets register state with <c>AnimationManager</c> and read it back through
+/// <c>GetAnimationValue</c>, but the clock only advances when something calls
+/// <c>AnimationManager.Tick()</c>. Upstream that happens inside <c>WidgetManager.Draw()</c>, a
+/// per-frame pump this library does not run.
+/// </para>
+/// <para>
+/// Without the tick the registered state is never removed and its elapsed time stays at zero, so
+/// <c>GetAnimationValue</c> keeps returning the eased value for t=0 rather than the -1 sentinel that
+/// means "no animation". <see cref="ImGuiWidgets.ToggleSwitch"/> reads that as a completed animation
+/// in the opposite direction and renders inverted from the first click onward.
+/// </para>
+/// <para>
+/// This is a stopgap, not the eventual lifecycle contract. When a real per-frame pump exists,
+/// delete this type and its call sites: <c>WidgetManager.Draw()</c> ticks the animation clock
+/// itself, so leaving both in place would advance animations at double speed.
+/// </para>
+/// </remarks>
+internal static class HexaAnimationPump
+{
+	/// <summary>
+	/// The ImGui frame the clock was last advanced on. -1 means never.
+	/// </summary>
+	private static int lastTickedFrame = -1;
+
+	/// <summary>
+	/// Advances Hexa's animation clock if it has not already been advanced this frame.
+	/// </summary>
+	/// <remarks>
+	/// Call before delegating to an animated Hexa widget. Ticking is idempotent within a frame, so
+	/// any number of animated widgets may call this and the clock still advances exactly once.
+	/// </remarks>
+	internal static void TickOncePerFrame()
+	{
+		if (ShouldTick(ImGui.GetFrameCount(), ref lastTickedFrame))
+		{
+			HexaAnimationManager.Tick();
+		}
+	}
+
+	/// <summary>
+	/// Decides whether the animation clock should advance, updating the recorded frame when it should.
+	/// </summary>
+	/// <param name="currentFrame">The current ImGui frame number.</param>
+	/// <param name="lastFrame">The frame the clock was last advanced on; updated when this returns <see langword="true"/>.</param>
+	/// <returns><see langword="true"/> if the caller should advance the clock.</returns>
+	/// <remarks>
+	/// Any change in frame number counts, not just an increase, so the clock keeps advancing if the
+	/// frame counter is ever reset — for example when the ImGui context is recreated.
+	/// </remarks>
+	internal static bool ShouldTick(int currentFrame, ref int lastFrame)
+	{
+		if (currentFrame == lastFrame)
+		{
+			return false;
+		}
+
+		lastFrame = currentFrame;
+		return true;
+	}
+}

--- a/ImGui.Widgets/HexaButtons.cs
+++ b/ImGui.Widgets/HexaButtons.cs
@@ -98,7 +98,14 @@ public static partial class ImGuiWidgets
 	/// </summary>
 	internal static class HexaButtonImpl
 	{
-		internal static bool ToggleSwitch(string label, ref bool selected) => HexaButton.ToggleSwitch(label, ref selected);
+		internal static bool ToggleSwitch(string label, ref bool selected)
+		{
+			// ToggleSwitch is animated, and Hexa's animation clock only advances when something
+			// ticks it. Without this the switch renders inverted after its first click; see
+			// HexaAnimationPump.
+			HexaAnimationPump.TickOncePerFrame();
+			return HexaButton.ToggleSwitch(label, ref selected);
+		}
 
 		internal static bool ToggleButton(string label, ref bool selected, Vector2 size) => HexaButton.ToggleButton(label, ref selected, size, ImGuiButtonFlags.None);
 

--- a/tests/ImGui.Widgets.Tests/HexaWidgetTests.cs
+++ b/tests/ImGui.Widgets.Tests/HexaWidgetTests.cs
@@ -259,4 +259,75 @@ public sealed class HexaWidgetTests
 			ImGuiWidgets.FlameGraph("label", null!, ref selected);
 		});
 	}
+
+	[TestMethod]
+	public void ShouldTick_FirstCallOnNeverTickedState_Ticks()
+	{
+		int lastFrame = -1;
+
+		Assert.IsTrue(HexaAnimationPump.ShouldTick(0, ref lastFrame));
+		Assert.AreEqual(0, lastFrame);
+	}
+
+	[TestMethod]
+	public void ShouldTick_SecondCallInSameFrame_DoesNotTick()
+	{
+		int lastFrame = -1;
+		_ = HexaAnimationPump.ShouldTick(7, ref lastFrame);
+
+		Assert.IsFalse(HexaAnimationPump.ShouldTick(7, ref lastFrame));
+		Assert.AreEqual(7, lastFrame);
+	}
+
+	[TestMethod]
+	public void ShouldTick_ManyCallsInSameFrame_TicksExactlyOnce()
+	{
+		int lastFrame = -1;
+		int ticks = 0;
+
+		for (int i = 0; i < 10; i++)
+		{
+			if (HexaAnimationPump.ShouldTick(3, ref lastFrame))
+			{
+				ticks++;
+			}
+		}
+
+		Assert.AreEqual(1, ticks);
+	}
+
+	[TestMethod]
+	public void ShouldTick_AdvancingFrames_TicksOncePerFrame()
+	{
+		int lastFrame = -1;
+		int ticks = 0;
+
+		for (int frame = 0; frame < 5; frame++)
+		{
+			// Two widgets drawing per frame must still only advance the clock once.
+			if (HexaAnimationPump.ShouldTick(frame, ref lastFrame))
+			{
+				ticks++;
+			}
+
+			if (HexaAnimationPump.ShouldTick(frame, ref lastFrame))
+			{
+				ticks++;
+			}
+		}
+
+		Assert.AreEqual(5, ticks);
+	}
+
+	[TestMethod]
+	public void ShouldTick_FrameCounterResets_StillTicks()
+	{
+		// A recreated ImGui context restarts the frame counter, so a decrease must not stall the
+		// clock the way a >= comparison would.
+		int lastFrame = -1;
+		_ = HexaAnimationPump.ShouldTick(500, ref lastFrame);
+
+		Assert.IsTrue(HexaAnimationPump.ShouldTick(0, ref lastFrame));
+		Assert.AreEqual(0, lastFrame);
+	}
 }


### PR DESCRIPTION
`ImGuiWidgets.ToggleSwitch` renders **backwards** in the shipped v3.4.0 — after its first click, `true` draws as off and `false` draws as on, permanently. The `ref bool` stays correct; only the visual lies.

## Root cause

Traced through `Hexa.NET.ImGui.Widgets/ImGuiButton.cs:19-78`:

1. On click, `ToggleSwitch` calls `AnimationManager.AddAnimation(id, .35f, 1, EaseOutCubic)`, which stores state with `Time = 0`.
2. It then reads `AnimationManager.GetAnimationValue(id)`.
3. The clock only advances in `AnimationManager.Tick()`, which upstream is called from `WidgetManager.Draw()` — **a per-frame pump this library does not run**.
4. So `Time` stays `0` and the state is never removed (removal also happens only inside `Tick`). `GetAnimationValue` returns `EaseOutCubic(0)` = `(0-1)³+1` = **0**, not the `-1` sentinel meaning "no animation".
5. Line 63 therefore executes `t = selected ? animationValue : (1 - animationValue)` → `t = selected ? 0 : 1` — exactly inverted.

`t` drives both the knob position (line 75) and the background colour lerp (lines 70/72), so the whole control reads wrong.

## Why this mattered more than it looks

The **"Hexa vs ktsu" comparison tab** drives `Switch` and `ToggleSwitch` from one shared `bool`. With this bug, Hexa's visibly contradicts ours on every click. That tab exists to decide which of the seven duplicated widget pairs to keep, so it was set to condemn Hexa's implementation for a reason that was not its own.

## The fix

Tick the clock at most once per frame, guarded on `ImGui.GetFrameCount()`, before delegating to an animated Hexa widget. Idempotent within a frame, so any number of animated widgets can call it and the clock still advances exactly once. This restores both correct orientation and the intended 0.35s ease-out.

**This is a stopgap with a named exit condition, not a lifecycle contract.** `WidgetManager.Draw()` ticks the clock itself, so when a real per-frame pump lands (the Tier 2 design question), `HexaAnimationPump` and its call sites must be deleted or animations will run at double speed. That is stated in the type's `<remarks>` and at the call site.

Alternatives rejected: stripping the animation via `RemoveAnimation` before delegating also fixes the inversion in one line, but permanently kills the animation Hexa intended — a poor thing to ship in a tab whose job is judging Hexa's widget on its merits. Adding a real per-frame hook to `ImGuiApp` is the correct long-term fix and is exactly the Tier 2 design decision being kept separate.

## Scope

`ToggleButton` is unaffected — it never registers an animation. `AnimationManager` is used by no other widget this library wraps, so `ToggleSwitch` is the only casualty.

## Testing

The frame guard is pure, so it has real tests — 5 new, 134 total passing:

- first call on a never-ticked state ticks
- a second call in the same frame does not
- ten calls in one frame tick exactly once
- two widgets per frame across five frames tick exactly five times
- a frame-counter reset (recreated ImGui context) still ticks, which a `>=` comparison would stall on

The rendering itself remains untestable without a live ImGui context — the same blind spot that let this ship. Verify visually in `ImGuiWidgetsDemo` → "Hexa Widgets" → "Hexa vs ktsu" → Toggle row: both switches should now agree and animate.

Solution builds at 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaexEpkpKEKbJgSBnVnjM7
