### PR TITLE
Live image display: in-place texture updates, in-memory texture API, and ImageCanvas

### DIFF
--- a/ImGui.App/IRendererBackend.cs
+++ b/ImGui.App/IRendererBackend.cs
@@ -28,6 +28,24 @@ internal interface IRendererBackend : IDisposable
 	public nint CreateTexture(ReadOnlySpan<byte> rgba, int width, int height);
 
 	/// <summary>
+	/// Replaces the pixel contents of an existing texture in place, reusing its GPU storage.
+	/// </summary>
+	/// <param name="id">The handle returned by <see cref="CreateTexture"/>.</param>
+	/// <param name="rgba">Tightly packed RGBA8 pixel data (<paramref name="width"/> * <paramref name="height"/> * 4 bytes).</param>
+	/// <param name="width">Texture width in pixels. Must match the width the texture was created with.</param>
+	/// <param name="height">Texture height in pixels. Must match the height the texture was created with.</param>
+	/// <returns>
+	/// <see langword="true"/> if the texture was updated in place. <see langword="false"/> if this backend
+	/// cannot update textures at all, in which case the caller should recreate the texture instead.
+	/// </returns>
+	/// <exception cref="InvalidOperationException">
+	/// The backend supports in-place update but its rendering context is not initialized. That is a
+	/// different condition from returning <see langword="false"/>, and recreating the texture will not
+	/// help, so it is reported as a fault rather than as a declined capability.
+	/// </exception>
+	public bool UpdateTexture(nint id, ReadOnlySpan<byte> rgba, int width, int height);
+
+	/// <summary>
 	/// Releases a texture previously returned by <see cref="CreateTexture"/>.
 	/// </summary>
 	/// <param name="id">The handle returned by <see cref="CreateTexture"/>.</param>

--- a/ImGui.App/ImGuiApp.cs
+++ b/ImGui.App/ImGuiApp.cs
@@ -1546,6 +1546,86 @@ public static partial class ImGuiApp
 	/// <exception cref="ArgumentNullException">Thrown if the textureInfo is null.</exception>
 	public static void DeleteTexture(ImGuiAppTextureInfo textureInfo) => DeleteTexture(Ensure.NotNull(textureInfo).TextureId);
 
+	/// <summary>
+	/// Creates a GPU texture from pixels held in memory.
+	/// </summary>
+	/// <param name="rgba">Tightly packed RGBA8 pixels, <paramref name="width"/> * <paramref name="height"/> * 4 bytes.</param>
+	/// <param name="width">Texture width in pixels.</param>
+	/// <param name="height">Texture height in pixels.</param>
+	/// <returns>Texture info owned by the caller.</returns>
+	/// <remarks>
+	/// Unlike <see cref="GetOrLoadTexture(AbsoluteFilePath)"/>, the returned texture is NOT tracked in the
+	/// internal texture cache: it has no file path to reload from, so it is not restored by
+	/// <c>ReloadAllTextures</c> after a renderer restart. The caller owns its lifetime, must call
+	/// <see cref="DeleteTexture(ImGuiAppTextureInfo)"/>, and must re-upload its contents if the renderer restarts.
+	/// </remarks>
+	/// <exception cref="ArgumentException">The span length does not equal width * height * 4.</exception>
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "Required for native ImGui texture interop; pointer is scoped to the call and not retained.")]
+	public static ImGuiAppTextureInfo CreateTexture(ReadOnlySpan<byte> rgba, int width, int height)
+	{
+		ValidatePixelSpan(rgba, width, height);
+
+		nint textureId = UploadTextureRGBA(rgba.ToArray(), width, height);
+		ImTextureRef textureRef;
+		unsafe
+		{
+			textureRef = new ImTextureRef(default, textureId);
+		}
+
+		return new ImGuiAppTextureInfo()
+		{
+			Width = width,
+			Height = height,
+			TextureId = textureId,
+			TextureRef = textureRef,
+		};
+	}
+
+	/// <summary>
+	/// Replaces the contents of a texture created by <see cref="CreateTexture"/>.
+	/// </summary>
+	/// <param name="textureInfo">The texture to update, as returned by <see cref="CreateTexture"/>.</param>
+	/// <param name="rgba">Tightly packed RGBA8 pixels, <paramref name="width"/> * <paramref name="height"/> * 4 bytes.</param>
+	/// <param name="width">Texture width in pixels.</param>
+	/// <param name="height">Texture height in pixels.</param>
+	/// <remarks>
+	/// Falls back to deleting and recreating the texture when the active renderer backend cannot update
+	/// in place, mutating <paramref name="textureInfo"/> to carry the new handle.
+	/// </remarks>
+	/// <exception cref="ArgumentNullException"><paramref name="textureInfo"/> is null.</exception>
+	/// <exception cref="ArgumentException">The span length does not equal width * height * 4.</exception>
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "Required for native ImGui texture interop; pointer is scoped to the call and not retained.")]
+	public static void UpdateTexture(ImGuiAppTextureInfo textureInfo, ReadOnlySpan<byte> rgba, int width, int height)
+	{
+		Ensure.NotNull(textureInfo);
+		ValidatePixelSpan(rgba, width, height);
+
+		bool sameSize = textureInfo.Width == width && textureInfo.Height == height;
+		if (sameSize && renderer is not null && renderer.UpdateTexture(textureInfo.TextureId, rgba, width, height))
+		{
+			return;
+		}
+
+		DeleteTexture(textureInfo.TextureId);
+		textureInfo.TextureId = UploadTextureRGBA(rgba.ToArray(), width, height);
+		unsafe
+		{
+			textureInfo.TextureRef = new ImTextureRef(default, textureInfo.TextureId);
+		}
+
+		textureInfo.Width = width;
+		textureInfo.Height = height;
+	}
+
+	private static void ValidatePixelSpan(ReadOnlySpan<byte> rgba, int width, int height)
+	{
+		int expected = checked(width * height * 4);
+		if (rgba.Length != expected)
+		{
+			throw new ArgumentException($"Expected {expected} bytes for a {width}x{height} RGBA texture but got {rgba.Length}.", nameof(rgba));
+		}
+	}
+
 	internal static void UpdateDpiScale()
 	{
 		float newScaleFactor = (float)ForceDpiAware.GetWindowScaleFactor();

--- a/ImGui.App/ImGuiController/GLWrapper.cs
+++ b/ImGui.App/ImGuiController/GLWrapper.cs
@@ -118,6 +118,14 @@ public sealed class GLWrapper(GL gl) : IGL
 	}
 
 	/// <inheritdoc/>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here.", Justification = "Required for native ImGui/OpenGL interop; pointer is scoped to the call and not retained.")]
