### PR TITLE
Add Histogram and HandleTrack widgets

### DIFF
--- a/ImGui.Widgets/HandleTrack.cs
+++ b/ImGui.Widgets/HandleTrack.cs
@@ -19,21 +19,25 @@ public static partial class ImGuiWidgets
 	/// Draws draggable handles over a rectangle the caller supplies, for example one just occupied
 	/// by a histogram plot. The handles stay ordered and at least <paramref name="minGap"/> apart.
 	/// </summary>
-	/// <param name="label">A unique label, used for the ImGui ID and the probe name.</param>
+	/// <param name="label">A unique label, used for the probe name.</param>
 	/// <param name="handles">The handle positions, updated in place. Kept sorted ascending.</param>
 	/// <param name="rectMin">The top-left of the rectangle to overlay.</param>
 	/// <param name="rectMax">The bottom-right of the rectangle to overlay.</param>
 	/// <param name="lowerBound">The value at the left edge.</param>
 	/// <param name="upperBound">The value at the right edge.</param>
-	/// <param name="minGap">The minimum distance kept between neighbouring handles.</param>
+	/// <param name="minGap">The minimum distance kept between neighboring handles.</param>
 	/// <param name="handleRadius">The grab radius in pixels. Non-positive derives it from the rectangle height.</param>
-	/// <param name="handleCenterY">The vertical centre of the handles. <see cref="float.NaN"/> uses the rectangle's centre.</param>
+	/// <param name="handleCenterY">The vertical center of the handles. <see cref="float.NaN"/> uses the rectangle's center.</param>
 	/// <returns><see langword="true"/> if a handle moved this frame; otherwise <see langword="false"/>.</returns>
 	/// <remarks>
 	/// The widget places an invisible button over the rectangle so activation and dragging work
 	/// through ImGui's normal item mechanics, then restores the cursor so the caller's layout is
 	/// undisturbed. It draws handles and nothing else — no track, no fill — because it is designed
-	/// to sit on top of content it does not own.
+	/// to sit on top of content it does not own, for example a <see cref="Histogram"/> already drawn
+	/// into the same rectangle. An empty <paramref name="handles"/> returns immediately, before the
+	/// invisible button is submitted and before the probe is marked, so a call with no handles
+	/// consumes no layout and registers no probe — the opposite policy to <see cref="Histogram"/>,
+	/// which always reserves layout and draws its frame.
 	/// </remarks>
 	public static bool HandleTrack(
 		string label,

--- a/ImGui.Widgets/HandleTrack.cs
+++ b/ImGui.Widgets/HandleTrack.cs
@@ -19,7 +19,7 @@ public static partial class ImGuiWidgets
 	/// Draws draggable handles over a rectangle the caller supplies, for example one just occupied
 	/// by a histogram plot. The handles stay ordered and at least <paramref name="minGap"/> apart.
 	/// </summary>
-	/// <param name="label">A unique label, used for the probe name.</param>
+	/// <param name="label">A unique label, used for the ImGui ID and the probe name.</param>
 	/// <param name="handles">The handle positions, updated in place. Kept sorted ascending.</param>
 	/// <param name="rectMin">The top-left of the rectangle to overlay.</param>
 	/// <param name="rectMax">The bottom-right of the rectangle to overlay.</param>

--- a/ImGui.Widgets/HandleTrack.cs
+++ b/ImGui.Widgets/HandleTrack.cs
@@ -1,0 +1,147 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+using ktsu.ImGui.Probes;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Draws draggable handles over a rectangle the caller supplies, for example one just occupied
+	/// by a histogram plot. The handles stay ordered and at least <paramref name="minGap"/> apart.
+	/// </summary>
+	/// <param name="label">A unique label, used for the ImGui ID and the probe name.</param>
+	/// <param name="handles">The handle positions, updated in place. Kept sorted ascending.</param>
+	/// <param name="rectMin">The top-left of the rectangle to overlay.</param>
+	/// <param name="rectMax">The bottom-right of the rectangle to overlay.</param>
+	/// <param name="lowerBound">The value at the left edge.</param>
+	/// <param name="upperBound">The value at the right edge.</param>
+	/// <param name="minGap">The minimum distance kept between neighbouring handles.</param>
+	/// <param name="handleRadius">The grab radius in pixels. Non-positive derives it from the rectangle height.</param>
+	/// <param name="handleCenterY">The vertical centre of the handles. <see cref="float.NaN"/> uses the rectangle's centre.</param>
+	/// <returns><see langword="true"/> if a handle moved this frame; otherwise <see langword="false"/>.</returns>
+	/// <remarks>
+	/// The widget places an invisible button over the rectangle so activation and dragging work
+	/// through ImGui's normal item mechanics, then restores the cursor so the caller's layout is
+	/// undisturbed. It draws handles and nothing else — no track, no fill — because it is designed
+	/// to sit on top of content it does not own.
+	/// </remarks>
+	public static bool HandleTrack(
+		string label,
+		Span<float> handles,
+		Vector2 rectMin,
+		Vector2 rectMax,
+		float lowerBound,
+		float upperBound,
+		float minGap = 0.0f,
+		float handleRadius = 0.0f,
+		float handleCenterY = float.NaN) =>
+		HandleTrackImpl.Draw(label, handles, rectMin, rectMax, lowerBound, upperBound, minGap, handleRadius, handleCenterY);
+
+	internal static class HandleTrackImpl
+	{
+		private static readonly Dictionary<uint, HandleTrackState> States = [];
+
+		public static bool Draw(
+			string label,
+			Span<float> handles,
+			Vector2 rectMin,
+			Vector2 rectMax,
+			float lowerBound,
+			float upperBound,
+			float minGap,
+			float handleRadius,
+			float handleCenterY)
+		{
+			if (handles.Length == 0)
+			{
+				return false;
+			}
+
+			if (lowerBound > upperBound)
+			{
+				(lowerBound, upperBound) = (upperBound, lowerBound);
+			}
+
+			float height = MathF.Max(rectMax.Y - rectMin.Y, 1.0f);
+			float radius = handleRadius > 0.0f ? handleRadius : height * 0.35f;
+			float centerY = float.IsNaN(handleCenterY) ? rectMin.Y + (height * 0.5f) : handleCenterY;
+
+			float trackMinX = rectMin.X + radius;
+			float trackMaxX = rectMax.X - radius;
+			float span = MathF.Max(trackMaxX - trackMinX, 1.0f);
+
+			HandleTrackState.Normalize(handles, lowerBound, upperBound, minGap);
+
+			// Overlay an item on the caller's rectangle, then put the cursor back where it was so
+			// this widget does not consume layout of its own.
+			Vector2 cursor = ImGui.GetCursorScreenPos();
+			ImGui.SetCursorScreenPos(rectMin);
+			ImGui.InvisibleButton(label, new Vector2(MathF.Max(rectMax.X - rectMin.X, 1.0f), height));
+			ImGuiProbes.MarkItem(label);
+			ImGui.SetCursorScreenPos(cursor);
+
+			uint id = ImGui.GetID(label);
+			if (!States.TryGetValue(id, out HandleTrackState? state))
+			{
+				state = new HandleTrackState();
+				States[id] = state;
+			}
+
+			float mouseValue = lowerBound
+				+ (Math.Clamp((ImGui.GetIO().MousePos.X - trackMinX) / span, 0.0f, 1.0f) * (upperBound - lowerBound));
+
+			if (ImGui.IsItemActivated())
+			{
+				state.Activate(handles, mouseValue);
+			}
+
+			bool changed = false;
+			if (ImGui.IsItemActive())
+			{
+				changed = state.Drag(handles, mouseValue, lowerBound, upperBound, minGap);
+			}
+			else
+			{
+				state.Release();
+			}
+
+			DrawHandles(handles, lowerBound, upperBound, trackMinX, span, centerY, radius);
+
+			return changed;
+		}
+
+		private static void DrawHandles(
+			ReadOnlySpan<float> handles,
+			float lowerBound,
+			float upperBound,
+			float trackMinX,
+			float span,
+			float centerY,
+			float radius)
+		{
+			ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+			Span<Vector4> colors = ImGui.GetStyle().Colors;
+			bool hovered = ImGui.IsItemHovered() || ImGui.IsItemActive();
+			uint grabColor = ImGui.GetColorU32(hovered ? colors[(int)ImGuiCol.SliderGrabActive] : colors[(int)ImGuiCol.SliderGrab]);
+
+			foreach (float handle in handles)
+			{
+				float x = trackMinX + (ValueToFraction(handle, lowerBound, upperBound) * span);
+				drawList.AddCircleFilled(new Vector2(x, centerY), radius, grabColor, 24);
+			}
+		}
+
+		private static float ValueToFraction(float value, float min, float max) =>
+			max <= min ? 0.0f : Math.Clamp((value - min) / (max - min), 0.0f, 1.0f);
+	}
+}

