### PR TITLE
[patch] Make the curve editor's selection guarantee true and reserve layout for empty curves

### DIFF
--- a/ImGui.Widgets/Editors/CurveField.cs
+++ b/ImGui.Widgets/Editors/CurveField.cs
@@ -5,6 +5,8 @@ namespace ktsu.ImGui.Widgets;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
+using Hexa.NET.ImGui;
+
 using HexaCurve = Hexa.NET.Mathematics.Curve;
 using HexaCurveEditor = Hexa.NET.ImGui.Widgets.Extras.ImGuiCurveEditor;
 
@@ -25,25 +27,33 @@ public static partial class ImGuiWidgets
 	/// <remarks>
 	/// Two upstream defects are absorbed here rather than passed through to callers.
 	/// <para>
-	/// An empty curve is never handed to the vendor: the call is skipped and <see langword="false"/>
+	/// An empty curve is never handed to the vendor: the call is skipped, a layout slot of
+	/// <paramref name="size"/> is reserved so nothing below shifts, and <see langword="false"/> is
 	/// returned. Upstream's add-a-point path (<c>ImGuiCurveEditor.cs:192</c>) evaluates
 	/// <c>Points[key]</c> before testing <c>key != Points.Count</c>, so a double-click — the
 	/// documented gesture for adding a point — throws immediately on a curve with no points, which
-	/// is exactly the state the parameterless <see cref="CurveData"/> constructor produces.
+	/// is exactly the state the parameterless <see cref="CurveData"/> constructor produces. Because
+	/// that gesture is also the only way to create a point, an empty curve cannot be populated
+	/// through this editor: seed at least one point with <see cref="CurveData.AddPoint"/> first.
 	/// </para>
 	/// <para>
-	/// <paramref name="selection"/> is passed through <see cref="ClampSelection"/> both before and
-	/// after the vendor call, so an index that does not address a point becomes -1. Upstream removes
-	/// <c>Points[currentSelection]</c> on a double-click (<c>ImGuiCurveEditor.cs:208-212</c>) but
-	/// writes the now-stale index straight back out (<c>:233</c>), so without this the next frame's
-	/// drag would index a slot that no longer exists.
+	/// <paramref name="selection"/> is normalised before and after the vendor call, so it never
+	/// addresses a point that is not there. Upstream removes <c>Points[currentSelection]</c> on a
+	/// double-click (<c>ImGuiCurveEditor.cs:208-212</c>) but writes the now-stale index straight back
+	/// out (<c>:233</c>). Clamping alone would only cover deletion of the <em>last</em> point, since
+	/// deleting any earlier one leaves the index addressing whichever point shifted down into that
+	/// slot — so a shrink in point count clears the selection outright.
 	/// </para>
 	/// <para>
 	/// One upstream defect is deliberately <em>not</em> absorbed: double-clicking to the right of the
 	/// last point, when that point sits left of <paramref name="rangeMax"/>'s X, still walks
-	/// <c>key</c> up to <c>Points.Count</c> and throws at <c>ImGuiCurveEditor.cs:192</c>. Preventing
-	/// it from out here would mean mutating the caller's curve, so it is left upstream. Keep the last
-	/// point at or beyond <paramref name="rangeMax"/>'s X to stay clear of it.
+	/// <c>key</c> up to <c>Points.Count</c> and throws at <c>ImGuiCurveEditor.cs:192</c>. It could be
+	/// prevented from out here, but only by rescaling the horizontal axis away from the range the
+	/// caller asked for, or by duplicating the vendor's hit-test maths and suppressing its gesture
+	/// through global IO state — both worse than the defect. Keep the last point at or beyond
+	/// <paramref name="rangeMax"/>'s X to stay clear of it. Note the throw escapes between the
+	/// vendor's <c>PushID</c> and <c>PopID</c>, so catching it and continuing to render leaves the
+	/// ImGui ID stack unbalanced; it is not a recoverable exception.
 	/// </para>
 	/// </remarks>
 	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "The only pointer is taken by fixed over the caller's selection, is pinned for exactly the duration of the vendor call, and is neither retained nor published beyond it.")]