+	public unsafe void TexSubImage2D(GLEnum target, int level, int xoffset, int yoffset, uint width, uint height, GLEnum format, GLEnum type, void* pixels)
+	{
+		ObjectDisposedException.ThrowIf(_disposed, this);
+		UnderlyingGL.TexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
+	}
+
+	/// <inheritdoc/>
 	public void Dispose()
 	{
 		if (!_disposed)

--- a/ImGui.App/ImGuiController/IGL.cs
+++ b/ImGui.App/ImGuiController/IGL.cs
@@ -90,4 +90,15 @@ public interface IGL : IDisposable
 	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here.", Justification = "Required for native OpenGL interop; pointer is scoped to the call and not retained.")]
 	[SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Mirrors the native OpenGL glTexImage2D signature; the parameter list is fixed by the GL API.")]
 	public unsafe void TexImage2D(GLEnum target, int level, int internalformat, uint width, uint height, int border, GLEnum format, GLEnum type, void* pixels);
+
+	/// <summary>
+	/// Replaces a rectangular sub-region of an existing two-dimensional texture image.
+	/// </summary>
+	/// <remarks>
+	/// Unlike <see cref="TexImage2D"/> this reuses the existing storage rather than reallocating it,
+	/// which is what makes repeated uploads to a live texture cheap.
+	/// </remarks>
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here.", Justification = "Required for native OpenGL interop; pointer is scoped to the call and not retained.")]
+	[SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Mirrors the native OpenGL glTexSubImage2D signature; the parameter list is fixed by the GL API.")]
+	public unsafe void TexSubImage2D(GLEnum target, int level, int xoffset, int yoffset, uint width, uint height, GLEnum format, GLEnum type, void* pixels);
 }

--- a/ImGui.App/ImGuiController/ImGuiController.cs
+++ b/ImGui.App/ImGuiController/ImGuiController.cs
@@ -302,6 +302,32 @@ internal sealed class ImGuiController : IRendererBackend
 	}
 
 	/// <inheritdoc />
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here", Justification = "Required for native ImGui/OpenGL interop; pointer is pinned within a fixed block and not retained.")]
+	public unsafe bool UpdateTexture(nint id, ReadOnlySpan<byte> rgba, int width, int height)
+	{
+		// Matches CreateTexture rather than DeleteTexture's null-conditional no-op: a torn-down context
+		// is a fault here, not a declined capability. Returning false would send the caller into the
+		// recreate path, where CreateTexture would throw this same exception one step further from the
+		// cause.
+		if (_gl is null)
+		{
+			throw new InvalidOperationException("OpenGL context is not initialized.");
+		}
+
+		// Preserve whatever was bound — the caller may be mid-frame.
+		_gl.GetInteger(GLEnum.TextureBinding2D, out int previousTextureId);
+		_gl.BindTexture(GLEnum.Texture2D, (uint)id);
+
+		fixed (byte* pixelPtr = rgba)
+		{
+			_gl.TexSubImage2D(GLEnum.Texture2D, 0, 0, 0, (uint)width, (uint)height, GLEnum.Rgba, GLEnum.UnsignedByte, pixelPtr);
+		}
+
+		_gl.BindTexture(GLEnum.Texture2D, (uint)previousTextureId);
+		return true;
+	}
+
+	/// <inheritdoc />
 	// _gl can be null if the context has already been torn down; callers expect a no-op then.
 	public void DeleteTexture(nint id) => _gl?.DeleteTexture((uint)id);
 

--- a/ImGui.App/Platform/iOS/MetalRendererBackend.cs
+++ b/ImGui.App/Platform/iOS/MetalRendererBackend.cs
@@ -95,6 +95,29 @@ internal sealed unsafe class MetalRendererBackend : IRendererBackend
 	}
 
 	/// <inheritdoc />