--- a/ImGui.Widgets/HandleTrackState.cs
+++ b/ImGui.Widgets/HandleTrackState.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// The interaction behind a set of draggable handles on a track: which one is being dragged,
+	/// where a drag moves it, and how the set stays ordered and separated.
+	/// </summary>
+	/// <remarks>
+	/// Deliberately free of ImGui. Callers convert a mouse position to a value on the track and
+	/// hand that in, which is what lets every rule here be tested without a graphics context —
+	/// the same split <see cref="ImageCanvasState"/> and the gesture types already use.
+	/// </remarks>
+	public sealed class HandleTrackState
+	{
+		/// <summary>
+		/// Clamps handles into the bounds, sorts them ascending, and opens each neighbouring pair
+		/// to at least <paramref name="minGap"/>.
+		/// </summary>
+		/// <remarks>
+		/// Run before interaction so the handles are in a valid state whatever the caller passed.
+		/// The gap pass walks upward and then back down, because pushing up alone would drive the
+		/// last handle past <paramref name="upperBound"/> when the gaps cannot all fit.
+		/// </remarks>
+		public static void Normalize(Span<float> handles, float lowerBound, float upperBound, float minGap)
+		{
+			if (lowerBound > upperBound)
+			{
+				(lowerBound, upperBound) = (upperBound, lowerBound);
+			}
+
+			minGap = Math.Clamp(minGap, 0f, upperBound - lowerBound);
+
+			for (int i = 0; i < handles.Length; i++)
+			{
+				handles[i] = Math.Clamp(handles[i], lowerBound, upperBound);
+			}
+
+			handles.Sort();
+
+			for (int i = 1; i < handles.Length; i++)
+			{
+				handles[i] = MathF.Max(handles[i], handles[i - 1] + minGap);
+			}
+
+			// The upward pass can overshoot the top when the gaps do not all fit; settle downward.
+			for (int i = handles.Length - 1; i >= 0; i--)
+			{
+				float ceiling = i == handles.Length - 1 ? upperBound : handles[i + 1] - minGap;
+				handles[i] = MathF.Min(handles[i], ceiling);
+			}
+		}
+	}
+}

--- a/ImGui.Widgets/HandleTrackState.cs
+++ b/ImGui.Widgets/HandleTrackState.cs
@@ -52,11 +52,29 @@ public static partial class ImGuiWidgets
 		/// <summary>Clears the active handle.</summary>
 		public void Release() => ActiveHandle = -1;
 
+		// Both public entry points take the same bounds and gap, and every defect this class has
+		// had so far came from the two disagreeing about what a degenerate argument means — an
+		// inverted pair, a negative gap, a gap too wide to fit. Deciding that once, here, is what
+		// stops them drifting apart again.
+		private static void NormalizeArguments(ref float lowerBound, ref float upperBound, ref float minGap, int handleCount)
+		{
+			if (lowerBound > upperBound)
+			{
+				(lowerBound, upperBound) = (upperBound, lowerBound);
+			}
+
+			minGap = Math.Clamp(minGap, 0f, handleCount > 1 ? (upperBound - lowerBound) / (handleCount - 1) : 0f);
+		}
+
 		/// <summary>Moves the active handle to <paramref name="value"/>, held inside its neighbours and the bounds.</summary>
 		/// <returns><see langword="true"/> if the handle moved; otherwise <see langword="false"/>.</returns>
 		/// <remarks>
 		/// A drag that resolves to where the handle already sits reports no change. Consumers turn
 		/// changes into undo entries, and a stationary mouse held down must not mint one per frame.
+		/// The handles are expected to already lie within the track, as <see cref="Normalize"/> leaves them.
+		/// A caller that skips <see cref="Normalize"/> and passes handles outside the bounds can still invert order,
+		/// because the track clamp outranks the order constraint. Degenerate arguments (inverted bounds, negative <paramref name="minGap"/>,
+		/// or <paramref name="minGap"/> too wide to fit) are normalized to match <see cref="Normalize"/>'s interpretation.
 		/// </remarks>
 		[SuppressMessage("Major Code Smell", "S1244:Do not check floating point inequality with exact values, use a range instead.", Justification = "Exact comparison is intentional: it detects whether the clamped value differs from the stored one at all, and a tolerance would suppress genuine small drags.")]
 		public bool Drag(Span<float> handles, float value, float lowerBound, float upperBound, float minGap)
@@ -66,10 +84,7 @@ public static partial class ImGuiWidgets
 				return false;
 			}
 
-			if (lowerBound > upperBound)
-			{
-				(lowerBound, upperBound) = (upperBound, lowerBound);
-			}
+			NormalizeArguments(ref lowerBound, ref upperBound, ref minGap, handles.Length);
 
 			bool hasLower = ActiveHandle > 0;
 			bool hasUpper = ActiveHandle < handles.Length - 1;
@@ -115,12 +130,7 @@ public static partial class ImGuiWidgets
 		/// </remarks>
 		public static void Normalize(Span<float> handles, float lowerBound, float upperBound, float minGap)
 		{
-			if (lowerBound > upperBound)
-			{
-				(lowerBound, upperBound) = (upperBound, lowerBound);
-			}
-
-			minGap = Math.Clamp(minGap, 0f, handles.Length > 1 ? (upperBound - lowerBound) / (handles.Length - 1) : 0f);
+			NormalizeArguments(ref lowerBound, ref upperBound, ref minGap, handles.Length);
 
 			for (int i = 0; i < handles.Length; i++)
 			{

--- a/ImGui.Widgets/HandleTrackState.cs
+++ b/ImGui.Widgets/HandleTrackState.cs
@@ -16,12 +16,17 @@ public static partial class ImGuiWidgets
 	/// </summary>
 	/// <remarks>
 	/// Deliberately free of ImGui. Callers convert a mouse position to a value on the track and
-	/// hand that in, which is what lets every rule here be tested without a graphics context —
-	/// the same split <see cref="ImageCanvasState"/> and the gesture types already use.
+	/// hand that in, which is what lets every rule here be tested without a graphics context.
 	/// </remarks>
-	public sealed class HandleTrackState
+	internal sealed class HandleTrackState
 	{
 		/// <summary>Gets the index of the handle being dragged, or -1 when none is.</summary>
+		/// <remarks>
+		/// The retained value is an array position, not a reference to any particular array.
+		/// Activating against one span and then dragging a different span of the same length
+		/// silently targets the same index in the new one — <see cref="Drag"/> only guards a
+		/// stale index when the new span is shorter.
+		/// </remarks>
 		public int ActiveHandle { get; private set; } = -1;
 
 		/// <summary>Selects the handle nearest <paramref name="value"/> as the one being dragged.</summary>
@@ -66,7 +71,7 @@ public static partial class ImGuiWidgets
 			minGap = Math.Clamp(minGap, 0f, handleCount > 1 ? (upperBound - lowerBound) / (handleCount - 1) : 0f);
 		}
 
-		/// <summary>Moves the active handle to <paramref name="value"/>, held inside its neighbours and the bounds.</summary>
+		/// <summary>Moves the active handle to <paramref name="value"/>, held inside its neighbors and the bounds.</summary>
 		/// <returns><see langword="true"/> if the handle moved; otherwise <see langword="false"/>.</returns>
 		/// <remarks>
 		/// A drag that resolves to where the handle already sits reports no change. Consumers turn
@@ -90,10 +95,9 @@ public static partial class ImGuiWidgets
 			bool hasUpper = ActiveHandle < handles.Length - 1;
 
 			// minGap separates handles from one another and never from the ends of the track, so it
-			// is added only on a side that has an actual neighbour — an edge handle must still be
+			// is added only on a side that has an actual neighbor — an edge handle must still be
 			// able to reach its own bound. Order and the track are inviolable; minGap is what yields
-			// when the neighbours are already closer together than it, which Normalize permits by
-			// narrowing an over-wide gap while Drag is handed the caller's original value.
+			// when the neighbors are already closer together than it.
 			float orderFloor = hasLower ? handles[ActiveHandle - 1] : lowerBound;
 			float orderCeiling = hasUpper ? handles[ActiveHandle + 1] : upperBound;
 
@@ -118,13 +122,15 @@ public static partial class ImGuiWidgets
 		}
 
 		/// <summary>
-		/// Clamps handles into the bounds, sorts them ascending, and opens each neighbouring pair
+		/// Clamps handles into the bounds, sorts them ascending, and opens each neighboring pair
 		/// to at least <paramref name="minGap"/>.
 		/// </summary>
 		/// <remarks>
 		/// Run before interaction so the handles are in a valid state whatever the caller passed.
 		/// The gap pass walks upward and then back down, because pushing up alone would drive the
-		/// last handle past <paramref name="upperBound"/> when the gaps cannot all fit.
+		/// last handle past <paramref name="upperBound"/> when the gaps cannot all fit. The downward
+		/// settle also re-clamps to <paramref name="lowerBound"/>, holding the track's lower edge as
+		/// well as its upper one.
 		/// If the requested <paramref name="minGap"/> is too wide to fit all handles, it is narrowed
 		/// so the handles spread evenly across the range — a sensible default for UI controls.
 		/// </remarks>
@@ -148,7 +154,7 @@ public static partial class ImGuiWidgets
 			for (int i = handles.Length - 1; i >= 0; i--)
 			{
 				float ceiling = i == handles.Length - 1 ? upperBound : handles[i + 1] - minGap;
-				handles[i] = MathF.Min(handles[i], ceiling);
+				handles[i] = MathF.Max(MathF.Min(handles[i], ceiling), lowerBound);
 			}
 		}
 	}

--- a/ImGui.Widgets/HandleTrackState.cs
+++ b/ImGui.Widgets/HandleTrackState.cs
@@ -66,16 +66,27 @@ public static partial class ImGuiWidgets
 				return false;
 			}
 
-			float low = ActiveHandle == 0 ? lowerBound : handles[ActiveHandle - 1];
-			float high = ActiveHandle == handles.Length - 1 ? upperBound : handles[ActiveHandle + 1];
+			if (lowerBound > upperBound)
+			{
+				(lowerBound, upperBound) = (upperBound, lowerBound);
+			}
 