@@ -57,9 +67,13 @@ public static partial class ImGuiWidgets
 		if (curve.PointCount == 0)
 		{
 			// See the remarks: upstream's add-a-point path indexes Points[0] on an empty list.
+			// Reserve the layout slot anyway, so an empty curve leaves a gap the caller sized rather
+			// than silently collapsing to nothing and shifting everything below it.
+			ImGui.Dummy(size);
 			return false;
 		}
 
+		int pointCountBefore = curve.PointCount;
 		ref HexaCurve vendorCurve = ref curve.AsVendorCurve();
 		bool changed;
 
@@ -78,7 +92,7 @@ public static partial class ImGuiWidgets
 			changed = HexaCurveEditor.Curve(label, size, ref vendorCurve, rangeMin, rangeMax, pSelection);
 		}
 
-		selection = ClampSelection(selection, curve.PointCount);
+		selection = ResolveSelectionAfterEdit(selection, pointCountBefore, curve.PointCount);
 
 		if (changed)
 		{
@@ -100,7 +114,31 @@ public static partial class ImGuiWidgets
 	/// -1 (no selection) rather than to the last point: it is reached by upstream deleting the point
 	/// that was selected, and silently retargeting the drag at whichever point happens to be adjacent
 	/// would move data the user never grabbed.
+	/// <para>
+	/// This handles an index that is out of range. It cannot detect a stale index that still happens
+	/// to be in range — the case where an earlier point was deleted and a later one shifted down into
+	/// its slot. Callers relying on that must compare the point count across the call, as
+	/// <see cref="CurveEditor(CurveData, Vector2, Vector2, Vector2, ref int, string)"/> does.
+	/// </para>
 	/// </remarks>
 	internal static int ClampSelection(int selection, int pointCount) =>
 		selection >= 0 && selection < pointCount ? selection : -1;
+
+	/// <summary>
+	/// Resolves a point selection after the editor has run, clearing it when the editor deleted a point.
+	/// </summary>
+	/// <param name="selection">The selection index the editor wrote back.</param>
+	/// <param name="pointCountBefore">How many points the curve held before the call.</param>
+	/// <param name="pointCountAfter">How many it holds now.</param>
+	/// <returns>The selection to hand back to the caller.</returns>
+	/// <remarks>
+	/// A drop in point count means the editor deleted the selected point — <c>RemoveAt</c> at
+	/// <c>ImGuiCurveEditor.cs:210</c> is its only removal path, and it removes the selected index.
+	/// The editor then writes that index straight back out, so clamping alone would only catch the
+	/// deletion of the <em>last</em> point: deleting any earlier one leaves the index addressing a
+	/// real slot, the point that shifted down into it, and the next drag would move a point the user
+	/// never grabbed. Any shrink therefore clears the selection outright.
+	/// </remarks>
+	internal static int ResolveSelectionAfterEdit(int selection, int pointCountBefore, int pointCountAfter) =>
+		pointCountAfter < pointCountBefore ? -1 : ClampSelection(selection, pointCountAfter);
 }

--- a/tests/ImGui.Widgets.Tests/CurveFieldTests.cs
+++ b/tests/ImGui.Widgets.Tests/CurveFieldTests.cs
@@ -69,4 +69,44 @@ public sealed class CurveFieldTests
 			}
 		}
 	}