+	/// <remarks>
+	/// Metal supports this natively: <c>ReplaceRegion</c> is the same call <see cref="CreateTexture"/>
+	/// already uses to populate a freshly allocated texture, so there is no reason to decline and send
+	/// the caller down the recreate path. An unrecognized handle does return <see langword="false"/>,
+	/// because recreating is the correct recovery when the texture is gone.
+	/// </remarks>
+	public bool UpdateTexture(nint id, ReadOnlySpan<byte> rgba, int width, int height)
+	{
+		if (!textures.TryGetValue(id, out IMTLTexture? texture))
+		{
+			return false;
+		}
+
+		MTLRegion region = MTLRegion.Create2D(0, 0, (nuint)width, (nuint)height);
+		fixed (byte* pixels = rgba)
+		{
+			texture.ReplaceRegion(region, 0, (nint)pixels, (nuint)(width * 4));
+		}
+
+		return true;
+	}
+
+	/// <inheritdoc />
 	public void DeleteTexture(nint id)
 	{
 		if (textures.Remove(id, out IMTLTexture? texture))

--- a/ImGui.Widgets/ImageCanvas.cs
+++ b/ImGui.Widgets/ImageCanvas.cs
@@ -1,0 +1,97 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.ImGui.Widgets;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+using ktsu.ImGui.Widgets.Gestures;
+
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Draws a pannable, zoomable image canvas with a checkerboard backing for transparency.
+	/// </summary>
+	/// <param name="id">Unique widget id.</param>
+	/// <param name="textureId">GPU texture handle to draw.</param>
+	/// <param name="imageSize">Native image size in pixels.</param>
+	/// <param name="state">View state, mutated by user interaction.</param>
+	/// <param name="canvasSize">Size of the canvas region in screen pixels.</param>
+	/// <remarks>
+	/// Drag to pan, scroll to zoom toward the cursor, double-click to fit. Panning and the double-click
+	/// come from <see cref="GestureDetector"/>, which also claims the region; only the wheel is handled
+	/// here, because zoom is not one of the gestures it reports.
+	/// </remarks>
+	[SuppressMessage("Major Code Smell", "S6640:Make sure that using \"unsafe\" is safe here.", Justification = "Required for native ImGui interop; pointer is scoped to the call and not retained.")]
+	public static void ImageCanvas(string id, nint textureId, Vector2 imageSize, ImageCanvasState state, Vector2 canvasSize)
+	{
+		Ensure.NotNull(state);
+
+		using ScopedId scopedId = new(id);
+
+		Vector2 origin = ImGui.GetCursorScreenPos();
+
+		// Claims the region with its own invisible button, so IsItemHovered below refers to it.
+		GestureResult gesture = GestureDetector("##canvas", canvasSize);
+		bool hovered = ImGui.IsItemHovered();
+
+		// MouseDelta, not gesture.Delta: gesture.Delta is total travel since press start, and PanBy is
+		// incremental. The Pan flag supplies the movement threshold that keeps a jittery click still.
+		if ((gesture.Gestures & GestureFlags.Pan) != 0)
+		{
+			state.PanBy(ImGui.GetIO().MouseDelta);
+		}
+
+		if (gesture.DoubleTapped)
+		{
+			state.FitToViewport(imageSize, canvasSize);
+		}
+
+		if (hovered)
+		{
+			float wheel = ImGui.GetIO().MouseWheel;
+			if (wheel != 0f)
+			{
+				// 1.1 per notch is a shallow enough curve to feel controllable at high zoom.
+				float factor = MathF.Pow(1.1f, wheel);
+				state.ZoomAt(factor, ImGui.GetMousePos() - origin, canvasSize);
+			}
+		}
+
+		ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+		drawList.PushClipRect(origin, origin + canvasSize, true);
+
+		DrawCheckerboard(drawList, origin, canvasSize);
+
+		(Vector2 min, Vector2 max) = state.ImageRectInViewport(imageSize, canvasSize);
+		unsafe
+		{
+			drawList.AddImage(new ImTextureRef(texId: textureId), origin + min, origin + max);
+		}
+
+		drawList.PopClipRect();
+	}
+
+	private static void DrawCheckerboard(ImDrawListPtr drawList, Vector2 origin, Vector2 size)
+	{
+		const float cell = 8f;
+		uint light = ImGui.GetColorU32(new Vector4(0.35f, 0.35f, 0.35f, 1f));
+		uint dark = ImGui.GetColorU32(new Vector4(0.25f, 0.25f, 0.25f, 1f));
+
+		drawList.AddRectFilled(origin, origin + size, dark);
+
+		int columns = (int)MathF.Ceiling(size.X / cell);
+		int rows = (int)MathF.Ceiling(size.Y / cell);
+		for (int row = 0; row < rows; row++)
+		{
+			for (int column = row % 2; column < columns; column += 2)
+			{
+				Vector2 cellMin = origin + new Vector2(column * cell, row * cell);
+				Vector2 cellMax = Vector2.Min(cellMin + new Vector2(cell, cell), origin + size);
+				drawList.AddRectFilled(cellMin, cellMax, light);
+			}
+		}
+	}
+}

--- a/ImGui.Widgets/ImageCanvasState.cs
+++ b/ImGui.Widgets/ImageCanvasState.cs
@@ -1,0 +1,98 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.ImGui.Widgets;
+
+using System.Numerics;
+
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Pan and zoom state for an image canvas, independent of any rendering.
+	/// </summary>
+	/// <remarks>
+	/// Pan is expressed as an offset in viewport pixels applied to the image's centred position, so a
+	/// pan of zero always means "centred", whatever the zoom.
+	/// </remarks>
+	public sealed class ImageCanvasState
+	{
+		/// <summary>Gets the current zoom factor, where 1.0 is one image pixel per viewport pixel.</summary>
+		public float Zoom { get; private set; } = 1f;
+
+		/// <summary>Gets the current pan offset in viewport pixels.</summary>
+		public Vector2 Pan { get; private set; }
+
+		/// <summary>Gets or sets the smallest permitted zoom factor.</summary>
+		public float MinZoom { get; init; } = 0.01f;
+
+		/// <summary>Gets or sets the largest permitted zoom factor.</summary>
+		public float MaxZoom { get; init; } = 64f;
+
+		/// <summary>Scales the image to fit entirely within the viewport and centres it.</summary>
+		/// <param name="imageSize">Native image size in pixels.</param>
+		/// <param name="viewportSize">Viewport size in pixels.</param>
+		public void FitToViewport(Vector2 imageSize, Vector2 viewportSize)
+		{
+			if (imageSize.X <= 0f || imageSize.Y <= 0f)
+			{
+				return;
+			}
+
+			float scale = Math.Min(viewportSize.X / imageSize.X, viewportSize.Y / imageSize.Y);
+			Zoom = Math.Clamp(scale, MinZoom, MaxZoom);
+			Pan = Vector2.Zero;
+		}
+
+		/// <summary>Sets zoom to 1:1 and recentres.</summary>
+		public void ResetToActualSize()
+		{
+			Zoom = Math.Clamp(1f, MinZoom, MaxZoom);
+			Pan = Vector2.Zero;
+		}
+
+		/// <summary>Translates the view by a delta in viewport pixels.</summary>
+		/// <param name="delta">Translation in viewport pixels.</param>
+		public void PanBy(Vector2 delta) => Pan += delta;
+
+		/// <summary>
+		/// Multiplies the zoom by <paramref name="factor"/> while holding the image point under
+		/// <paramref name="anchor"/> stationary.
+		/// </summary>
+		/// <param name="factor">Relative zoom change; greater than one zooms in.</param>
+		/// <param name="anchor">Anchor position in viewport pixels, relative to the viewport's top-left.</param>
+		/// <param name="viewportSize">Viewport size in pixels.</param>
+		public void ZoomAt(float factor, Vector2 anchor, Vector2 viewportSize)
+		{
+			float newZoom = Math.Clamp(Zoom * factor, MinZoom, MaxZoom);
+			float applied = newZoom / Zoom;
+
+			// Keep the anchor fixed: the vector from the image centre to the anchor scales with the zoom.
+			Vector2 centre = (viewportSize * 0.5f) + Pan;
+			Vector2 centreToAnchor = anchor - centre;
+			Pan += centreToAnchor - (centreToAnchor * applied);
+
+			Zoom = newZoom;
+		}
+
+		/// <summary>Gets the image's axis-aligned bounds in viewport pixels.</summary>
+		/// <param name="imageSize">Native image size in pixels.</param>
+		/// <param name="viewportSize">Viewport size in pixels.</param>
+		/// <returns>The image bounds in viewport pixels.</returns>
+		public (Vector2 Min, Vector2 Max) ImageRectInViewport(Vector2 imageSize, Vector2 viewportSize)
+		{
+			Vector2 scaled = imageSize * Zoom;
+			Vector2 min = (viewportSize * 0.5f) + Pan - (scaled * 0.5f);
+			return (min, min + scaled);
+		}
+
+		/// <summary>Converts a viewport position to image pixel coordinates.</summary>
+		/// <param name="viewportPoint">Position in viewport pixels, relative to the viewport's top-left.</param>
+		/// <param name="imageSize">Native image size in pixels.</param>
+		/// <param name="viewportSize">Viewport size in pixels.</param>
+		/// <returns>The corresponding position in image pixels.</returns>
+		public Vector2 ViewportToImage(Vector2 viewportPoint, Vector2 imageSize, Vector2 viewportSize)
+		{
+			(Vector2 min, _) = ImageRectInViewport(imageSize, viewportSize);
+			return (viewportPoint - min) / Zoom;
+		}
+	}
+}