-			// Order and the track bounds are inviolable; minGap is what yields when the neighbours
-			// are already closer together than it. They can be: Normalize narrows an over-wide gap
-			// to fit, but Drag is handed the caller's original value, so the two disagree by
-			// construction. Deriving the window from neighbour values and clamping both ends to the
-			// track is what keeps a squeezed handle from being pushed off the end of it.
-			float floor = Math.Clamp(MathF.Min(low + minGap, high), lowerBound, upperBound);
-			float ceiling = Math.Clamp(MathF.Max(high - minGap, low), lowerBound, upperBound);
+			bool hasLower = ActiveHandle > 0;
+			bool hasUpper = ActiveHandle < handles.Length - 1;
+
+			// minGap separates handles from one another and never from the ends of the track, so it
+			// is added only on a side that has an actual neighbour — an edge handle must still be
+			// able to reach its own bound. Order and the track are inviolable; minGap is what yields
+			// when the neighbours are already closer together than it, which Normalize permits by
+			// narrowing an over-wide gap while Drag is handed the caller's original value.
+			float orderFloor = hasLower ? handles[ActiveHandle - 1] : lowerBound;
+			float orderCeiling = hasUpper ? handles[ActiveHandle + 1] : upperBound;
+
+			float floor = hasLower ? MathF.Min(orderFloor + minGap, orderCeiling) : lowerBound;
+			float ceiling = hasUpper ? MathF.Max(orderCeiling - minGap, orderFloor) : upperBound;
+
+			floor = Math.Clamp(floor, lowerBound, upperBound);
+			ceiling = Math.Clamp(ceiling, lowerBound, upperBound);
 			if (ceiling < floor)
 			{
 				ceiling = floor;

--- a/ImGui.Widgets/HandleTrackState.cs
+++ b/ImGui.Widgets/HandleTrackState.cs
@@ -3,6 +3,7 @@
 namespace ktsu.ImGui.Widgets;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 /// <summary>
 /// Provides custom ImGui widgets.
@@ -20,6 +21,67 @@ public static partial class ImGuiWidgets
 	/// </remarks>
 	public sealed class HandleTrackState
 	{
+		/// <summary>Gets the index of the handle being dragged, or -1 when none is.</summary>
+		public int ActiveHandle { get; private set; } = -1;
+
+		/// <summary>Selects the handle nearest <paramref name="value"/> as the one being dragged.</summary>
+		/// <remarks>
+		/// Nearest by value rather than by pixel. The widget converts the mouse position to a value
+		/// before calling in, which keeps every rule here testable without a graphics context.
+		/// Ties resolve to the lower index so the midpoint between two handles behaves the same way
+		/// every time.
+		/// </remarks>
+		public void Activate(ReadOnlySpan<float> handles, float value)
+		{
+			int nearest = -1;
+			float bestDistance = float.MaxValue;
+
+			for (int i = 0; i < handles.Length; i++)
+			{
+				float distance = MathF.Abs(handles[i] - value);
+				if (distance < bestDistance)
+				{
+					bestDistance = distance;
+					nearest = i;
+				}
+			}
+
+			ActiveHandle = nearest;
+		}
+
+		/// <summary>Clears the active handle.</summary>
+		public void Release() => ActiveHandle = -1;
+
+		/// <summary>Moves the active handle to <paramref name="value"/>, held inside its neighbours and the bounds.</summary>
+		/// <returns><see langword="true"/> if the handle moved; otherwise <see langword="false"/>.</returns>
+		/// <remarks>
+		/// A drag that resolves to where the handle already sits reports no change. Consumers turn
+		/// changes into undo entries, and a stationary mouse held down must not mint one per frame.
+		/// </remarks>
+		[SuppressMessage("Major Code Smell", "S1244:Do not check floating point inequality with exact values, use a range instead.", Justification = "Exact comparison is intentional: it detects whether the clamped value differs from the stored one at all, and a tolerance would suppress genuine small drags.")]
+		public bool Drag(Span<float> handles, float value, float lowerBound, float upperBound, float minGap)
+		{
+			if (ActiveHandle < 0 || ActiveHandle >= handles.Length)
+			{
+				return false;
+			}
+
+			float floor = ActiveHandle == 0 ? lowerBound : handles[ActiveHandle - 1] + minGap;
+			float ceiling = ActiveHandle == handles.Length - 1 ? upperBound : handles[ActiveHandle + 1] - minGap;
+
+			// A gap wider than the space available would invert these; keep the window non-empty.
+			ceiling = MathF.Max(ceiling, floor);
+
+			float clamped = Math.Clamp(value, floor, ceiling);
+			if (clamped == handles[ActiveHandle])
+			{
+				return false;
+			}
+
+			handles[ActiveHandle] = clamped;
+			return true;
+		}
+
 		/// <summary>
 		/// Clamps handles into the bounds, sorts them ascending, and opens each neighbouring pair
 		/// to at least <paramref name="minGap"/>.

--- a/ImGui.Widgets/HandleTrackState.cs
+++ b/ImGui.Widgets/HandleTrackState.cs
@@ -28,6 +28,8 @@ public static partial class ImGuiWidgets
 		/// Run before interaction so the handles are in a valid state whatever the caller passed.
 		/// The gap pass walks upward and then back down, because pushing up alone would drive the
 		/// last handle past <paramref name="upperBound"/> when the gaps cannot all fit.
+		/// If the requested <paramref name="minGap"/> is too wide to fit all handles, it is narrowed
+		/// so the handles spread evenly across the range — a sensible default for UI controls.
 		/// </remarks>
 		public static void Normalize(Span<float> handles, float lowerBound, float upperBound, float minGap)
 		{
@@ -36,7 +38,7 @@ public static partial class ImGuiWidgets
 				(lowerBound, upperBound) = (upperBound, lowerBound);
 			}
 
-			minGap = Math.Clamp(minGap, 0f, upperBound - lowerBound);
+			minGap = Math.Clamp(minGap, 0f, handles.Length > 1 ? (upperBound - lowerBound) / (handles.Length - 1) : 0f);
 
 			for (int i = 0; i < handles.Length; i++)
 			{

--- a/ImGui.Widgets/HandleTrackState.cs
+++ b/ImGui.Widgets/HandleTrackState.cs
@@ -66,11 +66,20 @@ public static partial class ImGuiWidgets
 				return false;
 			}
 
-			float floor = ActiveHandle == 0 ? lowerBound : handles[ActiveHandle - 1] + minGap;
-			float ceiling = ActiveHandle == handles.Length - 1 ? upperBound : handles[ActiveHandle + 1] - minGap;
+			float low = ActiveHandle == 0 ? lowerBound : handles[ActiveHandle - 1];
+			float high = ActiveHandle == handles.Length - 1 ? upperBound : handles[ActiveHandle + 1];
 
-			// A gap wider than the space available would invert these; keep the window non-empty.
-			ceiling = MathF.Max(ceiling, floor);
+			// Order and the track bounds are inviolable; minGap is what yields when the neighbours
+			// are already closer together than it. They can be: Normalize narrows an over-wide gap
+			// to fit, but Drag is handed the caller's original value, so the two disagree by
+			// construction. Deriving the window from neighbour values and clamping both ends to the
+			// track is what keeps a squeezed handle from being pushed off the end of it.
+			float floor = Math.Clamp(MathF.Min(low + minGap, high), lowerBound, upperBound);
+			float ceiling = Math.Clamp(MathF.Max(high - minGap, low), lowerBound, upperBound);
+			if (ceiling < floor)
+			{
+				ceiling = floor;
+			}
 
 			float clamped = Math.Clamp(value, floor, ceiling);
 			if (clamped == handles[ActiveHandle])

--- a/ImGui.Widgets/Histogram.cs
+++ b/ImGui.Widgets/Histogram.cs
@@ -17,7 +17,7 @@ public static partial class ImGuiWidgets
 	/// <summary>
 	/// Draws one or more binned distributions as overlaid bars.
 	/// </summary>
-	/// <param name="label">A unique label, used for the ImGui ID and the probe name.</param>
+	/// <param name="label">A unique label, used for the probe name.</param>
 	/// <param name="bins">
 	/// Bin values, laid out as <paramref name="seriesCount"/> contiguous runs of equal length. A
 	/// trailing partial run (when <c>bins.Length</c> is not an exact multiple of

--- a/ImGui.Widgets/Histogram.cs
+++ b/ImGui.Widgets/Histogram.cs
@@ -30,7 +30,8 @@ public static partial class ImGuiWidgets
 	/// <param name="size">The box to draw into. Non-positive components fall back to sensible defaults.</param>
 	/// <param name="seriesColors">
 	/// One color per series. Entries missing for a series fall back to red, green and blue, then the
-	/// theme's plot color; entries beyond <paramref name="seriesCount"/> are ignored.
+	/// theme's plot color; entries beyond <paramref name="seriesCount"/> are ignored. A single-series
+	/// histogram with no entry skips the red fallback and goes straight to the theme's plot color.
 	/// </param>
 	/// <remarks>
 	/// Takes bins rather than the data they came from, which is what keeps it usable for any

--- a/ImGui.Widgets/Histogram.cs
+++ b/ImGui.Widgets/Histogram.cs
@@ -35,7 +35,9 @@ public static partial class ImGuiWidgets
 	/// <remarks>
 	/// Takes bins rather than the data they came from, which is what keeps it usable for any
 	/// distribution and keeps a full scan of the source off the render thread. Bars are scaled
-	/// against the largest finite, positive bin across every series, so the tallest bar always fills
+	/// against the largest finite, positive bin across every series that is actually drawn — a
+	/// trailing partial run dropped because <c>bins.Length</c> is not an exact multiple of
+	/// <paramref name="seriesCount"/> never competes for the peak, so the tallest bar always fills
 	/// the box and callers do not have to decide what full scale means. Negative, zero,
 	/// <see cref="float.NaN"/> and infinite bins are treated as empty and draw nothing for that bar;
 	/// they are also excluded when finding the peak, so one bad value cannot flatten every other bar
@@ -79,12 +81,18 @@ public static partial class ImGuiWidgets
 				return;
 			}
 
+			// Scope the peak search to the range that is actually drawn. bins.Length may not be an
+			// exact multiple of seriesCount, in which case a trailing partial run belongs to no
+			// series and is never drawn below (see the per-series Slice) — letting it compete for
+			// peak would scale every real bar against data that never appears on screen.
+			ReadOnlySpan<float> drawn = bins[..(seriesCount * binCount)];
+
 			// Only finite, positive bins can define the scale. A NaN or infinite bin is excluded here
 			// rather than allowed to win the max: MathF.Max would otherwise propagate NaN (or an
 			// infinite peak would flatten every other bar to zero height), turning one bad sample into
 			// a frame with no readable bars at all.
 			float peak = 0.0f;
-			foreach (float bin in bins)
+			foreach (float bin in drawn)
 			{
 				if (float.IsFinite(bin) && bin > peak)
 				{

--- a/ImGui.Widgets/Histogram.cs
+++ b/ImGui.Widgets/Histogram.cs
@@ -1,0 +1,146 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.ImGui.Widgets;
+
+using System;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+using ktsu.ImGui.Probes;
+
+/// <summary>
+/// Provides custom ImGui widgets.
+/// </summary>
+public static partial class ImGuiWidgets
+{
+	/// <summary>
+	/// Draws one or more binned distributions as overlaid bars.
+	/// </summary>
+	/// <param name="label">A unique label, used for the ImGui ID and the probe name.</param>
+	/// <param name="bins">
+	/// Bin values, laid out as <paramref name="seriesCount"/> contiguous runs of equal length. A
+	/// trailing partial run (when <c>bins.Length</c> is not an exact multiple of
+	/// <paramref name="seriesCount"/>) is dropped.
+	/// </param>
+	/// <param name="seriesCount">
+	/// How many series <paramref name="bins"/> holds. Values less than or equal to zero draw only
+	/// the empty frame.
+	/// </param>
+	/// <param name="size">The box to draw into. Non-positive components fall back to sensible defaults.</param>
+	/// <param name="seriesColors">
+	/// One color per series. Entries missing for a series fall back to red, green and blue, then the
+	/// theme's plot color; entries beyond <paramref name="seriesCount"/> are ignored.
+	/// </param>
+	/// <remarks>
+	/// Takes bins rather than the data they came from, which is what keeps it usable for any
+	/// distribution and keeps a full scan of the source off the render thread. Bars are scaled
+	/// against the largest finite, positive bin across every series, so the tallest bar always fills
+	/// the box and callers do not have to decide what full scale means. Negative, zero,
+	/// <see cref="float.NaN"/> and infinite bins are treated as empty and draw nothing for that bar;
+	/// they are also excluded when finding the peak, so one bad value cannot flatten every other bar
+	/// or poison the scale with <see cref="float.NaN"/>. Degenerate input (an empty or short
+	/// <paramref name="bins"/>, a non-positive <paramref name="seriesCount"/>, or a distribution with
+	/// no positive finite bin) still reserves layout and draws the empty frame rather than nothing.
+	/// </remarks>
+	public static void Histogram(string label, ReadOnlySpan<float> bins, int seriesCount, Vector2 size, ReadOnlySpan<uint> seriesColors = default) =>
+		HistogramImpl.Draw(label, bins, seriesCount, size, seriesColors);
+
+	internal static class HistogramImpl
+	{
+		public static void Draw(string label, ReadOnlySpan<float> bins, int seriesCount, Vector2 size, ReadOnlySpan<uint> seriesColors)
+		{
+			float lineHeight = ImGui.GetTextLineHeight();
+			Vector2 boxSize = new(
+				size.X > 0 ? size.X : ImGui.CalcItemWidth(),
+				size.Y > 0 ? size.Y : lineHeight * 6.0f);
+
+			Vector2 origin = ImGui.GetCursorScreenPos();
+			ImGui.Dummy(boxSize);
+			ImGuiProbes.MarkItem(label);
+
+			ImDrawListPtr drawList = ImGui.GetWindowDrawList();
+			Span<Vector4> colors = ImGui.GetStyle().Colors;
+			Vector2 min = origin;
+			Vector2 max = new(origin.X + boxSize.X, origin.Y + boxSize.Y);
+
+			// Background is drawn unconditionally so a degenerate call still reserves layout and
+			// leaves a sane, visible frame instead of drawing nothing at all.
+			drawList.AddRectFilled(min, max, ImGui.GetColorU32(colors[(int)ImGuiCol.FrameBg]));
+
+			if (seriesCount <= 0)
+			{
+				return;
+			}
+
+			int binCount = bins.Length / seriesCount;
+			if (binCount <= 0)
+			{
+				return;
+			}
+
+			// Only finite, positive bins can define the scale. A NaN or infinite bin is excluded here
+			// rather than allowed to win the max: MathF.Max would otherwise propagate NaN (or an
+			// infinite peak would flatten every other bar to zero height), turning one bad sample into
+			// a frame with no readable bars at all.
+			float peak = 0.0f;
+			foreach (float bin in bins)
+			{
+				if (float.IsFinite(bin) && bin > peak)
+				{
+					peak = bin;
+				}
+			}
+
+			if (peak <= 0.0f)
+			{
+				return;
+			}
+
+			float barWidth = boxSize.X / binCount;
+
+			for (int series = 0; series < seriesCount; series++)
+			{
+				uint color = SeriesColor(series, seriesCount, seriesColors, colors);
+				ReadOnlySpan<float> run = bins.Slice(series * binCount, binCount);
+
+				for (int bin = 0; bin < binCount; bin++)
+				{
+					float value = run[bin];
+					if (!float.IsFinite(value) || value <= 0.0f)
+					{
+						continue;
+					}
+
+					float fraction = MathF.Min(value / peak, 1.0f);
+					float x = min.X + (bin * barWidth);
+					float top = max.Y - (fraction * boxSize.Y);
+					drawList.AddRectFilled(new Vector2(x, top), new Vector2(x + barWidth, max.Y), color);
+				}
+			}
+		}
+
+		// Additive-looking overlays without a blend mode: the default channel colors are given a low
+		// alpha so overlapping series read as a lighter mix rather than the last one drawn.
+		private static uint SeriesColor(int series, int seriesCount, ReadOnlySpan<uint> seriesColors, ReadOnlySpan<Vector4> styleColors)
+		{
+			if (series < seriesColors.Length)
+			{
+				return seriesColors[series];
+			}
+
+			if (seriesCount == 1)
+			{
+				return ImGui.GetColorU32(styleColors[(int)ImGuiCol.PlotHistogram]);
+			}
+
+			return series switch
+			{
+				0 => ImGui.GetColorU32(new Vector4(1.0f, 0.25f, 0.25f, 0.6f)),
+				1 => ImGui.GetColorU32(new Vector4(0.25f, 1.0f, 0.25f, 0.6f)),
+				2 => ImGui.GetColorU32(new Vector4(0.35f, 0.5f, 1.0f, 0.6f)),
+				_ => ImGui.GetColorU32(styleColors[(int)ImGuiCol.PlotHistogram]),
+			};
+		}
+	}
+}

--- a/ImGui.Widgets/README.md
+++ b/ImGui.Widgets/README.md
@@ -18,7 +18,7 @@ ImGuiWidgets is a library of custom widgets using ImGui.NET. This library provid
 - **Scoped Id**: A utility class for creating scoped IDs
 - **Scoped Disable**: Temporarily disable UI elements within a scope
 - **SearchBox**: A powerful search box with support for various filter types (Glob, Regex, Fuzzy) and matching options
-- **Histogram**: Draws one or more binned distributions as overlaid bars, scaled to the tallest bin, keeping rendering off the main thread by accepting pre-computed bins
+- **Histogram**: Draws one or more binned distributions as overlaid bars, scaled to the tallest bin, keeping the binning scan off the render thread by accepting pre-computed bins
 - **HandleTrack**: Draggable handles over a rectangle you supply, kept sorted and a minimum distance apart, drawing handles only for overlay on content you own
 - **Hexa-backed widgets**: Thin adapters over [`Hexa.NET.ImGui.Widgets`](https://github.com/HexaEngine/Hexa.NET.ImGui.Widgets) — spinners, buffering bars, splitters, toggle/transparent/inline buttons, an icon tree node, an enum combo, text/image alignment helpers, tooltips, breadcrumbs, a date/year picker, a flame graph, a file tree view, stateful file/rename/message dialogs, and a docked-window base class. See [Hexa-backed Widgets](#hexa-backed-widgets) below.
 - **Callback-driven editors**: `Sequencer` (an editable clip timeline), `CurveEditor` (a multi-curve graph, or a single `CurveData` curve), and `BezierEditor` (a cubic easing curve) — driven by a `SequenceSource`/`CurveSource` you subclass, or by a `CurveData`/`BezierControlPoints` value. See [Callback-driven Editors](#callback-driven-editors) below.

--- a/ImGui.Widgets/README.md
+++ b/ImGui.Widgets/README.md
@@ -18,6 +18,8 @@ ImGuiWidgets is a library of custom widgets using ImGui.NET. This library provid
 - **Scoped Id**: A utility class for creating scoped IDs
 - **Scoped Disable**: Temporarily disable UI elements within a scope
 - **SearchBox**: A powerful search box with support for various filter types (Glob, Regex, Fuzzy) and matching options
+- **Histogram**: Draws one or more binned distributions as overlaid bars, scaled to the tallest bin, keeping rendering off the main thread by accepting pre-computed bins
+- **HandleTrack**: Draggable handles over a rectangle you supply, kept sorted and a minimum distance apart, drawing handles only for overlay on content you own
 - **Hexa-backed widgets**: Thin adapters over [`Hexa.NET.ImGui.Widgets`](https://github.com/HexaEngine/Hexa.NET.ImGui.Widgets) — spinners, buffering bars, splitters, toggle/transparent/inline buttons, an icon tree node, an enum combo, text/image alignment helpers, tooltips, breadcrumbs, a date/year picker, a flame graph, a file tree view, stateful file/rename/message dialogs, and a docked-window base class. See [Hexa-backed Widgets](#hexa-backed-widgets) below.
 - **Callback-driven editors**: `Sequencer` (an editable clip timeline), `CurveEditor` (a multi-curve graph, or a single `CurveData` curve), and `BezierEditor` (a cubic easing curve) — driven by a `SequenceSource`/`CurveSource` you subclass, or by a `CurveData`/`BezierControlPoints` value. See [Callback-driven Editors](#callback-driven-editors) below.
 

--- a/ImGui.Widgets/RangeSlider.cs
+++ b/ImGui.Widgets/RangeSlider.cs
@@ -47,8 +47,6 @@ public static partial class ImGuiWidgets
 				(min, max) = (max, min);
 			}
 
-			minGap = Math.Clamp(minGap, 0.0f, max - min);
-
 			uint id = ImGui.GetID(label);
 			float height = ImGui.GetFrameHeight();
 			float width = MathF.Max(ImGui.CalcItemWidth(), height * 3.0f);

--- a/ImGui.Widgets/RangeSlider.cs
+++ b/ImGui.Widgets/RangeSlider.cs
@@ -22,6 +22,10 @@ public static partial class ImGuiWidgets
 	/// span within <paramref name="min"/>..<paramref name="max"/>. The handles cannot cross and are
 	/// kept at least <paramref name="minGap"/> apart.
 	/// </summary>
+	/// <remarks>
+	/// If <paramref name="lower"/> and <paramref name="upper"/> arrive inverted, they are sorted rather than
+	/// collapsed, so a caller that passes them the wrong way round gets both values preserved.
+	/// </remarks>
 	/// <param name="label">A unique label; text after <c>##</c> is hidden but used for the ID. Visible text is drawn to the right.</param>
 	/// <param name="lower">The lower bound of the selected range. Updated in place.</param>
 	/// <param name="upper">The upper bound of the selected range. Updated in place.</param>

--- a/ImGui.Widgets/RangeSlider.cs
+++ b/ImGui.Widgets/RangeSlider.cs
@@ -34,10 +34,8 @@ public static partial class ImGuiWidgets
 
 	internal static class RangeSliderImpl
 	{
-		// Per-ID active handle: 0 = lower, 1 = upper, -1 = none.
-		private static readonly Dictionary<uint, int> ActiveHandle = [];
+		private static readonly Dictionary<uint, HandleTrackState> States = [];
 
-		[SuppressMessage("Major Code Smell", "S1244:Do not check floating point inequality with exact values, use a range instead.", Justification = "Exact comparison is intentional here (sentinel/identity check); a tolerance would change behavior.")]
 		public static bool Draw(string label, ref float lower, ref float upper, float min, float max, float minGap)
 		{
 			if (min > max)
@@ -61,69 +59,36 @@ public static partial class ImGuiWidgets
 			float trackY = origin.Y + (height * 0.5f);
 			float span = MathF.Max(trackMaxX - trackMinX, 1.0f);
 
-			// Clamp inputs to a valid, non-crossing, gap-respecting state before interaction.
-			lower = Math.Clamp(lower, min, max);
-			upper = Math.Clamp(upper, min, max);
-			if (upper - lower < minGap)
+			Span<float> handles = [lower, upper];
+			HandleTrackState.Normalize(handles, min, max, minGap);
+
+			if (!States.TryGetValue(id, out HandleTrackState? state))
 			{
-				upper = MathF.Min(max, lower + minGap);
-				lower = MathF.Min(lower, upper - minGap);
+				state = new HandleTrackState();
+				States[id] = state;
 			}
 
-			HandleActivation(id, lower, upper, min, max, trackMinX, span);
-			bool changed = HandleDrag(id, ref lower, ref upper, min, max, minGap, trackMinX, span);
-			DrawSlider(label, lower, upper, min, max, trackMinX, trackMaxX, trackY, span, grabRadius, height);
+			float mouseValue = min + (Math.Clamp((ImGui.GetIO().MousePos.X - trackMinX) / span, 0.0f, 1.0f) * (max - min));
 
-			return changed;
-		}
-
-		private static void HandleActivation(uint id, float lower, float upper, float min, float max, float trackMinX, float span)
-		{
-			if (!ImGui.IsItemActivated())
+			if (ImGui.IsItemActivated())
 			{
-				return;
+				state.Activate(handles, mouseValue);
 			}
-
-			// Grab whichever handle is nearer the click.
-			float mouseX = ImGui.GetIO().MousePos.X;
-			float lowerX = trackMinX + (ValueToFraction(lower, min, max) * span);
-			float upperX = trackMinX + (ValueToFraction(upper, min, max) * span);
-			ActiveHandle[id] = MathF.Abs(mouseX - lowerX) <= MathF.Abs(mouseX - upperX) ? 0 : 1;
-		}
-
-		[SuppressMessage("Major Code Smell", "S1244:Do not check floating point inequality with exact values, use a range instead.", Justification = "Exact comparison is intentional here (detecting whether the clamped value actually changed); a tolerance would change behavior.")]
-		[SuppressMessage("Major Code Smell", "S107:Methods should not have too many parameters", Justification = "Private interaction helper extracted from Draw to reduce cognitive complexity; the parameters thread the slider geometry computed once by the caller and bundling them would not improve readability.")]
-		private static bool HandleDrag(uint id, ref float lower, ref float upper, float min, float max, float minGap, float trackMinX, float span)
-		{
-			if (!ImGui.IsItemActive())
-			{
-				ActiveHandle.Remove(id);
-				return false;
-			}
-
-			int handle = ActiveHandle.GetValueOrDefault(id, -1);
-			float t = Math.Clamp((ImGui.GetIO().MousePos.X - trackMinX) / span, 0.0f, 1.0f);
-			float newValue = min + (t * (max - min));
 
 			bool changed = false;
-			if (handle == 0)
+			if (ImGui.IsItemActive())
 			{
-				float clamped = Math.Clamp(newValue, min, upper - minGap);
-				if (clamped != lower)
-				{
-					lower = clamped;
-					changed = true;
-				}
+				changed = state.Drag(handles, mouseValue, min, max, minGap);
 			}
-			else if (handle == 1)
+			else
 			{
-				float clamped = Math.Clamp(newValue, lower + minGap, max);
-				if (clamped != upper)
-				{
-					upper = clamped;
-					changed = true;
-				}
+				state.Release();
 			}
+
+			lower = handles[0];
+			upper = handles[1];
+
+			DrawSlider(label, lower, upper, min, max, trackMinX, trackMaxX, trackY, span, grabRadius, height);
 
 			return changed;
 		}

--- a/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
+++ b/examples/ImGuiWidgetsDemo/ImGuiWidgetsDemo.cs
@@ -90,6 +90,27 @@ internal static class ImGuiWidgetsDemo
 	private static string otpValue = string.Empty;
 	private static bool skeletonLoading = true;
 
+	// Histogram / HandleTrack demo state
+	private static readonly float[] histogramBins = BuildHistogramBins();
+	private static readonly float[] handleTrackHandles = [0.15f, 0.5f, 0.85f];
+
+	private static float[] BuildHistogramBins()
+	{
+		// Three offset bell curves, so the overlay and the per-series colors are both visible.
+		float[] bins = new float[3 * 256];
+		for (int series = 0; series < 3; series++)
+		{
+			float center = 96.0f + (series * 32.0f);
+			for (int bin = 0; bin < 256; bin++)
+			{
+				float d = (bin - center) / 40.0f;
+				bins[(series * 256) + bin] = MathF.Exp(-d * d);
+			}
+		}
+
+		return bins;
+	}
+
 	// The DividerContainer is no longer this demo's top-level layout -- the main window is a tab bar
 	// now -- so the widget keeps a live instance of its own, drawn inside its demo section.
 	private static ImGuiWidgets.DividerContainer DividerDemoContainer { get; } = new("DividerDemoContainer");
@@ -267,6 +288,7 @@ internal static class ImGuiWidgetsDemo
 		ShowTreeDemo();
 		ShowMobileDecoratorsDemo();
 		ShowMobileContainersDemo();
+		ShowHistogramAndHandleTrackDemo();
 	}
 
 	private static void ShowAdvancedDemos()
@@ -956,6 +978,39 @@ internal static class ImGuiWidgetsDemo
 			{
 				ImGui.TextUnformatted("Content loaded.");
 			}
+		}
+	}
+
+	private static void ShowHistogramAndHandleTrackDemo()
+	{
+		if (ImGui.CollapsingHeader("Histogram & Handle Track"))
+		{
+			ImGui.TextUnformatted("Three overlaid series, with a HandleTrack overlaying the exact rectangle Histogram just drew into:");
+			ImGui.Separator();
+
+			ImGuiWidgets.Histogram("##demoHistogram", histogramBins, 3, new Vector2(420.0f, 160.0f));
+
+			// The handoff that makes the two widgets compose: read the rectangle Histogram just
+			// occupied straight back off the item stack and hand it to HandleTrack unchanged.
+			Vector2 histogramMin = ImGui.GetItemRectMin();
+			Vector2 histogramMax = ImGui.GetItemRectMax();
+
+			// The box above is tall, so the default grab radius (derived from rectangle height)
+			// would be oversized; pass an explicit radius and center the handles on the bottom edge.
+			ImGuiWidgets.HandleTrack(
+				"##demoHandleTrack",
+				handleTrackHandles,
+				histogramMin,
+				histogramMax,
+				0.0f,
+				1.0f,
+				minGap: 0.02f,
+				handleRadius: 6.0f,
+				handleCenterY: histogramMax.Y);
+
+			ImGui.Separator();
+			ImGui.TextUnformatted("Drag a handle -- they stay ordered and at least 0.02 apart:");
+			ImGui.TextUnformatted($"Handles: {handleTrackHandles[0]:0.00}  {handleTrackHandles[1]:0.00}  {handleTrackHandles[2]:0.00}");
 		}
 	}
 

--- a/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
+++ b/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
@@ -298,4 +298,49 @@ public class HandleTrackStateTests
 		Assert.IsTrue(handles[0] <= handles[1] && handles[1] <= handles[2], "Handles must remain ascending after drag with negative minGap.");
 		Assert.IsTrue(handles[0] >= 0f && handles[2] <= 1f, "Handles must remain on track.");
 	}
+
+	// RangeSlider has never had tests. These describe the two-handle behaviour read out of its
+	// source before it was moved onto HandleTrackState, and stand in for the regression suite it
+	// never had. If one of these has to change, RangeSlider's behaviour changed with it.
+
+	[TestMethod]
+	public void TwoHandles_LowerCannotCrossUpper()
+	{
+		float[] handles = [0.2f, 0.6f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.2f);
+
+		state.Drag(handles, 0.95f, 0f, 1f, 0f);
+
+		Assert.AreEqual(0.6f, handles[0], 1e-6f, "The lower handle crossed the upper one.");
+		Assert.AreEqual(0.6f, handles[1], 1e-6f, "The upper handle moved.");
+	}
+
+	[TestMethod]
+	public void TwoHandles_UpperCannotCrossLower()
+	{
+		float[] handles = [0.4f, 0.8f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.8f);
+
+		state.Drag(handles, 0.05f, 0f, 1f, 0f);
+
+		Assert.AreEqual(0.4f, handles[0], 1e-6f, "The lower handle moved.");
+		Assert.AreEqual(0.4f, handles[1], 1e-6f, "The upper handle crossed the lower one.");
+	}
+
+	[TestMethod]
+	public void TwoHandles_MinGapIsHeldOnBothSides()
+	{
+		float[] handles = [0.4f, 0.6f];
+		ImGuiWidgets.HandleTrackState state = new();
+
+		state.Activate(handles, 0.4f);
+		state.Drag(handles, 0.9f, 0f, 1f, 0.2f);
+		Assert.AreEqual(0.4f, handles[0], 1e-6f, "The lower handle came closer than minGap.");
+
+		state.Activate(handles, 0.6f);
+		state.Drag(handles, 0.1f, 0f, 1f, 0.2f);
+		Assert.AreEqual(0.6f, handles[1], 1e-6f, "The upper handle came closer than minGap.");
+	}
 }

--- a/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
+++ b/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
@@ -268,4 +268,34 @@ public class HandleTrackStateTests
 
 		Assert.AreEqual(0.7f, handles[0], 1e-6f, "Handle should remain in the (swapped) bounds.");
 	}
+
+	[TestMethod]
+	public void Drag_HandlesNegativeMinGapByClampingToZero()
+	{
+		// A negative minGap is invalid and inverts handle order. Drag must clamp it to zero,
+		// matching Normalize. This protects against negative minGap being treated as licence to overlap.
+		float[] handles = [0.1f, 0.5f, 0.9f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.5f);
+
+		state.Drag(handles, 0f, 0f, 1f, -0.2f);
+
+		Assert.IsTrue(handles[0] <= handles[1] && handles[1] <= handles[2], "Handles must remain ascending after drag with negative minGap.");
+		Assert.IsTrue(handles[0] >= 0f && handles[2] <= 1f, "Handles must remain on track.");
+	}
+
+	[TestMethod]
+	public void Drag_KeepsHandlesAscendingWhenNegativeMinGapDragsToUpperBound()
+	{
+		// A negative minGap should not invert order even when dragging toward the upper bound.
+		// Verify ascending order is maintained.
+		float[] handles = [0.1f, 0.5f, 0.9f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.5f);
+
+		state.Drag(handles, 1f, 0f, 1f, -0.2f);
+
+		Assert.IsTrue(handles[0] <= handles[1] && handles[1] <= handles[2], "Handles must remain ascending after drag with negative minGap.");
+		Assert.IsTrue(handles[0] >= 0f && handles[2] <= 1f, "Handles must remain on track.");
+	}
 }

