### PR TITLE
Give the widgets demo a top-level tab bar

### DIFF
--- a/examples/ImGuiWidgetsDemo/HexaWidgetsDemo.cs
+++ b/examples/ImGuiWidgetsDemo/HexaWidgetsDemo.cs
@@ -5,7 +5,6 @@ namespace ktsu.ImGui.Examples.Widgets;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
 using Hexa.NET.ImGui;
@@ -22,6 +21,11 @@ using ktsu.Semantics.Strings;
 /// Hexa.NET.ImGui.Widgets, plus a gallery of the Hexa widgets that have no ktsu counterpart.
 /// Each comparison row drives both implementations from the same backing field so behavioural
 /// differences are visible rather than inferred.
+/// <para>
+/// The three entry points -- <see cref="ShowComparison"/>, <see cref="ShowNetNew"/> and
+/// <see cref="ShowDialogComparison"/> -- are each a top-level tab of the demo window, drawn by
+/// ImGuiWidgetsDemo.OnRender.
+/// </para>
 /// </summary>
 internal static class HexaWidgetsDemo
 {
@@ -40,13 +44,14 @@ internal static class HexaWidgetsDemo
 	private static string sharedMessageAnswer = "(none)";
 
 	// ktsu's popups render inline wherever they are pumped (see the ShowIfOpen calls at the end of
-	// Show), unlike Hexa's static deferred-draw manager, so each needs its own persistent instance
-	// to survive across frames and its own per-frame pump call. Each instance must also be owned
-	// exclusively by the pane that opens it: ImGui derives a popup's underlying ID from the ID
-	// stack of whichever window is current when Open()/ShowIfOpen() run, so sharing one instance
-	// across two panes that tick every frame in their own BeginChild (as this "Hexa Widgets" zone
-	// and the "Advanced Demos" zone both do via DividerContainer) lets a later Open() from one pane
-	// silently strand a popup already open under the other pane's ID.
+	// ShowDialogComparison), unlike Hexa's static deferred-draw manager, so each needs its own
+	// persistent instance to survive across frames and its own pump call. Each instance must also be
+	// owned exclusively by the tab that opens it: ImGui derives a popup's underlying ID from the ID
+	// stack current when Open()/ShowIfOpen() run, and a tab item pushes its own ID, so an instance
+	// shared with another tab (as with the "Advanced Demos" tab's own MessageOK) would be opened
+	// under one tab's ID and pumped under the other's, and never appear. Pumping from inside the tab
+	// is enough to keep an open popup alive because these are modal: while one is up the user cannot
+	// reach the tab bar to switch away from it.
 	private static readonly ImGuiPopups.FilesystemBrowser KtsuOpenFileBrowser = new();
 	private static readonly ImGuiPopups.FilesystemBrowser KtsuOpenFolderBrowser = new();
 	private static readonly ImGuiPopups.FilesystemBrowser KtsuSaveFileBrowser = new();
@@ -88,43 +93,10 @@ internal static class HexaWidgetsDemo
 		new(6f, 9.4f, 2, "Draw"),
 	];
 