--- a/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
+++ b/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
@@ -93,6 +93,7 @@ internal static class ImGuiWidgetsDemo
 	private static ImGuiWidgets.DividerContainer DividerContainer { get; } = new("DemoDividerContainer");
 	private static ImGuiPopups.MessageOK MessageOK { get; } = new();
 	private static ImGuiWidgets.TabPanel DemoTabPanel { get; } = new("DemoTabPanel", true, true);
+	private static ImGuiWidgets.ImageCanvasState ImageCanvasDemoState { get; } = new();
 	private static Dictionary<string, string> TabIds { get; } = [];
 	private static int NextDynamicTabId { get; set; } = 1;
 
@@ -237,12 +238,41 @@ internal static class ImGuiWidgetsDemo
 		ImGui.Separator();
 
 		ShowImageAndIconDemo(ktsuTexture);
+		ShowImageCanvasDemo(ktsuTexture);
 		ShowTabPanelDemo();
 		ShowSearchBoxDemo();
 		ShowGridDemo(ktsuTexture);
 		ShowDividerDemo();
 
 		MessageOK.ShowIfOpen();
+	}
+
+	private static void ShowImageCanvasDemo(ImGuiAppTextureInfo ktsuTexture)
+	{
+		if (ImGui.CollapsingHeader("ImageCanvas"))
+		{
+			ImGui.TextUnformatted("Pannable, zoomable image canvas with a checkerboard behind transparency:");
+			ImGui.BulletText("Drag to pan");
+			ImGui.BulletText("Scroll to zoom toward the cursor");
+			ImGui.BulletText("Double-click to fit the image to the canvas");
+			ImGui.Separator();
+
+			if (ImGui.Button("Fit"))
+			{
+				ImageCanvasDemoState.FitToViewport(new Vector2(ktsuTexture.Width, ktsuTexture.Height), new Vector2(ImGui.GetContentRegionAvail().X, 300f));
+			}
+			ImGui.SameLine();
+			if (ImGui.Button("1:1"))
+			{
+				ImageCanvasDemoState.ResetToActualSize();
+			}
+			ImGui.SameLine();
+			ImGui.TextUnformatted($"Zoom: {ImageCanvasDemoState.Zoom:0.##}x");
+
+			Vector2 imageSize = new(ktsuTexture.Width, ktsuTexture.Height);
+			Vector2 canvasSize = new(ImGui.GetContentRegionAvail().X, 300f);
+			ImGuiWidgets.ImageCanvas("image_canvas_demo", ktsuTexture.TextureId, imageSize, ImageCanvasDemoState, canvasSize);
+		}
 	}
 
 	private static void ShowTabPanelDemo()

--- a/tests/ImGui.App.Tests/ImGuiAppTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppTests.cs
@@ -464,6 +464,8 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		public int CreateTextureCallCount { get; private set; }
 		public int DeleteTextureCallCount { get; private set; }
 		public nint NextHandle { get; init; }
+		public nint LastUpdatedTextureId { get; private set; }
+		public byte[] LastUpdatedPixels { get; private set; } = [];
 
 		public nint CreateTexture(ReadOnlySpan<byte> rgba, int width, int height)
 		{
@@ -471,9 +473,35 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 			return NextHandle;
 		}
 
+		public bool UpdateTexture(nint id, ReadOnlySpan<byte> rgba, int width, int height)
+		{
+			LastUpdatedTextureId = id;
+			LastUpdatedPixels = rgba.ToArray();
+			return true;
+		}
+
 		public void DeleteTexture(nint id) => DeleteTextureCallCount++;
 		public void RenderDrawData(Hexa.NET.ImGui.ImDrawDataPtr drawData) { }
 		public void Dispose() { }