--- a/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
+++ b/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
@@ -220,4 +220,52 @@ public class HandleTrackStateTests
 		Assert.IsTrue(handles[0] >= 0f, "First handle pushed below lowerBound.");
 		Assert.IsTrue(handles[2] <= 1f, "Last handle pushed above upperBound.");
 	}
+
+	[TestMethod]
+	public void Drag_AllowsEdgeHandleToReachItsTrackBoundWithNonzeroMinGap()
+	{
+		// minGap separates handles from each other, not from the track ends. An edge handle
+		// with a nonzero minGap must still be able to reach its own bound. This protects against
+		// regression 1: minGap being incorrectly applied to bounds.
+		float[] handles = [0.1f, 0.5f, 0.9f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.1f);
+
+		state.Drag(handles, -5f, 0f, 1f, 0.05f);
+
+		Assert.AreEqual(0f, handles[0], 1e-6f, "Edge handle should reach its track bound.");
+	}
+
+	[TestMethod]
+	public void Drag_AllowsSingleHandleToReachBothBoundsWithNonzeroMinGap()
+	{
+		// A single handle has no neighbours, so minGap never applies. With or without minGap,
+		// it should still reach both bounds. This protects against regression 1.
+		float[] handles = [0.5f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.5f);
+
+		state.Drag(handles, -5f, 0f, 1f, 0.2f);
+
+		Assert.AreEqual(0f, handles[0], 1e-6f, "Single handle should reach lowerBound.");
+
+		state.Drag(handles, 5f, 0f, 1f, 0.2f);
+
+		Assert.AreEqual(1f, handles[0], 1e-6f, "Single handle should reach upperBound.");
+	}
+
+	[TestMethod]
+	public void Drag_AcceptsInvertedBoundsWithoutThrowing()
+	{
+		// Drag must handle inverted bounds the same way Normalize does: swap them. It must not
+		// throw ArgumentException. This protects against regression 2.
+		float[] handles = [0.7f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.7f);
+
+		// Should not throw, and should clamp to the (swapped) bounds [0, 1]
+		state.Drag(handles, 0.7f, 1f, 0f, 0f);
+
+		Assert.AreEqual(0.7f, handles[0], 1e-6f, "Handle should remain in the (swapped) bounds.");
+	}
 }

