### PR TITLE
fix: match every pattern in a semicolon-separated glob

### DIFF
--- a/ImGui.Popups/FilesystemBrowser.cs
+++ b/ImGui.Popups/FilesystemBrowser.cs
@@ -144,7 +144,7 @@ public partial class ImGuiPopups
 		/// </summary>
 		/// <param name="title">The title of the dialog.</param>
 		/// <param name="onChooseFile">Callback invoked when a file is chosen.</param>
-		/// <param name="glob">Glob pattern for filtering files.</param>
+		/// <param name="glob">Glob pattern for filtering files. Several patterns may be separated by semicolons, for example <c>*.png;*.jpg</c>.</param>
 		public void FileOpen(string title, Action<AbsoluteFilePath> onChooseFile, string glob = "*") => FileOpen(title, onChooseFile, customSize: Vector2.Zero, glob);
 
 		/// <summary>
@@ -153,7 +153,7 @@ public partial class ImGuiPopups
 		/// <param name="title">The title of the dialog.</param>
 		/// <param name="onChooseFile">Callback invoked when a file is chosen.</param>
 		/// <param name="customSize">Custom size of the dialog.</param>
-		/// <param name="glob">Glob pattern for filtering files.</param>
+		/// <param name="glob">Glob pattern for filtering files. Several patterns may be separated by semicolons, for example <c>*.png;*.jpg</c>.</param>
 		public void FileOpen(string title, Action<AbsoluteFilePath> onChooseFile, Vector2 customSize, string glob = "*") => File(title, FilesystemBrowserMode.Open, onChooseFile, customSize, glob);
 
 		/// <summary>
@@ -161,7 +161,7 @@ public partial class ImGuiPopups
 		/// </summary>
 		/// <param name="title">The title of the dialog.</param>
 		/// <param name="onChooseFile">Callback invoked when a file is chosen.</param>
-		/// <param name="glob">Glob pattern for filtering files.</param>
+		/// <param name="glob">Glob pattern for filtering files. Several patterns may be separated by semicolons, for example <c>*.png;*.jpg</c>.</param>
 		public void FileSave(string title, Action<AbsoluteFilePath> onChooseFile, string glob = "*") => FileSave(title, onChooseFile, customSize: Vector2.Zero, glob);
 
 		/// <summary>
@@ -170,7 +170,7 @@ public partial class ImGuiPopups
 		/// <param name="title">The title of the dialog.</param>
 		/// <param name="onChooseFile">Callback invoked when a file is chosen.</param>
 		/// <param name="customSize">Custom size of the dialog.</param>
-		/// <param name="glob">Glob pattern for filtering files.</param>
+		/// <param name="glob">Glob pattern for filtering files. Several patterns may be separated by semicolons, for example <c>*.png;*.jpg</c>.</param>
 		public void FileSave(string title, Action<AbsoluteFilePath> onChooseFile, Vector2 customSize, string glob = "*") => File(title, FilesystemBrowserMode.Save, onChooseFile, customSize, glob);
 
 		/// <summary>
@@ -180,7 +180,7 @@ public partial class ImGuiPopups
 		/// <param name="mode">The mode of the browser (Open or Save).</param>
 		/// <param name="onChooseFile">Callback for when a file is chosen.</param>
 		/// <param name="customSize">Custom size of the popup.</param>
-		/// <param name="glob">Glob pattern for filtering files.</param>
+		/// <param name="glob">Glob pattern for filtering files. Several patterns may be separated by semicolons, for example <c>*.png;*.jpg</c>.</param>
 		private void File(string title, FilesystemBrowserMode mode, Action<AbsoluteFilePath> onChooseFile, Vector2 customSize, string glob) => OpenPopup(title, mode, FilesystemBrowserTarget.File, onChooseFile, (d) => { }, customSize, glob);
 
 		/// <summary>
@@ -207,7 +207,7 @@ public partial class ImGuiPopups
 		/// <param name="onChooseFile">Callback for when a file is chosen.</param>
 		/// <param name="onChooseDirectory">Callback for when a directory is chosen.</param>
 		/// <param name="customSize">Custom size of the popup.</param>