-	[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Signature must match ktsu.ImGui.Widgets.DividerContainer's Action<float> tick delegate (see DividerContainer.Add); this pane's content does not depend on the available width.")]
-	internal static void Show(float size)
-	{
-		if (ImGui.BeginTabBar("HexaWidgetsTabs"))
-		{
-			if (ImGui.BeginTabItem("Hexa vs ktsu"))
-			{
-				ShowComparison();
-				ImGui.EndTabItem();
-			}
-
-			if (ImGui.BeginTabItem("Net New"))
-			{
-				ShowNetNew();
-				ImGui.EndTabItem();
-			}
-
-			if (ImGui.BeginTabItem("Dialogs"))
-			{
-				ShowDialogComparison();
-				ImGui.EndTabItem();
-			}
-
-			ImGui.EndTabBar();
-		}
-
-		// ktsu's popups render inline wherever they're pumped, so each live dialog in the "Dialogs"
-		// tab needs an unconditional per-frame ShowIfOpen() call here. This method runs every frame
-		// regardless of which internal tab is active -- the same guarantee ImGuiWidgets.DrawDeferred()
-		// relies on in OnRender for the Hexa side.
-		KtsuMessageBox.ShowIfOpen();
-		KtsuOpenFileBrowser.ShowIfOpen();
-		KtsuOpenFolderBrowser.ShowIfOpen();
-		KtsuSaveFileBrowser.ShowIfOpen();
-	}
-
-	private static void ShowComparison()
+	/// <summary>
+	/// The "Hexa vs ktsu" tab: every widget with an implementation on both sides, a row apiece.
+	/// </summary>
+	internal static void ShowComparison()
 	{
 		ImGui.TextWrapped("Both columns of each row are bound to the same value. Change one and the other follows.");
 		ImGui.Separator();
@@ -193,7 +165,7 @@ internal static class HexaWidgetsDemo
 		ImGuiWidgets.ImageCenteredH(sharedImage.TextureId, imageSize);
 
 		BeginRow("Splitter");
-		ImGui.TextUnformatted($"DividerContainer: see the Advanced pane ({sharedSplitWidth:F0}px)");
+		ImGui.TextUnformatted($"DividerContainer: see the Advanced Demos tab ({sharedSplitWidth:F0}px)");
 		ImGui.TableNextColumn();
 		ImGuiWidgets.VerticalSplitter("##hexaSplitter", ref sharedSplitWidth, 80f, 400f, 40f);
 		ImGui.SameLine();
@@ -214,7 +186,23 @@ internal static class HexaWidgetsDemo
 		ImGui.TableNextColumn();
 	}
 
-	private static void ShowDialogComparison()
+	/// <summary>
+	/// The "Dialogs" tab: the dialog pairs, plus the per-frame pump ktsu's inline popups need.
+	/// </summary>
+	internal static void ShowDialogComparison()
+	{
+		ShowDialogTable();
+
+		// ktsu's popups render inline wherever they're pumped, so each dialog opened above needs an
+		// unconditional ShowIfOpen() call from this same tab, every frame. It is outside
+		// ShowDialogTable so that the early return in there cannot skip it.
+		KtsuMessageBox.ShowIfOpen();
+		KtsuOpenFileBrowser.ShowIfOpen();
+		KtsuOpenFolderBrowser.ShowIfOpen();
+		KtsuSaveFileBrowser.ShowIfOpen();
+	}
+
+	private static void ShowDialogTable()
 	{
 		ImGui.TextWrapped("Dialogs are windows, not inline widgets, so each row is a pair of buttons writing to one shared field. Open ktsu's, then Hexa's, and compare what comes back.");
 		ImGui.Separator();
@@ -298,10 +286,13 @@ internal static class HexaWidgetsDemo
 		ImGui.TextUnformatted($"Answer:  {sharedMessageAnswer}");
 
 		ImGui.Separator();
-		ImGui.TextWrapped("Hexa's file dialogs need a Material Icons font for their navigation bar, and block the UI thread briefly when closing while the async directory scan unwinds. Hexa's message box re-centres itself every frame and cannot be dragged. ktsu's dialogs render inline wherever they are pumped (see the ShowIfOpen calls in Show) rather than through a central deferred-draw manager, and ktsu's MessageOK has no built-in Yes/No button-set the way Hexa's ShowMessageBox does -- this row's ktsu answer is always \"Ok\".");
+		ImGui.TextWrapped("Hexa's file dialogs need a Material Icons font for their navigation bar, and block the UI thread briefly when closing while the async directory scan unwinds. Hexa's message box re-centres itself every frame and cannot be dragged. ktsu's dialogs render inline wherever they are pumped (see the ShowIfOpen calls in ShowDialogComparison) rather than through a central deferred-draw manager, and ktsu's MessageOK has no built-in Yes/No button-set the way Hexa's ShowMessageBox does -- this row's ktsu answer is always \"Ok\".");
 	}
 
-	private static void ShowNetNew()
+	/// <summary>
+	/// The "Net New" tab: Hexa widgets with no ktsu counterpart.
+	/// </summary>
+	internal static void ShowNetNew()
 	{
 		ImGui.TextWrapped("Hexa widgets with no ktsu counterpart.");
 		ImGui.Separator();
@@ -393,8 +384,8 @@ internal static class HexaWidgetsDemo
 	}
 
 	/// <summary>
-	/// Width for the curve editors: the remaining content region, floored so a collapsed or
-	/// clipped pane still yields something the editor can draw into rather than a zero-width sliver.
+	/// Width for the curve editors: the remaining content region, floored so a narrow or clipped
+	/// window still yields something the editor can draw into rather than a zero-width sliver.
 	/// </summary>
 	/// <returns>The width in pixels.</returns>
 	private static float AvailableEditorWidth() => Math.Max(ImGui.GetContentRegionAvail().X, 120f);

--- a/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
+++ b/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
@@ -90,7 +90,14 @@ internal static class ImGuiWidgetsDemo
 	private static string otpValue = string.Empty;
 	private static bool skeletonLoading = true;
 
-	private static ImGuiWidgets.DividerContainer DividerContainer { get; } = new("DemoDividerContainer");
+	// The DividerContainer is no longer this demo's top-level layout -- the main window is a tab bar
+	// now -- so the widget keeps a live instance of its own, drawn inside its demo section.
+	private static ImGuiWidgets.DividerContainer DividerDemoContainer { get; } = new("DividerDemoContainer");
+
+	// DividerContainer.Tick needs a delta time, and the divider demo runs from a collapsing header
+	// that has none threaded through to it, so OnRender stashes the frame's delta here.
+	private static float deltaTime;
+
 	private static ImGuiPopups.MessageOK MessageOK { get; } = new();
 	private static ImGuiWidgets.TabPanel DemoTabPanel { get; } = new("DemoTabPanel", true, true);
 	private static Dictionary<string, string> TabIds { get; } = [];
@@ -154,10 +161,12 @@ internal static class ImGuiWidgetsDemo
 	[SuppressMessage("Security Hotspot", "S2245:Make sure that using this pseudorandom number generator is safe here", Justification = "Random is used only for generating visual demo data; no security or cryptographic use.")]
 	private static void OnStart()
 	{
-		// Create main layout with dedicated demo sections
-		DividerContainer.Add(new("Widget Demos", 0.4f, ShowWidgetDemos));
-		DividerContainer.Add(new("Advanced Demos", 0.3f, ShowAdvancedDemos));
-		DividerContainer.Add(new("Hexa Widgets", 0.3f, HexaWidgetsDemo.Show));
+		// Zones for the live DividerContainer demo (see ShowDividerDemo); the demo's own layout is
+		// the tab bar in OnRender.
+		DividerDemoContainer.Add(new("DividerDemoLeft", 0.5f, _ =>
+			ImGui.TextWrapped("Drag the handle between these zones to resize them, or double-click it to reset.")));
+		DividerDemoContainer.Add(new("DividerDemoRight", 0.5f, _ =>
+			ImGui.TextWrapped("Each zone is its own child window, so it scrolls and clips independently.")));
 
 		// Initialize TabPanel demo
 		TabIds["tab1"] = DemoTabPanel.AddTab("tab1", "Tab 1", ShowTab1Content);
@@ -194,11 +203,42 @@ internal static class ImGuiWidgetsDemo
 
 	private static void OnRender(float dt)
 	{
-		DividerContainer.Tick(dt);
+		deltaTime = dt;
+
+		if (ImGui.BeginTabBar("DemoTabs"))
+		{
+			ShowTab("Widget Demos", ShowWidgetDemos);
+			ShowTab("Advanced Demos", ShowAdvancedDemos);
+			ShowTab("Hexa vs ktsu", HexaWidgetsDemo.ShowComparison);
+			ShowTab("Net New", HexaWidgetsDemo.ShowNetNew);
+			ShowTab("Dialogs", HexaWidgetsDemo.ShowDialogComparison);
+
+			ImGui.EndTabBar();
+		}
 
 		// Hexa's dialogs are stateful: Show() registers them with a static manager and they are
-		// only drawn by this pump. Without it no dialog appears.
+		// only drawn by this pump. Without it no dialog appears. It sits outside the tab bar because
+		// Hexa draws its dialogs as their own windows, so it does not matter which tab is active --
+		// unlike ktsu's popups, which are pumped inline by the tab that opens them.
 		ImGuiWidgets.DrawDeferred();
+	}
+
+	/// <summary>
+	/// Draws one top-level tab. The content goes in a child window so that it scrolls under a tab
+	/// bar that stays put, rather than scrolling the tab bar off the top of the window with it.
+	/// </summary>
+	/// <param name="label">The tab label.</param>
+	/// <param name="content">The tab's contents, drawn only while the tab is active.</param>
+	private static void ShowTab(string label, Action content)
+	{
+		if (ImGui.BeginTabItem(label))
+		{
+			// BeginChild must be paired with EndChild whatever it returns, so the result is ignored.
+			ImGui.BeginChild($"{label}Content", Vector2.Zero, ImGuiChildFlags.None);
+			content();
+			ImGui.EndChild();
+			ImGui.EndTabItem();
+		}
 	}
 
 	private static void OnAppMenu()
@@ -211,7 +251,7 @@ internal static class ImGuiWidgetsDemo
 		// Method intentionally left empty.
 	}
 
-	private static void ShowWidgetDemos(float size)
+	private static void ShowWidgetDemos()
 	{
 		ImGui.TextUnformatted("ImGuiWidgets Library - Comprehensive Demo");
 		ImGui.Separator();
@@ -228,7 +268,7 @@ internal static class ImGuiWidgetsDemo
 		ShowMobileContainersDemo();
 	}
 
-	private static void ShowAdvancedDemos(float size)
+	private static void ShowAdvancedDemos()
 	{
 		AbsoluteFilePath ktsuIconPath = AppContext.BaseDirectory.As<AbsoluteDirectoryPath>() / "ktsu.png".As<FileName>();
 		ImGuiAppTextureInfo ktsuTexture = ImGuiApp.GetOrLoadTexture(ktsuIconPath);
@@ -1122,16 +1162,19 @@ internal static class ImGuiWidgetsDemo
 	{
 		if (ImGui.CollapsingHeader("Divider Container"))
 		{
-			ImGui.TextUnformatted("This entire demo uses a DividerContainer!");
-			ImGui.TextUnformatted("The resizable divider between 'Widget Demos' and 'Advanced Demos'");
-			ImGui.TextUnformatted("is created using ImGuiWidgets.DividerContainer.");
-
-			ImGui.Separator();
 			ImGui.TextUnformatted("DividerContainer features:");
 			ImGui.BulletText("Resizable panes with drag handle");
 			ImGui.BulletText("Persistent sizing ratios");
 			ImGui.BulletText("Automatic content management");
 			ImGui.BulletText("Nested dividers support");
+
+			ImGui.Separator();
+
+			// The container lays itself out into the whole remaining content region, so it is given a
+			// fixed-height host to draw into rather than being left to swallow the rest of the tab.
+			ImGui.BeginChild("DividerDemoHost", new Vector2(0f, 120f), ImGuiChildFlags.None);
+			DividerDemoContainer.Tick(deltaTime);
+			ImGui.EndChild();
 		}
 	}
 


### PR DESCRIPTION
## Summary

The "Hexa vs ktsu" comparison was a tab inside a tab bar inside the third `DividerContainer` pane of `examples/ImGuiWidgetsDemo`, so it rendered into ~30% of the window width — too narrow to compare two implementations side by side. It is now its own top-level tab.

The demo window is a tab bar instead of a three-pane `DividerContainer`:

**Widget Demos · Advanced Demos · Hexa vs ktsu · Net New · Dialogs**

## Changes

- `ImGuiWidgetsDemo.OnRender` builds the tab bar; a `ShowTab(label, content)` helper wraps each tab body in a child window so content scrolls under a tab bar that stays put.
- `ShowWidgetDemos`/`ShowAdvancedDemos` lose their `float size` parameter — they are no longer `DividerZone` tick delegates.
- `HexaWidgetsDemo.Show` is gone; `ShowComparison`, `ShowNetNew` and `ShowDialogComparison` are now `internal` tab entry points.
- ktsu's inline modal popups are pumped at the end of `ShowDialogComparison`, in the same tab — and therefore the same ImGui ID scope — that opens them. The table body moved to `ShowDialogTable` so its early return cannot skip the pump. `ImGuiWidgets.DrawDeferred()` stays outside the tab bar, since Hexa draws dialogs as their own windows.
- The "Divider Container" section used to just assert "this entire demo uses a DividerContainer!". With that no longer true, it now hosts a **live** two-zone container in a fixed-height child, so the widget keeps a real demo rather than only a description.

## Testing

- `dotnet build` clean under warnings-as-errors.
- Ran the demo: all five tabs render, the comparison table draws full-width in its own tab, and the relocated `DividerContainer` demo draws two resizable zones with a working drag handle.