--- a/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
+++ b/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
@@ -273,7 +273,7 @@ public class HandleTrackStateTests
 	public void Drag_HandlesNegativeMinGapByClampingToZero()
 	{
 		// A negative minGap is invalid and inverts handle order. Drag must clamp it to zero,
-		// matching Normalize. This protects against negative minGap being treated as licence to overlap.
+		// matching Normalize. This protects against negative minGap being treated as license to overlap.
 		float[] handles = [0.1f, 0.5f, 0.9f];
 		ImGuiWidgets.HandleTrackState state = new();
 		state.Activate(handles, 0.5f);

--- a/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
+++ b/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
@@ -183,4 +183,41 @@ public class HandleTrackStateTests
 
 		Assert.AreEqual(-1, state.ActiveHandle);
 	}
+
+	[TestMethod]
+	public void Drag_KeepsHandlesOnTheTrackWhenMinGapIsTooWide()
+	{
+		// Two handles at the top with a minGap so wide it cannot fit between bounds.
+		// The active handle must not be pushed outside the track. This reproduces a case where
+		// Normalize narrowed the gap but Drag received the caller's original value, causing
+		// derived floor/ceiling to exceed the bounds.
+		float[] handles = [0.9f, 0.95f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.95f);
+
+		state.Drag(handles, 1.5f, 0f, 1f, 0.5f);
+
+		Assert.IsTrue(handles[0] >= 0f, "First handle pushed below lowerBound.");
+		Assert.IsTrue(handles[1] <= 1f, "Active handle pushed above upperBound.");
+		Assert.IsTrue(handles[1] >= handles[0], "Handles are not in ascending order.");
+	}
+
+	[TestMethod]
+	public void Drag_PreservesHandleOrderWhenNeighborsAreAlreadyCloserThanMinGap()
+	{
+		// Three handles clustered together with a minGap so wide the neighbors are already
+		// closer than it allows. The middle handle must stay between its neighbors and remain
+		// on the track. This reproduces the case where Normalize narrowed the gap internally
+		// but Drag received the original value, causing inversion.
+		float[] handles = [0.85f, 0.9f, 0.95f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.9f);
+
+		state.Drag(handles, 1.5f, 0f, 1f, 0.6f);
+
+		Assert.IsTrue(handles[1] >= handles[0], "Handles are not in ascending order.");
+		Assert.IsTrue(handles[2] >= handles[1], "Handles are not in ascending order.");
+		Assert.IsTrue(handles[0] >= 0f, "First handle pushed below lowerBound.");
+		Assert.IsTrue(handles[2] <= 1f, "Last handle pushed above upperBound.");
+	}
 }