+	}
+
+	[TestMethod]
+	public void UpdateTexture_ThroughTheBackendInterface_ReceivesTheHandleAndPixels()
+	{
+		// The local is typed as IRendererBackend deliberately. Calling through the interface is what
+		// makes this fail to compile until the interface declares UpdateTexture. Calling it on the
+		// concrete fake would compile and pass the moment the fake gained the method, proving nothing
+		// about the contract this task exists to add.
+		using FakeRendererBackend fake = new() { NextHandle = 11 };
+		IRendererBackend backend = fake;
+		nint id = backend.CreateTexture(new byte[4], 1, 1);
+		byte[] pixels = [1, 2, 3, 4];
+
+		bool updated = backend.UpdateTexture(id, pixels, 1, 1);
+
+		Assert.IsTrue(updated, "A backend that supports in-place update should report success");
+		Assert.AreEqual(id, fake.LastUpdatedTextureId, "The handle should reach the backend unchanged");
+		CollectionAssert.AreEqual(pixels, fake.LastUpdatedPixels, "The pixel payload should reach the backend unchanged");
 	}
 
 	[TestMethod]

--- a/tests/ImGui.App.Tests/ImGuiAppTests.cs
+++ b/tests/ImGui.App.Tests/ImGuiAppTests.cs
@@ -466,6 +466,7 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		public nint NextHandle { get; init; }
 		public nint LastUpdatedTextureId { get; private set; }
 		public byte[] LastUpdatedPixels { get; private set; } = [];
+		public bool UpdateTextureResult { get; init; } = true;
 
 		public nint CreateTexture(ReadOnlySpan<byte> rgba, int width, int height)
 		{
@@ -477,7 +478,7 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		{
 			LastUpdatedTextureId = id;
 			LastUpdatedPixels = rgba.ToArray();
-			return true;
+			return UpdateTextureResult;
 		}
 
 		public void DeleteTexture(nint id) => DeleteTextureCallCount++;
@@ -535,6 +536,90 @@ callsAfterForced, "Forced validation should cause additional monitor access");
 		ImGuiApp.DeleteTexture(123);
 
 		Assert.AreEqual(1, backend.DeleteTextureCallCount, "Delete should route through the registered backend");
+	}
+
+	[TestMethod]
+	public void CreateTexture_WithWrongPixelCount_Throws()
+	{
+		byte[] tooFew = new byte[8];
+
+		Assert.ThrowsExactly<ArgumentException>(() => ImGuiApp.CreateTexture(tooFew, 2, 2));
+	}
+
+	[TestMethod]
+	public void UpdateTexture_WithNullInfo_Throws()
+	{
+		Assert.ThrowsExactly<ArgumentNullException>(() => ImGuiApp.UpdateTexture(null!, new byte[4], 1, 1));
+	}
+
+	[TestMethod]
+	public void CreateTexture_WithBackendRegistered_ReturnsUntrackedTextureInfo()
+	{
+		ResetState();
+		ImGuiApp.Invoker = new Invoker.Invoker();
+		FakeRendererBackend backend = new() { NextHandle = 42 };
+		ImGuiApp.renderer = backend;
+		ImGuiApp.controller = null;
+
+		ImGuiAppTextureInfo info = ImGuiApp.CreateTexture(new byte[2 * 2 * 4], 2, 2);
+
+		Assert.AreEqual(42, info.TextureId, "Handle should come from the backend");
+		Assert.AreEqual(2, info.Width);
+		Assert.AreEqual(2, info.Height);
+		Assert.AreEqual(0, ImGuiApp.Textures.Count, "Memory textures must stay out of the path-keyed cache");
+	}
+
+	[TestMethod]
+	public void UpdateTexture_WithSameSize_UpdatesInPlaceWithoutRecreating()
+	{
+		ResetState();
+		ImGuiApp.Invoker = new Invoker.Invoker();
+		FakeRendererBackend backend = new() { NextHandle = 42 };
+		ImGuiApp.renderer = backend;
+		ImGuiApp.controller = null;
+		ImGuiAppTextureInfo info = ImGuiApp.CreateTexture(new byte[1 * 1 * 4], 1, 1);
+		byte[] pixels = [1, 2, 3, 4];
+
+		ImGuiApp.UpdateTexture(info, pixels, 1, 1);
+
+		Assert.AreEqual(info.TextureId, backend.LastUpdatedTextureId, "In-place update should target the existing handle");
+		CollectionAssert.AreEqual(pixels, backend.LastUpdatedPixels, "The pixel payload should reach the backend unchanged");
+		Assert.AreEqual(0, backend.DeleteTextureCallCount, "A successful in-place update must not delete the texture");
+		Assert.AreEqual(1, backend.CreateTextureCallCount, "A successful in-place update must not recreate the texture");
+	}
+
+	[TestMethod]
+	public void UpdateTexture_WithDifferentSize_RecreatesTexture()
+	{
+		ResetState();
+		ImGuiApp.Invoker = new Invoker.Invoker();
+		FakeRendererBackend backend = new() { NextHandle = 42 };
+		ImGuiApp.renderer = backend;
+		ImGuiApp.controller = null;
+		ImGuiAppTextureInfo info = ImGuiApp.CreateTexture(new byte[2 * 2 * 4], 2, 2);
+
+		ImGuiApp.UpdateTexture(info, new byte[1 * 1 * 4], 1, 1);
+
+		Assert.AreEqual(1, backend.DeleteTextureCallCount, "A size change must delete the old texture");
+		Assert.AreEqual(2, backend.CreateTextureCallCount, "A size change must recreate the texture");
+		Assert.AreEqual(1, info.Width, "The info must carry the new width");
+		Assert.AreEqual(1, info.Height, "The info must carry the new height");
+	}
+
+	[TestMethod]
+	public void UpdateTexture_WhenBackendDeclines_FallsBackToRecreate()
+	{
+		ResetState();
+		ImGuiApp.Invoker = new Invoker.Invoker();
+		FakeRendererBackend backend = new() { NextHandle = 42, UpdateTextureResult = false };
+		ImGuiApp.renderer = backend;
+		ImGuiApp.controller = null;
+		ImGuiAppTextureInfo info = ImGuiApp.CreateTexture(new byte[1 * 1 * 4], 1, 1);
+
+		ImGuiApp.UpdateTexture(info, new byte[1 * 1 * 4], 1, 1);
+
+		Assert.AreEqual(1, backend.DeleteTextureCallCount, "A declined update must delete the old texture");
+		Assert.AreEqual(2, backend.CreateTextureCallCount, "A declined update must recreate the texture");
 	}
 
 	[TestMethod]