-		/// <param name="glob">Glob pattern for filtering files.</param>
+		/// <param name="glob">Glob pattern for filtering files. Several patterns may be separated by semicolons, for example <c>*.png;*.jpg</c>.</param>
 		private void OpenPopup(string title, FilesystemBrowserMode mode, FilesystemBrowserTarget target, Action<AbsoluteFilePath> onChooseFile, Action<AbsoluteDirectoryPath> onChooseDirectory, Vector2 customSize, string glob)
 		{
 			FileName = new();
@@ -216,12 +216,30 @@ public partial class ImGuiPopups
 			OnChooseFile = onChooseFile;
 			OnChooseDirectory = onChooseDirectory;
 			Glob = glob;
-			Matcher = new();
-			Matcher.AddInclude(Glob);
+			Matcher = BuildMatcher(glob);
 			Drives.Clear();
 			GetNavigableDrives().ForEach(Drives.Add);
 			RefreshContents();
 			Modal.Open(title, ShowContent, customSize);
+		}
+
+		/// <summary>
+		/// Builds a matcher from a glob string. Several patterns may be supplied separated by
+		/// semicolons, for example <c>*.png;*.jpg</c>. The underlying globbing library treats a
+		/// whole string as a single pattern and has no separator of its own, so each pattern has
+		/// to be added as its own include or the combined string matches nothing at all.
+		/// </summary>
+		/// <param name="glob">Glob pattern, or several separated by semicolons.</param>
+		/// <returns>A matcher including every pattern supplied.</returns>
+		internal static Matcher BuildMatcher(string glob)
+		{
+			Matcher matcher = new();
+			foreach (string pattern in glob.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+			{
+				matcher.AddInclude(pattern);
+			}
+
+			return matcher;
 		}
 
 		/// <summary>

--- a/tests/ImGui.Popups.Tests/FilesystemBrowserGlobTests.cs
+++ b/tests/ImGui.Popups.Tests/FilesystemBrowserGlobTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.ImGui.Popups.Tests;
+
+using Microsoft.Extensions.FileSystemGlobbing;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class FilesystemBrowserGlobTests
+{
+	/// <summary>
+	/// A semicolon-separated glob is the natural way for a caller to ask for several extensions,
+	/// but <see cref="Matcher"/> has no separator of its own and treats a whole string as one
+	/// pattern, so passing the combined string to a single AddInclude matched nothing and the
+	/// browser listed no files at all.
+	/// </summary>
+	[TestMethod]
+	public void BuildMatcher_SemicolonSeparatedPatterns_MatchesEveryExtension()
+	{
+		Matcher matcher = ImGuiPopups.FilesystemBrowser.BuildMatcher("*.png;*.jpg;*.jpeg;*.webp");
+
+		Assert.IsTrue(matcher.Match("photo.png").HasMatches);
+		Assert.IsTrue(matcher.Match("photo.jpg").HasMatches);
+		Assert.IsTrue(matcher.Match("photo.jpeg").HasMatches);
+		Assert.IsTrue(matcher.Match("photo.webp").HasMatches);
+	}
+
+	[TestMethod]
+	public void BuildMatcher_SemicolonSeparatedPatterns_RejectsOtherExtensions()
+	{
+		Matcher matcher = ImGuiPopups.FilesystemBrowser.BuildMatcher("*.png;*.jpg");
+
+		Assert.IsFalse(matcher.Match("notes.txt").HasMatches);
+		Assert.IsFalse(matcher.Match("archive.zip").HasMatches);
+	}
+
+	[TestMethod]
+	public void BuildMatcher_SinglePattern_BehavesAsBefore()
+	{
+		Matcher matcher = ImGuiPopups.FilesystemBrowser.BuildMatcher("*.png");
+
+		Assert.IsTrue(matcher.Match("photo.png").HasMatches);
+		Assert.IsFalse(matcher.Match("photo.jpg").HasMatches);
+	}
+
+	[TestMethod]
+	public void BuildMatcher_DefaultGlob_MatchesEverything()
+	{
+		Matcher matcher = ImGuiPopups.FilesystemBrowser.BuildMatcher("*");
+
+		Assert.IsTrue(matcher.Match("photo.png").HasMatches);
+		Assert.IsTrue(matcher.Match("notes.txt").HasMatches);
+	}
+
+	[TestMethod]
+	public void BuildMatcher_PatternsWithSurroundingWhitespace_AreTrimmed()
+	{
+		Matcher matcher = ImGuiPopups.FilesystemBrowser.BuildMatcher("*.png; *.jpg ; *.webp");
+
+		Assert.IsTrue(matcher.Match("photo.jpg").HasMatches);
+		Assert.IsTrue(matcher.Match("photo.webp").HasMatches);
+	}
+
+	[TestMethod]
+	public void BuildMatcher_EmptyEntries_AreIgnored()
+	{
+		Matcher matcher = ImGuiPopups.FilesystemBrowser.BuildMatcher(";;*.png;;");
+
+		Assert.IsTrue(matcher.Match("photo.png").HasMatches);
+		Assert.IsFalse(matcher.Match("notes.txt").HasMatches);
+	}
+}


### PR DESCRIPTION
## Problem

`FilesystemBrowser` passed the whole glob string to a single `Matcher.AddInclude`. `Microsoft.Extensions.FileSystemGlobbing` has no separator of its own and treats an entire string as one pattern, so a caller asking for `"*.png;*.jpg;*.jpeg;*.webp"` matched **nothing** and the browser listed no files at all — only `..`.

The same matcher gates the save dialog's filename validation, so `FileSave` also rejected every name typed into it with "The file name does not match the glob pattern."

Verified empirically — only repeated `AddInclude` calls work:

| Pattern | `photo.png` | `photo.jpg` | `notes.txt` |
|---|---|---|---|
| `AddInclude("*.png;*.jpg")` | no | no | no |
| `AddInclude("*.{png,jpg}")` | no | no | no |
| separate `AddInclude` per pattern | **YES** | **YES** | no |

Brace expansion is not supported either, so splitting is the only route.

## Fix

Extract `BuildMatcher(glob)`, which splits on `;` and adds each pattern as its own include. Empty entries are dropped and surrounding whitespace trimmed, so `"*.png; *.jpg ;"` behaves as expected.

Backwards compatible: a single-pattern glob and the `"*"` default are unchanged, and the public signatures are untouched.

## Tests

Six new tests in `FilesystemBrowserGlobTests` cover multi-pattern matching, rejection of non-matching extensions, the single-pattern regression, the `"*"` default, whitespace trimming and empty entries. Suite goes 13 → 19 passing, 0 failed.

## How this surfaced

Found while verifying ImageGui's Milestone 1 file-open flow — its `File > Open` dialog listed no images at all. ImageGui needs a release containing this before it can filter by codec type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2jh1ZMuULEMd49svVWTsg