--- a/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
+++ b/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
@@ -48,15 +48,35 @@ public class HandleTrackStateTests
 	}
 
 	[TestMethod]
-	public void Normalize_KeepsHandlesInsideTheBoundsWhenOpeningTheGap()
+	public void Normalize_SettlesDownWhenHandlesAreClusteredAtTheTop()
 	{
-		// Three handles piled against the top with a gap that will not fit below it. Pushing up
-		// blindly would put a handle past upperBound; the pass has to walk back down instead.
+		// Three handles piled against the top with a minGap that fits comfortably. The upward
+		// pass separates them; the downward settle ensures none escape upperBound.
 		float[] handles = [1f, 1f, 1f];
 
 		ImGuiWidgets.HandleTrackState.Normalize(handles, 0f, 1f, 0.25f);
 
 		Assert.IsGreaterThanOrEqualTo(0f, handles[0], "A handle was pushed below lowerBound.");
 		Assert.IsLessThanOrEqualTo(1f, handles[2], "A handle was pushed above upperBound.");
+	}
+
+	[TestMethod]
+	public void Normalize_NarrowsMinGapWhenItCannotFit()
+	{
+		// Three handles in a span of 1 with minGap = 0.6 require spread of 1.2, which exceeds
+		// the available range. The gap is narrowed to spread evenly (0.5 each) with all handles
+		// kept strictly inside bounds.
+		float[] handles = [1f, 1f, 1f];
+
+		ImGuiWidgets.HandleTrackState.Normalize(handles, 0f, 1f, 0.6f);
+
+		// Verify all handles are strictly inside bounds
+		Assert.IsGreaterThanOrEqualTo(0f, handles[0], "First handle pushed below lowerBound.");
+		Assert.IsLessThanOrEqualTo(1f, handles[2], "Last handle pushed above upperBound.");
+
+		// Verify handles are evenly spread
+		float gap1 = handles[1] - handles[0];
+		float gap2 = handles[2] - handles[1];
+		Assert.AreEqual(gap1, gap2, 1e-6f, "Gaps should be equal when minGap is narrowed.");
 	}
 }

--- a/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
+++ b/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
@@ -79,4 +79,108 @@ public class HandleTrackStateTests
 		float gap2 = handles[2] - handles[1];
 		Assert.AreEqual(gap1, gap2, 1e-6f, "Gaps should be equal when minGap is narrowed.");
 	}
+
+	[TestMethod]
+	public void Activate_SelectsTheNearestHandle()
+	{
+		float[] handles = [0.1f, 0.5f, 0.9f];
+		ImGuiWidgets.HandleTrackState state = new();
+
+		state.Activate(handles, 0.55f);
+
+		Assert.AreEqual(1, state.ActiveHandle);
+	}
+
+	[TestMethod]
+	public void Activate_TieGoesToTheLowerHandle()
+	{
+		// Exactly between two handles. These values are exactly representable in binary floating
+		// point, so the two distances really are equal and the tie rule is genuinely exercised —
+		// with values like 0.2/0.4/0.3 the distances differ in the last bits and the test would
+		// pass without the rule holding at all.
+		float[] handles = [0.25f, 0.75f];
+		ImGuiWidgets.HandleTrackState state = new();
+
+		state.Activate(handles, 0.5f);
+
+		Assert.AreEqual(0, state.ActiveHandle);
+	}
+
+	[TestMethod]
+	public void Drag_MovesOnlyTheActiveHandle()
+	{
+		float[] handles = [0.1f, 0.5f, 0.9f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.5f);
+
+		bool changed = state.Drag(handles, 0.6f, 0f, 1f, 0f);
+
+		Assert.IsTrue(changed);
+		Assert.AreEqual(0.1f, handles[0], 1e-6f, "The lower handle moved.");
+		Assert.AreEqual(0.6f, handles[1], 1e-6f);
+		Assert.AreEqual(0.9f, handles[2], 1e-6f, "The upper handle moved.");
+	}
+
+	[TestMethod]
+	public void Drag_StopsAtTheMinimumGapFromItsNeighbour()
+	{
+		float[] handles = [0.1f, 0.5f, 0.9f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.5f);
+
+		state.Drag(handles, 0.95f, 0f, 1f, 0.1f);
+
+		Assert.AreEqual(0.8f, handles[1], 1e-6f, "The middle handle did not stop a gap short of the upper one.");
+		Assert.AreEqual(0.9f, handles[2], 1e-6f, "Dragging into a neighbour pushed it instead of stopping.");
+	}
+
+	[TestMethod]
+	public void Drag_ClampsToTheBoundsRatherThanWrapping()
+	{
+		float[] handles = [0.5f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.5f);
+
+		state.Drag(handles, 4f, 0f, 1f, 0f);
+
+		Assert.AreEqual(1f, handles[0], 1e-6f);
+	}
+
+	[TestMethod]
+	public void Drag_ReportsNoChangeWhenTheValueIsWhereItAlreadyWas()
+	{
+		// A drag that resolves to the same clamped value must not report a change, or a consumer
+		// turning changes into undo entries records one per frame for a stationary mouse.
+		float[] handles = [0.5f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.5f);
+
+		bool changed = state.Drag(handles, 0.5f, 0f, 1f, 0f);
+
+		Assert.IsFalse(changed);
+	}
+
+	[TestMethod]
+	public void Drag_WithoutActivationChangesNothing()
+	{
+		float[] handles = [0.5f];
+		ImGuiWidgets.HandleTrackState state = new();
+
+		bool changed = state.Drag(handles, 0.9f, 0f, 1f, 0f);
+
+		Assert.IsFalse(changed);
+		Assert.AreEqual(0.5f, handles[0], 1e-6f);
+	}
+
+	[TestMethod]
+	public void Release_ClearsTheActiveHandle()
+	{
+		float[] handles = [0.1f, 0.9f];
+		ImGuiWidgets.HandleTrackState state = new();
+		state.Activate(handles, 0.1f);
+
+		state.Release();
+
+		Assert.AreEqual(-1, state.ActiveHandle);
+	}
 }

--- a/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
+++ b/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.ImGui.Widgets.Tests;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Tests the interaction behind HandleTrack and RangeSlider. All pure — no ImGui context required.
+/// </summary>
+[TestClass]
+public class HandleTrackStateTests
+{
+	[TestMethod]
+	public void Normalize_ClampsHandlesIntoTheBounds()
+	{
+		float[] handles = [-3f, 0.5f, 9f];
+
+		ImGuiWidgets.HandleTrackState.Normalize(handles, 0f, 1f, 0f);
+
+		Assert.AreEqual(0f, handles[0], 1e-6f);
+		Assert.AreEqual(0.5f, handles[1], 1e-6f);
+		Assert.AreEqual(1f, handles[2], 1e-6f);
+	}
+
+	[TestMethod]
+	public void Normalize_SortsHandlesAscending()
+	{
+		float[] handles = [0.9f, 0.1f, 0.5f];
+
+		ImGuiWidgets.HandleTrackState.Normalize(handles, 0f, 1f, 0f);
+
+		Assert.AreEqual(0.1f, handles[0], 1e-6f);
+		Assert.AreEqual(0.5f, handles[1], 1e-6f);
+		Assert.AreEqual(0.9f, handles[2], 1e-6f);
+	}
+
+	[TestMethod]
+	public void Normalize_OpensCollapsedHandlesToTheMinimumGap()
+	{
+		float[] handles = [0.5f, 0.5f, 0.5f];
+
+		ImGuiWidgets.HandleTrackState.Normalize(handles, 0f, 1f, 0.1f);
+
+		// Tolerance because the gap is opened by repeated float addition; asserting the exact
+		// bound would be testing rounding, not Normalize.
+		Assert.IsGreaterThanOrEqualTo(0.1f - 1e-6f, handles[1] - handles[0], "The first pair is closer than minGap.");
+		Assert.IsGreaterThanOrEqualTo(0.1f - 1e-6f, handles[2] - handles[1], "The second pair is closer than minGap.");
+	}
+
+	[TestMethod]
+	public void Normalize_KeepsHandlesInsideTheBoundsWhenOpeningTheGap()
+	{
+		// Three handles piled against the top with a gap that will not fit below it. Pushing up
+		// blindly would put a handle past upperBound; the pass has to walk back down instead.
+		float[] handles = [1f, 1f, 1f];
+
+		ImGuiWidgets.HandleTrackState.Normalize(handles, 0f, 1f, 0.25f);
+
+		Assert.IsGreaterThanOrEqualTo(0f, handles[0], "A handle was pushed below lowerBound.");
+		Assert.IsLessThanOrEqualTo(1f, handles[2], "A handle was pushed above upperBound.");
+	}
+}

--- a/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
+++ b/tests/ImGui.Widgets.Tests/HandleTrackStateTests.cs
@@ -122,7 +122,7 @@ public class HandleTrackStateTests
 	}
 
 	[TestMethod]