+
+	[TestMethod]
+	public void ResolveSelectionAfterEdit_CountUnchanged_KeepsValidSelection() =>
+		Assert.AreEqual(1, ImGuiWidgets.ResolveSelectionAfterEdit(1, 3, 3));
+
+	[TestMethod]
+	public void ResolveSelectionAfterEdit_LastPointDeleted_ClearsSelection() =>
+		Assert.AreEqual(-1, ImGuiWidgets.ResolveSelectionAfterEdit(2, 3, 2));
+
+	[TestMethod]
+	public void ResolveSelectionAfterEdit_MiddlePointDeleted_ClearsSelection()
+	{
+		// The regression this exists for. After deleting point 1 of 3, the vendor writes index 1 back
+		// out and it still addresses a real slot - the point that shifted down. A plain clamp would
+		// keep it and the next drag would move a point the user never grabbed.
+		Assert.AreEqual(-1, ImGuiWidgets.ResolveSelectionAfterEdit(1, 3, 2));
+		Assert.AreEqual(1, ImGuiWidgets.ClampSelection(1, 2));
+	}
+
+	[TestMethod]
+	public void ResolveSelectionAfterEdit_FirstPointDeleted_ClearsSelection() =>
+		Assert.AreEqual(-1, ImGuiWidgets.ResolveSelectionAfterEdit(0, 3, 2));
+
+	[TestMethod]
+	public void ResolveSelectionAfterEdit_PointAdded_KeepsSelection()
+	{
+		// Growth is the add gesture, which does not invalidate an existing selection.
+		Assert.AreEqual(1, ImGuiWidgets.ResolveSelectionAfterEdit(1, 3, 4));
+	}
+
+	[TestMethod]
+	public void ResolveSelectionAfterEdit_NoSelection_StaysCleared()
+	{
+		Assert.AreEqual(-1, ImGuiWidgets.ResolveSelectionAfterEdit(-1, 3, 3));
+		Assert.AreEqual(-1, ImGuiWidgets.ResolveSelectionAfterEdit(-1, 3, 2));
+	}
+
+	[TestMethod]
+	public void ResolveSelectionAfterEdit_CurveEmptied_ClearsSelection() =>
+		Assert.AreEqual(-1, ImGuiWidgets.ResolveSelectionAfterEdit(0, 1, 0));
 }


### PR DESCRIPTION
Two follow-ups from the Tier 3 review (#305), both in `ImGui.Widgets/Editors/CurveField.cs`.

## 1. The selection guarantee was a claim, not a fact

`ClampSelection`'s remarks said the wrapper prevented a stale selection after the editor deletes a point. It only did when the deleted point was the **last** one.

Deleting any earlier point leaves the vendor's written-back index addressing a real slot — the point that shifted down into it — so `ClampSelection` passes it through untouched and the next drag moves a point the user never grabbed.

**Rather than weaken the doc to match the code, this makes the claim true.** A shrink in point count means the vendor deleted the selection: `RemoveAt` at `ImGuiCurveEditor.cs:210` is its only removal path and it removes the selected index. So any shrink now clears the selection outright.

The rule lives in a new pure `ResolveSelectionAfterEdit(selection, before, after)` rather than inline in `CurveEditor`, which no test can reach — consistent with how the rest of this tier isolates its testable logic. `ClampSelection` keeps its narrower job, and its remarks now state what it *cannot* detect.

Seven new tests, including one that asserts both halves of the distinction: `ResolveSelectionAfterEdit(1, 3, 2)` clears, while `ClampSelection(1, 2)` would have kept it. That test fails against the old behaviour.

## 2. An empty curve reserved no layout space

The empty-curve guard returns before any ImGui call, so `ItemSize`/`ItemAdd` never ran and the widget vanished entirely — no frame, no gap, everything below shifted up. Previously it at least drew a framed grid.

Now reserves the slot with `ImGui.Dummy(size)`.

Documented alongside it: an empty curve **cannot be populated through the editor at all**, because double-click is the only add gesture and it throws on an empty point list. Callers must seed a point with `CurveData.AddPoint` first. That was true before this change and undocumented.

## Also corrected in the same remarks

Two overstatements the review flagged:

- "Preventing it from out here would mean mutating the caller's curve" — not true. Two routes exist (rescaling the horizontal axis away from the caller's requested range, or duplicating the vendor's hit-test maths and suppressing its gesture through global IO state). Both are worse than the defect, which is the actual reason to leave it — so the remark now says that instead of claiming impossibility.
- The residual throw escapes between the vendor's `PushID` and `PopID`, so catching it and continuing to render leaves the ImGui ID stack unbalanced. Worth saying, since the remarks hand callers a workaround and should rule out the wrong one.

## Testing

**226 tests passing** (219 + 7), 0 failures. Solution and demo both build 0 warnings / 0 errors.

The layout fix still needs a human eye — nothing here can exercise a draw path. Constructing a `CurveData()` with no points and rendering it should now leave a correctly-sized gap rather than nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaexEpkpKEKbJgSBnVnjM7
