### PR TITLE
Let a headless session install its own renderer backend

### DIFF
--- a/ImGui.App.Testing/ImGuiAppHarness.cs
+++ b/ImGui.App.Testing/ImGuiAppHarness.cs
@@ -75,9 +75,24 @@ public sealed class ImGuiAppHarness : IDisposable
 				"An ImGuiAppHarness is already running in this process. ImGui contexts are global, so harnesses cannot overlap. Dispose the previous one first.");
 		}
 
-		ImGuiApp.BeginExternalFrameSession();
-
 		ImGuiAppHarness harness = new(config, options);
+
+		// The rasterizer becomes ImGuiApp's renderer backend for the session, so an application
+		// that uploads a texture through ImGuiApp reaches the renderer that is drawing its frames.
+		// Without this, anything showing an image it generated rather than loaded fails on a
+		// backend that was never installed.
+		try
+		{
+			ImGuiApp.BeginExternalFrameSession(harness.renderer);
+		}
+		catch
+		{
+			// Not yet the live harness, so this releases the context and the rasterizer without
+			// ending a session that was never begun.
+			harness.Dispose();
+			throw;
+		}
+
 		live = harness;
 
 		// Items are recorded against the frame being rendered, which is FrameCount until the step

--- a/ImGui.App.Testing/SoftwareRenderer.cs
+++ b/ImGui.App.Testing/SoftwareRenderer.cs
@@ -10,15 +10,19 @@ using System.Numerics;
 using Hexa.NET.ImGui;
 
 /// <summary>
-/// Turns ImGui draw data into pixels on the CPU. Mirrors the shape of the renderer seam the OpenGL
-/// and Metal backends implement, but deliberately does not implement that interface: it is internal
-/// to ktsu.ImGui.App, and depending on it would require friend access, which in turn makes every
-/// polyfilled call in this assembly ambiguous between two copies of the same source-only package.
-/// Nothing inside ktsu.ImGui.App consumes this renderer, so the interface buys nothing here.
+/// Turns ImGui draw data into pixels on the CPU, as the renderer backend for a headless session.
 /// </summary>
+/// <remarks>
+/// This implements the same seam the OpenGL and Metal backends do, which is what lets an
+/// application under test upload its own textures through <see cref="ImGuiApp.CreateTexture"/> and
+/// have them reach the rasterizer that is actually drawing. It previously only mirrored the seam's
+/// shape without implementing it, because the interface was internal and friend access would have
+/// made every polyfilled call in this assembly ambiguous between two compiled copies of a
+/// source-only package. The interface is public now, so neither problem applies.
+/// </remarks>
 /// <param name="width">Render target width in pixels.</param>
 /// <param name="height">Render target height in pixels.</param>
-public sealed class SoftwareRenderer(int width, int height) : IDisposable
+public sealed class SoftwareRenderer(int width, int height) : IRendererBackend
 {
 	private readonly Dictionary<nint, TextureSource> textures = [];
 	private nint nextId = 1;

--- a/ImGui.App/IRendererBackend.cs
+++ b/ImGui.App/IRendererBackend.cs
@@ -16,12 +16,16 @@ using Hexa.NET.ImGui;
 /// </summary>
 /// <remarks>
 /// Public because a host that drives its own frames through
-/// <see cref="ImGuiApp.BeginExternalFrameSession(IRendererBackend)"/> has to supply one. Without
-/// that, every texture the application uploads through <see cref="ImGuiApp.CreateTexture"/> fails
-/// on a backend that was never installed, which rules out testing any application that shows an
-/// image it generated. Keeping the seam internal and reaching it through friend access was tried
-/// and does not work: <c>Polyfill</c> is source-only, so friend access makes every polyfilled call
-/// ambiguous between the two compiled copies.
+/// <c>ImGuiApp.BeginExternalFrameSession</c> has to supply one. Without that, every texture the
+/// application uploads through <c>ImGuiApp.CreateTexture</c> fails on a backend that was never
+/// installed, which rules out testing any application that shows an image it generated. Keeping
+/// the seam internal and reaching it through friend access was tried and does not work:
+/// <c>Polyfill</c> is source-only, so friend access makes every polyfilled call ambiguous between
+/// the two compiled copies.
+/// <para>
+/// Referred to here in plain code rather than with a cref: this file compiles for the iOS target
+/// framework as well, where the desktop host type is not part of the compilation.
+/// </para>
 /// </remarks>
 public interface IRendererBackend : IDisposable
 {

--- a/ImGui.App/IRendererBackend.cs
+++ b/ImGui.App/IRendererBackend.cs
@@ -14,7 +14,16 @@ using Hexa.NET.ImGui;
 /// (input, NewFrame/EndFrame, font configuration) stays in the concrete backend until
 /// the broader split described in the iOS port plan is in place.
 /// </summary>
-internal interface IRendererBackend : IDisposable
+/// <remarks>
+/// Public because a host that drives its own frames through
+/// <see cref="ImGuiApp.BeginExternalFrameSession(IRendererBackend)"/> has to supply one. Without
+/// that, every texture the application uploads through <see cref="ImGuiApp.CreateTexture"/> fails
+/// on a backend that was never installed, which rules out testing any application that shows an
+/// image it generated. Keeping the seam internal and reaching it through friend access was tried
+/// and does not work: <c>Polyfill</c> is source-only, so friend access makes every polyfilled call
+/// ambiguous between the two compiled copies.
+/// </remarks>
+public interface IRendererBackend : IDisposable
 {
 	/// <summary>
 	/// Uploads an RGBA8 pixel buffer to the GPU and returns an opaque, pointer-sized handle.

--- a/ImGui.App/ImGuiApp.cs
+++ b/ImGui.App/ImGuiApp.cs
@@ -746,7 +746,7 @@ public static partial class ImGuiApp
 	/// the headless test harness in ktsu.ImGui.App.Testing drives an application. Sharing this method
 	/// rather than reimplementing it is the point: a harness that reproduced the frame body would be
 	/// testing its own copy instead of the code that ships. Call
-	/// <see cref="BeginExternalFrameSession"/> first.
+	/// <see cref="BeginExternalFrameSession()"/> first.
 	/// </remarks>
 	/// <param name="config">The configuration supplying the render callbacks.</param>
 	/// <param name="delta">Seconds elapsed since the previous frame.</param>
@@ -785,9 +785,40 @@ public static partial class ImGuiApp
 	}
 
 	/// <summary>
-	/// Releases the state established by <see cref="BeginExternalFrameSession"/>.
+	/// Prepares the shared state a host needs before driving frames itself, and installs the
+	/// renderer that host draws with.
 	/// </summary>
-	public static void EndExternalFrameSession() => Invoker = null!;
+	/// <remarks>
+	/// The parameterless overload leaves no backend installed, which is correct for a host that
+	/// never uploads a texture but fatal for one that does: <see cref="CreateTexture"/>,
+	/// <see cref="UpdateTexture"/> and <see cref="DeleteTexture(nint)"/> all route through the
+	/// backend and throw without one. An application that shows an image it generated — rather than
+	/// one loaded from a file — reaches exactly that path, so a host that intends to render such an
+	/// application supplies its renderer here.
+	/// </remarks>
+	/// <param name="backend">The renderer this session's frames are drawn with.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="backend"/> is null.</exception>
+	/// <exception cref="InvalidOperationException">A session is already active.</exception>
+	public static void BeginExternalFrameSession(IRendererBackend backend)
+	{
+		Ensure.NotNull(backend);
+		BeginExternalFrameSession();
+		renderer = backend;
+	}
+
+	/// <summary>
+	/// Releases the state established by <see cref="BeginExternalFrameSession()"/>.
+	/// </summary>
+	/// <remarks>
+	/// The backend is released along with the invoker, but not disposed: the host supplied it and
+	/// owns its lifetime, and a session that disposed it would break a host that runs a second
+	/// session with the same renderer.
+	/// </remarks>
+	public static void EndExternalFrameSession()
+	{
+		Invoker = null!;
+		renderer = null;
+	}
 
 	internal static void ApplyFrameRateLimit()
 	{

--- a/docs/superpowers/specs/2026-08-19-headless-ui-test-harness-design.md
+++ b/docs/superpowers/specs/2026-08-19-headless-ui-test-harness-design.md
@@ -117,6 +117,13 @@ using ImGuiAppHarness harness = ImGuiAppHarness.Start(app.BuildConfig(), new Har
 });
 ```
 
+The harness also installs its rasterizer as the application host's renderer backend for the
+duration of the session. That is what lets an application upload its own textures through
+`ImGuiApp.CreateTexture` and have them reach the renderer actually drawing the frame. Without it,
+every such call fails on a backend that was never installed, which rules out testing any
+application that shows an image it generated rather than one loaded from a file — ImageGui's entire
+preview path, among others. The seam is `IRendererBackend`, made public for this reason.
+
 ### Determinism Controls
 
 `HarnessOptions` pins everything that would otherwise vary between runs:

--- a/tests/ImGui.App.Testing.Tests/RendererBackendTests.cs
+++ b/tests/ImGui.App.Testing.Tests/RendererBackendTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.ImGui.App.Testing.Tests;
+
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+using ktsu.ImGui.App;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Covers the harness installing its rasterizer as ImGuiApp's renderer backend.
+/// </summary>
+/// <remarks>
+/// An application that shows an image it generated uploads it through ImGuiApp rather than loading
+/// it from a file, and every one of those calls routes through the backend. A harness that leaves
+/// no backend installed cannot render such an application at all, so these tests guard the wiring
+/// rather than the rasterizer.
+/// </remarks>
+[TestClass]
+public sealed class RendererBackendTests
+{
+	private static HarnessOptions Window() => new() { Width = 200, Height = 120 };
+
+	/// <summary>Four opaque red pixels, tightly packed.</summary>
+	private static byte[] RedPixels(int width, int height)
+	{
+		byte[] rgba = new byte[width * height * 4];
+		for (int i = 0; i < rgba.Length; i += 4)
+		{
+			rgba[i] = 255;
+			rgba[i + 3] = 255;
+		}
+
+		return rgba;
+	}
+
+	[TestMethod]
+	public void CreateTexture_SucceedsWhileAHarnessIsRunning()
+	{
+		using ImGuiAppHarness harness = ImGuiAppHarness.Start(new ImGuiAppConfig(), Window());
+
+		ImGuiAppTextureInfo texture = ImGuiApp.CreateTexture(RedPixels(2, 2), 2, 2);
+
+		Assert.AreEqual(2, texture.Width);
+		Assert.AreEqual(2, texture.Height);
+		Assert.AreNotEqual(nint.Zero, texture.TextureId, "A texture with no handle cannot be drawn.");
+	}
+
+	[TestMethod]
+	public void UpdateTexture_ReusesTheHandleWhenTheSizeIsUnchanged()
+	{
+		using ImGuiAppHarness harness = ImGuiAppHarness.Start(new ImGuiAppConfig(), Window());
+		ImGuiAppTextureInfo texture = ImGuiApp.CreateTexture(RedPixels(2, 2), 2, 2);
+		nint original = texture.TextureId;
+
+		ImGuiApp.UpdateTexture(texture, RedPixels(2, 2), 2, 2);
+
+		Assert.AreEqual(original, texture.TextureId, "A same-size update should have been made in place.");
+	}
+
+	[TestMethod]
+	public void UpdateTexture_RecreatesTheTextureWhenTheSizeChanges()
+	{
+		using ImGuiAppHarness harness = ImGuiAppHarness.Start(new ImGuiAppConfig(), Window());
+		ImGuiAppTextureInfo texture = ImGuiApp.CreateTexture(RedPixels(2, 2), 2, 2);
+
+		ImGuiApp.UpdateTexture(texture, RedPixels(4, 3), 4, 3);
+
+		Assert.AreEqual(4, texture.Width);
+		Assert.AreEqual(3, texture.Height);
+	}
+
+	[TestMethod]
+	public void UploadedTexture_ReachesTheRasterizer()
+	{
+		ImGuiAppTextureInfo? texture = null;
+		using ImGuiAppHarness harness = ImGuiAppHarness.Start(
+			new ImGuiAppConfig
+			{
+				OnRender = _ =>
+				{
+					texture ??= ImGuiApp.CreateTexture(RedPixels(8, 8), 8, 8);
+
+					ImGui.SetNextWindowPos(Vector2.Zero);
+					ImGui.SetNextWindowSize(new Vector2(160, 100));
+					ImGui.Begin("image", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoSavedSettings);
+					ImGui.Image(texture.TextureRef, new Vector2(64, 64));
+					ImGui.End();
+				},
+			},
+			Window());
+
+		harness.Step(2);
+
+		// The rasterizer only has these pixels if the upload reached it, so counting them proves
+		// the whole path rather than just that the call returned a handle.
+		int red = harness.Capture().CountPixels(p => p.R > 200 && p.G < 80 && p.B < 80);
+		Assert.IsGreaterThan(1000, red, "The uploaded texture was not drawn, so the backend never received it.");
+	}
+
+	[TestMethod]
+	public void ASecondHarness_InstallsItsOwnBackend()
+	{
+		using (ImGuiAppHarness first = ImGuiAppHarness.Start(new ImGuiAppConfig(), Window()))
+		{
+			ImGuiApp.CreateTexture(RedPixels(2, 2), 2, 2);
+		}
+
+		// The session releases the backend rather than disposing it, and installs a fresh one next
+		// time. A harness that left the previous, disposed rasterizer in place would fail here, so
+		// this is what keeps a suite of many scenarios from poisoning itself after the first.
+		using ImGuiAppHarness second = ImGuiAppHarness.Start(new ImGuiAppConfig(), Window());
+		ImGuiAppTextureInfo texture = ImGuiApp.CreateTexture(RedPixels(2, 2), 2, 2);
+
+		Assert.AreNotEqual(nint.Zero, texture.TextureId);
+	}
+}


### PR DESCRIPTION
## Why

`ImGuiApp` routes every texture call — `CreateTexture`, `UpdateTexture`, `DeleteTexture` — through `IRendererBackend`, and `BeginExternalFrameSession` left that field null.

So `ktsu.ImGui.App.Testing` could render an application's widgets but not its images. Anything showing pixels it generated rather than loaded from a file failed with `InvalidOperationException: Renderer backend is not initialized.` That is ImageGui's entire preview path, so none of its user interface could be driven under the harness — found while writing the ImageGui scenarios this harness was built for.

## What

`SoftwareRenderer` already had the seam's four members with matching signatures and only stopped short of implementing it. Its own comment recorded why: the interface was internal, friend access was the only way to reach it, and friend access makes every polyfilled call in that assembly ambiguous between two compiled copies of the source-only `Polyfill` package.

That reasoning rested on "nothing inside `ktsu.ImGui.App` consumes this renderer" — which is what has changed, since `ImGuiApp`'s own texture API does.

- `IRendererBackend` is public, so the rasterizer implements it directly and no friend access is needed.
- `BeginExternalFrameSession(IRendererBackend)` installs the backend; the parameterless overload is unchanged.
- `EndExternalFrameSession` releases the backend without disposing it — the host owns its lifetime and may run a second session with the same renderer.
- The harness installs its rasterizer on `Start`, and releases the context if that fails.

## Verification

All suites run from their executables, zero failures:

| Suite | Total | Failed |
| --- | --- | --- |
| ImGui.App.Tests | 317 | 0 |
| ImGui.App.Testing.Tests | 78 | 0 |
| ImGui.Widgets.Tests | 233 | 0 |
| NodeGraph.Tests | 106 | 0 |
| ImGui.Markdown.Tests | 32 | 0 |
| ForceDirectedLayout.Tests | 20 | 0 |
| ImGui.Color.Tests | 20 | 0 |
| ImGui.Popups.Tests | 19 | 0 |
| ImGui.Probes.Tests | 10 | 0 |

Five new tests in `RendererBackendTests` cover the wiring rather than the rasterizer: create succeeds under a harness, same-size update reuses the handle, a size change recreates it, an uploaded texture actually reaches the rasterizer (counted in the captured frame), and a second harness installs a fresh backend after the first is disposed.

Solution builds with 0 warnings and 0 errors.