-	public void Drag_StopsAtTheMinimumGapFromItsNeighbour()
+	public void Drag_StopsAtTheMinimumGapFromItsNeighbor()
 	{
 		float[] handles = [0.1f, 0.5f, 0.9f];
 		ImGuiWidgets.HandleTrackState state = new();
@@ -131,7 +131,7 @@ public class HandleTrackStateTests
 		state.Drag(handles, 0.95f, 0f, 1f, 0.1f);
 
 		Assert.AreEqual(0.8f, handles[1], 1e-6f, "The middle handle did not stop a gap short of the upper one.");
-		Assert.AreEqual(0.9f, handles[2], 1e-6f, "Dragging into a neighbour pushed it instead of stopping.");
+		Assert.AreEqual(0.9f, handles[2], 1e-6f, "Dragging into a neighbor pushed it instead of stopping.");
 	}
 
 	[TestMethod]
@@ -197,9 +197,9 @@ public class HandleTrackStateTests
 
 		state.Drag(handles, 1.5f, 0f, 1f, 0.5f);
 
-		Assert.IsTrue(handles[0] >= 0f, "First handle pushed below lowerBound.");
-		Assert.IsTrue(handles[1] <= 1f, "Active handle pushed above upperBound.");
-		Assert.IsTrue(handles[1] >= handles[0], "Handles are not in ascending order.");
+		Assert.IsGreaterThanOrEqualTo(0f, handles[0], "First handle pushed below lowerBound.");
+		Assert.IsLessThanOrEqualTo(1f, handles[1], "Active handle pushed above upperBound.");
+		Assert.IsGreaterThanOrEqualTo(handles[0], handles[1], "Handles are not in ascending order.");
 	}
 
 	[TestMethod]
@@ -215,10 +215,10 @@ public class HandleTrackStateTests
 
 		state.Drag(handles, 1.5f, 0f, 1f, 0.6f);
 
-		Assert.IsTrue(handles[1] >= handles[0], "Handles are not in ascending order.");
-		Assert.IsTrue(handles[2] >= handles[1], "Handles are not in ascending order.");
-		Assert.IsTrue(handles[0] >= 0f, "First handle pushed below lowerBound.");
-		Assert.IsTrue(handles[2] <= 1f, "Last handle pushed above upperBound.");
+		Assert.IsGreaterThanOrEqualTo(handles[0], handles[1], "Handles are not in ascending order.");
+		Assert.IsGreaterThanOrEqualTo(handles[1], handles[2], "Handles are not in ascending order.");
+		Assert.IsGreaterThanOrEqualTo(0f, handles[0], "First handle pushed below lowerBound.");
+		Assert.IsLessThanOrEqualTo(1f, handles[2], "Last handle pushed above upperBound.");
 	}
 
 	[TestMethod]
@@ -239,7 +239,7 @@ public class HandleTrackStateTests
 	[TestMethod]
 	public void Drag_AllowsSingleHandleToReachBothBoundsWithNonzeroMinGap()
 	{
-		// A single handle has no neighbours, so minGap never applies. With or without minGap,
+		// A single handle has no neighbors, so minGap never applies. With or without minGap,
 		// it should still reach both bounds. This protects against regression 1.
 		float[] handles = [0.5f];
 		ImGuiWidgets.HandleTrackState state = new();
@@ -280,8 +280,10 @@ public class HandleTrackStateTests
 
 		state.Drag(handles, 0f, 0f, 1f, -0.2f);
 
-		Assert.IsTrue(handles[0] <= handles[1] && handles[1] <= handles[2], "Handles must remain ascending after drag with negative minGap.");
-		Assert.IsTrue(handles[0] >= 0f && handles[2] <= 1f, "Handles must remain on track.");
+		Assert.IsLessThanOrEqualTo(handles[1], handles[0], "handles[0] must not exceed handles[1] after drag with negative minGap.");
+		Assert.IsLessThanOrEqualTo(handles[2], handles[1], "handles[1] must not exceed handles[2] after drag with negative minGap.");
+		Assert.IsGreaterThanOrEqualTo(0f, handles[0], "handles[0] must remain on track (at or above lowerBound).");
+		Assert.IsLessThanOrEqualTo(1f, handles[2], "handles[2] must remain on track (at or below upperBound).");
 	}
 
 	[TestMethod]
@@ -295,13 +297,19 @@ public class HandleTrackStateTests
 
 		state.Drag(handles, 1f, 0f, 1f, -0.2f);
 
-		Assert.IsTrue(handles[0] <= handles[1] && handles[1] <= handles[2], "Handles must remain ascending after drag with negative minGap.");
-		Assert.IsTrue(handles[0] >= 0f && handles[2] <= 1f, "Handles must remain on track.");
+		Assert.IsLessThanOrEqualTo(handles[1], handles[0], "handles[0] must not exceed handles[1] after drag with negative minGap.");
+		Assert.IsLessThanOrEqualTo(handles[2], handles[1], "handles[1] must not exceed handles[2] after drag with negative minGap.");
+		Assert.IsGreaterThanOrEqualTo(0f, handles[0], "handles[0] must remain on track (at or above lowerBound).");
+		Assert.IsLessThanOrEqualTo(1f, handles[2], "handles[2] must remain on track (at or below upperBound).");
 	}
 
-	// RangeSlider has never had tests. These describe the two-handle behaviour read out of its
-	// source before it was moved onto HandleTrackState, and stand in for the regression suite it
-	// never had. If one of these has to change, RangeSlider's behaviour changed with it.
+	// These three tests pin the shared two-handle interaction rules that RangeSlider now depends
+	// on via HandleTrackState. RangeSlider's own refactor commit does not modify HandleTrackState,
+	// so these tests passed before that refactor and would pass even if RangeSlider's wiring to it
+	// were wrong. They do not observe RangeSlider's wiring — its mouseValue formula, the order it
+	// calls Activate/Drag/Release in, writing handles[0]/handles[1] back to lower/upper, or drawing
+	// only after interaction — and RangeSlider has no test covering that wiring, before or after
+	// this branch.
 
 	[TestMethod]
 	public void TwoHandles_LowerCannotCrossUpper()


### PR DESCRIPTION
Adds two widgets to `ktsu.ImGui.Widgets`, backed by a pure interaction type that `RangeSlider` also moves onto. This is step 1 of ImageGui's M2b milestone — a levels adjustment needs a histogram with draggable black/gamma/white handles, and both halves of that are reusable well beyond it.

## What's here

**`HandleTrackState`** (internal) — activation, dragging, clamping and gap enforcement, with no ImGui dependency, following the pattern every tested widget in this library already uses (`ImageCanvasState`, `GestureMachine`, `InertialScroll`). All 25 new tests target this type.

**`HandleTrack`** — draggable handles over a rectangle the caller supplies. Draws handles only, no track or fill, so it can be laid over content it does not own.

**`Histogram`** — display-only, takes pre-computed bins rather than raw data, which keeps it usable for any distribution and keeps the binning scan off the render thread.

**`RangeSlider`** moves onto the shared state. Its public signature, layout and drawing are unchanged.

The two widgets are deliberately separate rather than one combined levels control, so no photo-editing idiom enters a general widget library. `Histogram` draws, the caller takes `GetItemRectMin()`/`GetItemRectMax()`, and `HandleTrack` overlays exactly that rectangle. The demo shows the composition.

## Why RangeSlider changed

`RangeSlider` already contained handle-picking and gap-pushing logic — `HandleTrack` with two handles and a track it reserves itself. Leaving them separate would have put two copies of the same interaction in one directory.

It could not simply call `HandleTrack`: it fills the track *between* its handles, and an ImGui draw list is call-ordered, so delegating would mean drawing the fill a frame late or painting over the handles. What is shared is the interaction, not the widget.

## Verification

| | |
| --- | --- |
| Tests | 256/256, up from 231 |
| Build | clean across `net10.0;net9.0;net8.0`, 0 warnings under warnings-as-errors |

`RangeSlider` had **no tests before this branch and has none now** — the 25 new tests cover `HandleTrackState`, not `RangeSlider`'s wiring. That refactor was instead verified differentially: the old interaction arithmetic and the new path compiled side by side and driven through ~2M frame sequences comparing `lower`, `upper`, the `bool` return and which handle was picked.

That comparison found four behavior differences, three reachable:

- **The old code threw `ArgumentException`** when `upper - minGap` rounded an ULP below `min` — 17% of `(min, max, minGap)` triples on a lower-handle press. This branch removes a latent crash.
- Inverted `lower`/`upper` are now sorted rather than collapsed, so both values survive. Documented on the widget.
- A click at the exact pixel midpoint can pick the other handle (0.13% of positions; arbitrary in both versions).
- `lower` could return ~1e-7 below `min` at an exactly-feasible gap — fixed on this branch.

**The demo's configuration — the only `RangeSlider` caller in either repo — was bit-identical across 2,410,668 simulated interactions.**

A visual drag-check of the running demo is still worth a minute of someone's time; nothing automated here reaches a drawing path.

## Notes for review

- `HandleTrackState` is `internal`. Nothing needs it public, and this library publishes to nuget.org — internal now, public later is additive; the reverse is breaking.
- `HandleTrack` and `RangeSlider` still each carry their own ~30 lines of plumbing (state dictionary, mouse-to-value, activate/drag/release). The *rules* are shared; the wiring is not. Making the state a caller-owned parameter, as `ImageCanvasState` is, would remove most of it — deliberately not done here.
- Neither new widget has a unit test covering its drawing path, consistent with the other 20+ widgets. The demo is where their rendering is exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2jh1ZMuULEMd49svVWTsg