--- a/tests/ImGui.App.Tests/MockGL.cs
+++ b/tests/ImGui.App.Tests/MockGL.cs
@@ -104,6 +104,12 @@ public sealed unsafe class MockGL(TestGL testGL) : IGL
 		_testGL.TexImage2D(target, level, internalformat, width, height, border, format, type, pixels);
 	}
 
+	public void TexSubImage2D(GLEnum target, int level, int xoffset, int yoffset, uint width, uint height, GLEnum format, GLEnum type, void* pixels)
+	{
+		ThrowIfDisposed();
+		_testGL.TexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
+	}
+
 	public void Dispose()
 	{
 		if (!_disposed)

--- a/tests/ImGui.App.Tests/TestGL.cs
+++ b/tests/ImGui.App.Tests/TestGL.cs
@@ -92,6 +92,11 @@ public sealed unsafe class TestGL : IGL
 		ThrowIfDisposed();
 	}
 
+	public void TexSubImage2D(GLEnum target, int level, int xoffset, int yoffset, uint width, uint height, GLEnum format, GLEnum type, void* pixels)
+	{
+		ThrowIfDisposed();
+	}
+
 	public void Dispose()
 	{
 		if (!_disposed)

--- a/tests/ImGui.Widgets.Tests/ImageCanvasStateTests.cs
+++ b/tests/ImGui.Widgets.Tests/ImageCanvasStateTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.ImGui.Widgets.Tests;
+
+using System.Numerics;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Tests the pan/zoom/fit view math behind the image canvas. All pure — no ImGui context required.
+/// </summary>
+[TestClass]
+public class ImageCanvasStateTests
+{
+	[TestMethod]
+	public void FitToViewport_WiderImage_FitsToWidth()
+	{
+		ImGuiWidgets.ImageCanvasState state = new();
+
+		state.FitToViewport(new Vector2(400, 100), new Vector2(200, 200));
+
+		Assert.AreEqual(0.5f, state.Zoom, 0.0001f);
+	}
+
+	[TestMethod]
+	public void FitToViewport_TallerImage_FitsToHeight()
+	{
+		ImGuiWidgets.ImageCanvasState state = new();
+
+		state.FitToViewport(new Vector2(100, 400), new Vector2(200, 200));
+
+		Assert.AreEqual(0.5f, state.Zoom, 0.0001f);
+	}
+
+	[TestMethod]
+	public void FitToViewport_CentresImage()
+	{
+		ImGuiWidgets.ImageCanvasState state = new();
+
+		state.FitToViewport(new Vector2(400, 100), new Vector2(200, 200));
+		(Vector2 min, Vector2 max) = state.ImageRectInViewport(new Vector2(400, 100), new Vector2(200, 200));
+
+		Assert.AreEqual(0f, min.X, 0.0001f);
+		Assert.AreEqual(200f, max.X, 0.0001f);
+		Assert.AreEqual(75f, min.Y, 0.0001f);
+		Assert.AreEqual(125f, max.Y, 0.0001f);
+	}
+
+	[TestMethod]
+	public void ResetToActualSize_SetsZoomToOne()
+	{
+		ImGuiWidgets.ImageCanvasState state = new();
+		state.FitToViewport(new Vector2(400, 100), new Vector2(200, 200));
+
+		state.ResetToActualSize();
+
+		Assert.AreEqual(1f, state.Zoom, 0.0001f);
+	}
+
+	[TestMethod]
+	public void ZoomAt_KeepsAnchorPointStationary()
+	{
+		// Zooming under the cursor must leave the image pixel under the cursor unmoved.
+		ImGuiWidgets.ImageCanvasState state = new();
+		Vector2 imageSize = new(400, 400);
+		Vector2 viewportSize = new(200, 200);
+		state.FitToViewport(imageSize, viewportSize);
+		Vector2 anchor = new(150, 50);
+
+		Vector2 imagePointBefore = state.ViewportToImage(anchor, imageSize, viewportSize);
+		state.ZoomAt(2f, anchor, viewportSize);
+		Vector2 imagePointAfter = state.ViewportToImage(anchor, imageSize, viewportSize);
+
+		Assert.AreEqual(imagePointBefore.X, imagePointAfter.X, 0.001f);
+		Assert.AreEqual(imagePointBefore.Y, imagePointAfter.Y, 0.001f);
+	}
+
+	[TestMethod]
+	public void ZoomAt_ClampsToConfiguredRange()
+	{
+		ImGuiWidgets.ImageCanvasState state = new() { MinZoom = 0.1f, MaxZoom = 4f };
+
+		state.ZoomAt(1000f, new Vector2(100, 100), new Vector2(200, 200));
+		Assert.AreEqual(4f, state.Zoom, 0.0001f);
+
+		state.ZoomAt(0.00001f, new Vector2(100, 100), new Vector2(200, 200));
+		Assert.AreEqual(0.1f, state.Zoom, 0.0001f);
+	}
+
+	[TestMethod]
+	public void PanBy_TranslatesImageRect()
+	{
+		ImGuiWidgets.ImageCanvasState state = new();
+		state.FitToViewport(new Vector2(200, 200), new Vector2(200, 200));
+		(Vector2 minBefore, _) = state.ImageRectInViewport(new Vector2(200, 200), new Vector2(200, 200));
+
+		state.PanBy(new Vector2(10, -5));
+		(Vector2 minAfter, _) = state.ImageRectInViewport(new Vector2(200, 200), new Vector2(200, 200));
+
+		Assert.AreEqual(minBefore.X + 10f, minAfter.X, 0.0001f);
+		Assert.AreEqual(minBefore.Y - 5f, minAfter.Y, 0.0001f);
+	}
+}


### PR DESCRIPTION
## Summary

Adds the upstream pieces an app needs to show a live, re-computed image: in-place GPU texture updates, a public in-memory texture API, and a pan/zoom image canvas widget. Implements all four tasks of the ImageGui live-image-display plan.

- **`IRendererBackend.UpdateTexture`** — in-place texture upload, implemented for OpenGL (`glTexSubImage2D`, added to `IGL`/`GLWrapper`/`TestGL`/`MockGL`) and Metal (`ReplaceRegion`). Returns `bool` meaning "recreate instead"; a torn-down context throws, matching `CreateTexture`.
- **`ImGuiApp.CreateTexture` / `ImGuiApp.UpdateTexture`** — public entry points for pixels generated in memory. Created textures stay out of the path-keyed cache (no file to reload from), so the caller owns their lifetime. `UpdateTexture` updates in place when the backend can, and falls back to delete-and-recreate when it declines or the size changed.
- **`ImGuiWidgets.ImageCanvasState`** — pure pan/zoom/fit view math, no ImGui dependency, unit-tested (anchor-stationary zoom, clamping, centred fit).
- **`ImGuiWidgets.ImageCanvas`** — thin drawing layer over `GestureDetector`: drag to pan, wheel to zoom toward the cursor, double-click to fit, checkerboard behind transparency. Demo section added to ImGuiWidgetsDemo.

## Test plan

- Full solution suite: 736 tests, 0 failed (13 new: 6 texture API, 7 canvas math).
- Solution builds with 0 warnings.
- Demo app launches and runs cleanly on Windows.

## Caveats

- The Metal `UpdateTexture` implementation has not been compiled: `net10.0-ios` only enters `TargetFrameworks` on macOS, and this branch was built on Windows. Needs a macOS build before release.
- The ImageCanvas demo section has not been driven by hand yet (pan/zoom/fit interaction checks outstanding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaavRoQ3LDHz537ugXsyvi