### PR TITLE
Fan CI tests out across platforms and projects

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -162,6 +162,9 @@ jobs:
           set -euo pipefail
           ktsubuild test run --project "${{ matrix.project }}" --workspace "$GITHUB_WORKSPACE" --verbose
 
+      # `warn` rather than `error`, because this step runs with `if: always()` and a cell that
+      # genuinely failed its tests legitimately produces no coverage. `error` here would break
+      # the failure path instead of just reporting it.
       - name: Upload Coverage
         uses: actions/upload-artifact@v7
         if: always()
@@ -174,11 +177,12 @@ jobs:
   release:
     name: Analyze & Release
     needs: [discover, test]
-    # `always()` is required because `test` is skipped when a repo has no test projects, and a
-    # skipped dependency would otherwise skip this job too. The explicit result checks are what
-    # keep a genuine test failure from releasing anyway.
+    # `!cancelled()` is required because `test` is skipped when a repo has no test projects, and
+    # a skipped dependency would otherwise skip this job too. It also stops a run that
+    # `concurrency.cancel-in-progress` superseded from reaching `Release` and racing the newer
+    # run. The explicit result checks are what keep a genuine test failure from releasing anyway.
     if: |
-      always()
+      !cancelled()
       && needs.discover.result == 'success'
       && (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: windows-latest
@@ -276,7 +280,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: pwsh
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"${{ github.repository_owner }}_${{ github.event.repository.name }}" /o:"${{ github.repository_owner }}" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.projectBaseDir="${{ github.workspace }}" /d:sonar.cs.vscoveragexml.reportsPaths="coverage/**/coverage.xml" /d:sonar.coverage.exclusions="**/*Test*.cs,**/*.Tests.cs,**/*.Tests/**/*,**/obj/**/*,**/*.dll,**/NativeExports.cs" /d:sonar.cs.vstest.reportsPaths="coverage/**/*.trx" /d:sonar.exclusions="**/NativeExports.cs"
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"${{ github.repository_owner }}_${{ github.event.repository.name }}" /o:"${{ github.repository_owner }}" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.projectBaseDir="${{ github.workspace }}" /d:sonar.qualitygate.wait=true /d:sonar.cs.vscoveragexml.reportsPaths="coverage/**/coverage.xml" /d:sonar.coverage.exclusions="**/*Test*.cs,**/*.Tests.cs,**/*.Tests/**/*,**/obj/**/*,**/*.dll,**/NativeExports.cs" /d:sonar.cs.vstest.reportsPaths="coverage/**/*.trx" /d:sonar.exclusions="**/NativeExports.cs"
 
       # `ci` rather than restore and build directly, because it is the only place that updates
       # and commits the metadata files, updates the repository topics, applies the version gate
@@ -328,7 +332,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: coverage-report
+          name: analysis-coverage-report
           path: |
             ./coverage/*
           retention-days: 7

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -171,10 +171,173 @@ jobs:
           retention-days: 7
           if-no-files-found: warn
 
+  release:
+    name: Analyze & Release
+    needs: [discover, test]
+    # `always()` is required because `test` is skipped when a repo has no test projects, and a
+    # skipped dependency would otherwise skip this job too. The explicit result checks are what
+    # keep a genuine test failure from releasing anyway.
+    if: |
+      always()
+      && needs.discover.result == 'success'
+      && (needs.test.result == 'success' || needs.test.result == 'skipped')
+    runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write # For creating releases and committing metadata
+      packages: write # For publishing packages
+
+    outputs:
+      version: ${{ steps.pipeline.outputs.version }}
+      release_hash: ${{ steps.pipeline.outputs.release_hash }}
+      should_release: ${{ steps.pipeline.outputs.should_release }}
+
+    steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: "zulu" # Alternative distribution options are available.
+
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # Full history for versioning
+          fetch-tags: true
+          lfs: true
+          submodules: recursive
+          persist-credentials: true
+
+      - name: Setup .NET SDK ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}.x
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/Directory.Packages.props
+            **/global.json
+
+      # Ensure NuGet packages directory exists for caching (prevents error when pipeline exits early)
+      - name: Ensure NuGet cache directory exists
+        run: New-Item -Path "$env:USERPROFILE\.nuget\packages" -ItemType Directory -Force
+        shell: pwsh
+
+      - name: Cache SonarQube Cloud packages
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: actions/cache@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache SonarQube Cloud scanner
+        if: ${{ env.SONAR_TOKEN != '' }}
+        id: cache-sonar-scanner
+        uses: actions/cache@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          path: .\.sonar\scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+
+      - name: Install SonarQube Cloud scanner
+        if: ${{ env.SONAR_TOKEN != '' && steps.cache-sonar-scanner.outputs.cache-hit != 'true' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: pwsh
+        run: |
+          New-Item -Path .\.sonar\scanner -ItemType Directory
+          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+
+      - name: Install KtsuBuild
+        shell: pwsh
+        run: |
+          dotnet tool install ktsu.KtsuBuild.Tool --tool-path "${{ runner.temp }}/ktsubuild"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "${{ runner.temp }}/ktsubuild" >> $env:GITHUB_PATH
+
+      # Every cell wrote a file named coverage.xml, so the downloads must stay in their own
+      # per-artifact directories. Merging them would leave one file and report the coverage of
+      # a single test project as though it were the whole repository's.
+      - name: Download Coverage
+        if: needs.discover.outputs.has_tests == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          pattern: coverage-*
+          path: coverage
+
+      - name: Begin SonarQube
+        if: ${{ env.SONAR_TOKEN != '' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: pwsh
+        run: |
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"${{ github.repository_owner }}_${{ github.event.repository.name }}" /o:"${{ github.repository_owner }}" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.projectBaseDir="${{ github.workspace }}" /d:sonar.cs.vscoveragexml.reportsPaths="coverage/**/coverage.xml" /d:sonar.coverage.exclusions="**/*Test*.cs,**/*.Tests.cs,**/*.Tests/**/*,**/obj/**/*,**/*.dll,**/NativeExports.cs" /d:sonar.cs.vstest.reportsPaths="coverage/**/*.trx" /d:sonar.exclusions="**/NativeExports.cs"
+
+      # `ci` rather than restore and build directly, because it is the only place that updates
+      # and commits the metadata files, updates the repository topics, applies the version gate
+      # behind `[skip ci]`, and writes the step outputs the winget and security jobs read.
+      # The tests already ran in the matrix, and the release waits for the quality gate below.
+      - name: Run KtsuBuild Pipeline
+        id: pipeline
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUGET_API_KEY: ${{ secrets.NUGET_KEY }}
+          KTSU_PACKAGE_KEY: ${{ secrets.KTSU_PACKAGE_KEY }}
+          EXPECTED_OWNER: ktsu-dev
+        run: |
+          $versionBump = "${{ github.event.inputs.version-bump }}"
+
+          $args = @("ci", "--workspace", "${{ github.workspace }}", "--no-test", "--no-release", "--verbose")
+          if (![string]::IsNullOrEmpty($versionBump) -and $versionBump -ne "auto") {
+            $args += @("--version-bump", $versionBump)
+          }
+
+          & ktsubuild @args
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: End SonarQube
+        if: env.SONAR_TOKEN != '' && steps.pipeline.outputs.build_skipped != 'true'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: pwsh
+        run: |
+          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="$env:SONAR_TOKEN"
+
+      # After the gate, not before. A failed quality gate fails the step above and this never
+      # runs, which is a deliberate change from the old shape where `ci` released first and
+      # Sonar reported afterward.
+      - name: Release
+        if: steps.pipeline.outputs.should_release == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUGET_API_KEY: ${{ secrets.NUGET_KEY }}
+          KTSU_PACKAGE_KEY: ${{ secrets.KTSU_PACKAGE_KEY }}
+          EXPECTED_OWNER: ktsu-dev
+        run: |
+          ktsubuild release --workspace "${{ github.workspace }}" --verbose
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage-report
+          path: |
+            ./coverage/*
+          retention-days: 7
+          if-no-files-found: ignore
+
   winget:
     name: Update Winget Manifests
-    needs: build
-    if: needs.build.outputs.should_release == 'true'
+    needs: release
+    if: needs.release.outputs.should_release == 'true'
     runs-on: windows-latest
     timeout-minutes: 10
     permissions:
@@ -184,7 +347,7 @@ jobs:
       - name: Checkout Release Commit
         uses: actions/checkout@v7
         with:
-          ref: ${{ needs.build.outputs.release_hash }}
+          ref: ${{ needs.release.outputs.release_hash }}
           fetch-depth: 0 # Full history for better auto-detection
 
       - name: Setup .NET SDK ${{ env.DOTNET_VERSION }}
@@ -205,19 +368,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ktsubuild winget generate --version "${{ needs.build.outputs.version }}" --workspace "${{ github.workspace }}" --verbose
+          ktsubuild winget generate --version "${{ needs.release.outputs.version }}" --workspace "${{ github.workspace }}" --verbose
 
       - name: Upload Updated Manifests
         uses: actions/upload-artifact@v7
         with:
-          name: winget-manifests-${{ needs.build.outputs.version }}
+          name: winget-manifests-${{ needs.release.outputs.version }}
           path: winget/*.yaml
           retention-days: 30
 
   security:
     name: Security Scanning
-    needs: build
-    if: needs.build.outputs.should_release == 'true'
+    needs: release
+    if: needs.release.outputs.should_release == 'true'
     runs-on: windows-latest
     timeout-minutes: 10
     permissions:
@@ -228,6 +391,6 @@ jobs:
       - name: Checkout Release Commit
         uses: actions/checkout@v7
         with:
-          ref: ${{ needs.build.outputs.release_hash }}
+          ref: ${{ needs.release.outputs.release_hash }}
       - name: Detect Dependencies
         uses: advanced-security/component-detection-dependency-submission-action@31f25a8de68ae5ce2ca274bc28546a78683c15ce # v0.1.4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -81,21 +81,28 @@ jobs:
           # An unrecognized platform must stop the run rather than drop the project. Dropping
           # it would produce a smaller matrix that still reports success, which is the failure
           # this design exists to remove.
-          unknown=$(echo "$projects" | jq -r '[.[] | select(.platform as $p | ["neutral","windows","ios"] | index($p) | not) | .platform] | unique | join(", ")')
+          unknown=$(echo "$projects" | jq -r '[.[] | select(.platform as $p | ["neutral","windows"] | index($p) | not) | .platform] | unique | join(", ")')
           if [ -n "$unknown" ]; then
-            echo "::error::ktsubuild test list reported unrecognized platform(s): $unknown"
+            echo "::error::Cannot place test project(s) on a runner. Unhandled platform(s): $unknown"
+            echo "::error::macOS is currently excluded from the matrix, so an ios-tied test project has nowhere to run."
             exit 1
           fi
 
+          # macOS is deliberately absent from this mapping. A macOS runner builds any project
+          # whose target frameworks are widened on that host, and in a repo with an iOS head that
+          # pulls in a target framework needing a workload this job does not install, so every
+          # macOS cell fails during its build. Restoring the workload on each cell is slow and
+          # macOS runner minutes are billed at a premium, so the platform is excluded until the
+          # underlying problem is fixed rather than papered over. An ios-tied test project now
+          # fails the guard above instead of silently finding no runner.
           matrix=$(echo "$projects" | jq -c '
             {
               include: [
                 .[]
                 | . as $p
                 | {
-                    neutral: ["ubuntu-latest", "windows-latest", "macos-latest"],
-                    windows: ["windows-latest"],
-                    ios: ["macos-latest"]
+                    neutral: ["ubuntu-latest", "windows-latest"],
+                    windows: ["windows-latest"]
                   }[$p.platform][]
                 | {
                     os: .,

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -117,34 +117,25 @@ jobs:
             echo "has_tests=false" >> "$GITHUB_OUTPUT"
           fi
 
-  build:
-    name: Build, Test & Release
-    runs-on: windows-latest
-    timeout-minutes: 20
-    permissions:
-      contents: write # For creating releases and committing metadata
-      packages: write # For publishing packages
+  test:
+    name: Test ${{ matrix.name }} (${{ matrix.os }})
+    needs: discover
+    if: needs.discover.outputs.has_tests == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
-    outputs:
-      version: ${{ steps.pipeline.outputs.version }}
-      release_hash: ${{ steps.pipeline.outputs.release_hash }}
-      should_release: ${{ steps.pipeline.outputs.should_release }}
+    strategy:
+      # One platform's failure must not cancel the others. Knowing that a project fails on
+      # macOS only is the point of running the matrix at all.
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
 
     steps:
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: 17
-          distribution: "zulu" # Alternative distribution options are available.
-
       - name: Checkout Repository
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0 # Full history for versioning
-          fetch-tags: true
           lfs: true
           submodules: recursive
-          persist-credentials: true
 
       - name: Setup .NET SDK ${{ env.DOTNET_VERSION }}
         uses: actions/setup-dotnet@v6
@@ -156,94 +147,29 @@ jobs:
             **/Directory.Packages.props
             **/global.json
 
-      # Ensure NuGet packages directory exists for caching (prevents error when pipeline exits early)
-      - name: Ensure NuGet cache directory exists
-        run: New-Item -Path "$env:USERPROFILE\.nuget\packages" -ItemType Directory -Force
-        shell: pwsh
-
-      - name: Cache SonarQube Cloud packages
-        if: ${{ env.SONAR_TOKEN != '' }}
-        uses: actions/cache@v6
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          path: ~\sonar\cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Cache SonarQube Cloud scanner
-        if: ${{ env.SONAR_TOKEN != '' }}
-        id: cache-sonar-scanner
-        uses: actions/cache@v6
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          path: .\.sonar\scanner
-          key: ${{ runner.os }}-sonar-scanner
-          restore-keys: ${{ runner.os }}-sonar-scanner
-
-      - name: Install SonarQube Cloud scanner
-        if: ${{ env.SONAR_TOKEN != '' && steps.cache-sonar-scanner.outputs.cache-hit != 'true' }}
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        shell: pwsh
-        run: |
-          New-Item -Path .\.sonar\scanner -ItemType Directory
-          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
-
       - name: Install KtsuBuild
-        shell: pwsh
+        shell: bash
         run: |
           dotnet tool install ktsu.KtsuBuild.Tool --tool-path "${{ runner.temp }}/ktsubuild"
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          "${{ runner.temp }}/ktsubuild" >> $env:GITHUB_PATH
+          echo "${{ runner.temp }}/ktsubuild" >> "$GITHUB_PATH"
 
-      - name: Begin SonarQube
-        if: ${{ env.SONAR_TOKEN != '' }}
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        shell: pwsh
+      # One test project per invocation. Besides parallelizing the suite, this removes the
+      # condition behind a coverage-collector flake that KtsuBuild otherwise retries around:
+      # the instrumentation pipe drops during teardown when several assemblies run together.
+      - name: Run Tests
+        shell: bash
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"${{ github.repository_owner }}_${{ github.event.repository.name }}" /o:"${{ github.repository_owner }}" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.projectBaseDir="${{ github.workspace }}" /d:sonar.cs.vscoveragexml.reportsPaths="coverage/coverage.xml" /d:sonar.coverage.exclusions="**/*Test*.cs,**/*.Tests.cs,**/*.Tests/**/*,**/obj/**/*,**/*.dll,**/NativeExports.cs" /d:sonar.cs.vstest.reportsPaths="coverage/TestResults/**/*.trx" /d:sonar.exclusions="**/NativeExports.cs"
+          set -euo pipefail
+          ktsubuild test run --project "${{ matrix.project }}" --workspace "$GITHUB_WORKSPACE" --verbose
 
-      - name: Run KtsuBuild CI Pipeline
-        id: pipeline
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-          NUGET_API_KEY: ${{ secrets.NUGET_KEY }}
-          KTSU_PACKAGE_KEY: ${{ secrets.KTSU_PACKAGE_KEY }}
-          EXPECTED_OWNER: ktsu-dev
-        run: |
-          # Run the CI pipeline
-          $versionBump = "${{ github.event.inputs.version-bump }}"
-
-          # Build arguments array - only add --version-bump if explicitly set (for backward compatibility during bootstrap)
-          $args = @("ci", "--workspace", "${{ github.workspace }}", "--verbose")
-          if (![string]::IsNullOrEmpty($versionBump) -and $versionBump -ne "auto") {
-            $args += @("--version-bump", $versionBump)
-          }
-
-          & ktsubuild @args
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: End SonarQube
-        if: env.SONAR_TOKEN != '' && steps.pipeline.outputs.build_skipped != 'true'
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        shell: pwsh
-        run: |
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="$env:SONAR_TOKEN"
-
-      - name: Upload Coverage Report
+      - name: Upload Coverage
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: coverage-report
-          path: |
-            ./coverage/*
+          name: coverage-${{ matrix.slug }}-${{ matrix.os }}
+          path: ./coverage/*
           retention-days: 7
-          if-no-files-found: ignore
+          if-no-files-found: warn
 
   winget:
     name: Update Winget Manifests

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,6 +35,88 @@ env:
   DOTNET_VERSION: "10.0" # Only needed for actions/setup-dotnet
 
 jobs:
+  discover:
+    name: Discover Test Projects
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      has_tests: ${{ steps.discover.outputs.has_tests }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET SDK ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}.x
+
+      - name: Install KtsuBuild
+        shell: bash
+        run: |
+          dotnet tool install ktsu.KtsuBuild.Tool --tool-path "${{ runner.temp }}/ktsubuild"
+          echo "${{ runner.temp }}/ktsubuild" >> "$GITHUB_PATH"
+
+      # `test list` reports every test project regardless of the host it runs on, unlike the
+      # filter `build` and `ci` apply, so one Linux job can enumerate cells that Windows and
+      # macOS runners will execute. It writes failures to stdout rather than stderr, so the
+      # exit code is the only reliable signal and has to be checked before parsing.
+      - name: Discover Test Projects
+        id: discover
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! projects=$(ktsubuild test list --workspace "$GITHUB_WORKSPACE"); then
+            echo "::error::ktsubuild test list failed:"
+            echo "$projects"
+            exit 1
+          fi
+
+          echo "Discovered test projects:"
+          echo "$projects" | jq .
+
+          # An unrecognized platform must stop the run rather than drop the project. Dropping
+          # it would produce a smaller matrix that still reports success, which is the failure
+          # this design exists to remove.
+          unknown=$(echo "$projects" | jq -r '[.[] | select(.platform as $p | ["neutral","windows","ios"] | index($p) | not) | .platform] | unique | join(", ")')
+          if [ -n "$unknown" ]; then
+            echo "::error::ktsubuild test list reported unrecognized platform(s): $unknown"
+            exit 1
+          fi
+
+          matrix=$(echo "$projects" | jq -c '
+            {
+              include: [
+                .[]
+                | . as $p
+                | {
+                    neutral: ["ubuntu-latest", "windows-latest", "macos-latest"],
+                    windows: ["windows-latest"],
+                    ios: ["macos-latest"]
+                  }[$p.platform][]
+                | {
+                    os: .,
+                    project: $p.project,
+                    name: ($p.project | split("/") | last | rtrimstr(".csproj")),
+                    slug: ($p.project | rtrimstr(".csproj") | gsub("[^A-Za-z0-9]"; "-"))
+                  }
+              ]
+            }')
+
+          count=$(echo "$matrix" | jq '.include | length')
+          echo "Matrix has $count cell(s)."
+          echo "$matrix" | jq .
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          if [ "$count" -gt 0 ]; then
+            echo "has_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: Build, Test & Release
     runs-on: windows-latest

--- a/docs/superpowers/plans/2026-08-21-ci-parallel-test-matrix.md
+++ b/docs/superpowers/plans/2026-08-21-ci-parallel-test-matrix.md
@@ -1,0 +1,666 @@
+# CI parallel test matrix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure `.github/workflows/dotnet.yml` so test projects fan out across Linux, Windows, and macOS in parallel instead of running serially in one Windows job that already exceeds its timeout.
+
+**Architecture:** Three jobs replace the single `build` job. `discover` asks `ktsubuild test list` what test projects exist and emits a matrix. `test` runs one project on one platform per cell and uploads that cell's coverage. `release` downloads every cell's coverage, runs `ktsubuild ci --no-test --no-release` inside the SonarCloud begin and end window, then releases only if the quality gate passed and the version moved. The existing `winget` and `security` jobs are repointed at `release`.
+
+**Tech Stack:** GitHub Actions, `ktsu.KtsuBuild.Tool` 2.3.0 or later, SonarCloud, jq.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md` — read it, including its Revisions section, which records three corrections made after the original design.
+
+## Global Constraints
+
+- **This file propagates verbatim to roughly sixty repositories** through `ktsu sync`, which hashes every copy of a filename and pushes the chosen version to all the others. Nothing in the workflow may be specific to ImGuiApp: no hardcoded project names, no hardcoded test counts, no repository name outside the `${{ github.* }}` expressions GitHub already substitutes. The matrix must be discovered at runtime for correctness, not for elegance.
+- **It must work for a repo with one test project and for a repo with fifteen, and for a repo with none.** When there are no test projects the matrix is empty, the `test` job is skipped, and `release` must still run.
+- **Never pass `--nologo` to `dotnet test` or to any `ktsubuild` command.** It makes the runner report `total: 0` with exit code 5 while every test passes. A step that passes it looks green and tests nothing.
+- **`ktsubuild test list` writes its errors to stdout, not stderr, and exits 1.** Always check the exit code before parsing stdout, or the workflow will try to parse an error message as JSON.
+- **A step that skips its own work and reports success is the specific failure this design exists to remove.** Where a shell step can silently do nothing, make it fail loudly instead.
+- YAML indents with two spaces. Match the existing file's style, including its comment voice.
+- US English throughout.
+- Prose in comments must not use em dashes, en dashes, or semicolons joining clauses.
+- **Building rewrites `.editorconfig`.** Run `git checkout .editorconfig` before every commit, and stage files by name. Never `git add -A`.
+- Commit messages carry a version tag such as `[patch]` or `[minor]`. Do not add Co-Authored-By lines.
+- Do not touch `.github/workflows/ios.yml`, `.github/workflows/dependabot-merge.yml`, or `.github/workflows/update-sdks.yml`.
+
+## What exists today
+
+`.github/workflows/dotnet.yml` has three jobs:
+
+- `build` on `windows-latest`, `timeout-minutes: 20`. Sets up JDK 17, checks out with full history, sets up .NET, caches and installs the SonarCloud scanner, installs `ktsubuild`, runs `dotnet-sonarscanner begin`, runs `ktsubuild ci`, runs `dotnet-sonarscanner end`, and uploads `./coverage/*`. Its outputs are `version`, `release_hash`, and `should_release`, all read from `steps.pipeline.outputs`.
+- `winget`, `needs: build`, `if: needs.build.outputs.should_release == 'true'`, checks out `needs.build.outputs.release_hash`.
+- `security`, `needs: build`, same condition, same checkout ref.
+
+The `End SonarQube` step is conditioned on `steps.pipeline.outputs.build_skipped != 'true'`. `ktsubuild ci` always writes `build_skipped=false`, and still will.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `.github/workflows/dotnet.yml` (modify) | The whole change. Three jobs replace `build`, and two jobs are repointed. |
+
+Everything lands in one file, so the tasks below split by reviewable unit rather than by file: the discovery contract first, then the matrix that consumes it, then the release job, then the live validation the spec demands.
+
+---
+
+### Task 1: Add the discover job
+
+**Files:**
+- Modify: `.github/workflows/dotnet.yml`
+
+**Interfaces:**
+- Consumes: `ktsubuild test list --workspace <path>`, which prints one line of JSON to stdout, an array of `{"project": "<forward-slash path relative to the workspace>", "platform": "neutral"|"windows"|"ios"}`, sorted by project. On failure it prints a message to stdout and exits 1.
+- Produces: job outputs `matrix` (a JSON object with a single `include` key) and `has_tests` (the string `"true"` or `"false"`). Task 2 consumes both by those exact names. Each `include` entry has the keys `os`, `project`, `name`, and `slug`.
+
+- [ ] **Step 1: Read the current workflow**
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+cat .github/workflows/dotnet.yml
+```
+
+Note the `env:` block defining `DOTNET_VERSION`, the `Install KtsuBuild` step (it appears twice and is identical both times), and the exact `actions/*` versions in use. Reuse those versions rather than introducing new ones.
+
+- [ ] **Step 2: Insert the discover job**
+
+Add this as the FIRST job under `jobs:`, before the existing `build` job. Do not modify `build` in this task.
+
+```yaml
+  discover:
+    name: Discover Test Projects
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      has_tests: ${{ steps.discover.outputs.has_tests }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET SDK ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}.x
+
+      - name: Install KtsuBuild
+        shell: bash
+        run: |
+          dotnet tool install ktsu.KtsuBuild.Tool --tool-path "${{ runner.temp }}/ktsubuild"
+          echo "${{ runner.temp }}/ktsubuild" >> "$GITHUB_PATH"
+
+      # `test list` reports every test project regardless of the host it runs on, unlike the
+      # filter `build` and `ci` apply, so one Linux job can enumerate cells that Windows and
+      # macOS runners will execute. It writes failures to stdout rather than stderr, so the
+      # exit code is the only reliable signal and has to be checked before parsing.
+      - name: Discover Test Projects
+        id: discover
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! projects=$(ktsubuild test list --workspace "$GITHUB_WORKSPACE"); then
+            echo "::error::ktsubuild test list failed:"
+            echo "$projects"
+            exit 1
+          fi
+
+          echo "Discovered test projects:"
+          echo "$projects" | jq .
+
+          # An unrecognized platform must stop the run rather than drop the project. Dropping
+          # it would produce a smaller matrix that still reports success, which is the failure
+          # this design exists to remove.
+          unknown=$(echo "$projects" | jq -r '[.[] | select(.platform as $p | ["neutral","windows","ios"] | index($p) | not) | .platform] | unique | join(", ")')
+          if [ -n "$unknown" ]; then
+            echo "::error::ktsubuild test list reported unrecognized platform(s): $unknown"
+            exit 1
+          fi
+
+          matrix=$(echo "$projects" | jq -c '
+            {
+              include: [
+                .[]
+                | . as $p
+                | {
+                    neutral: ["ubuntu-latest", "windows-latest", "macos-latest"],
+                    windows: ["windows-latest"],
+                    ios: ["macos-latest"]
+                  }[$p.platform][]
+                | {
+                    os: .,
+                    project: $p.project,
+                    name: ($p.project | split("/") | last | rtrimstr(".csproj")),
+                    slug: ($p.project | rtrimstr(".csproj") | gsub("[^A-Za-z0-9]"; "-"))
+                  }
+              ]
+            }')
+
+          count=$(echo "$matrix" | jq '.include | length')
+          echo "Matrix has $count cell(s)."
+          echo "$matrix" | jq .
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          if [ "$count" -gt 0 ]; then
+            echo "has_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+```
+
+`slug` exists because artifact names cannot contain `/`, and two test projects in different directories can share a basename. The slug is derived from the whole path, so it stays unique.
+
+- [ ] **Step 3: Validate the jq locally before pushing**
+
+The jq program is the part most likely to be wrong, and a CI round trip to find out is slow. Run it against real input first.
+
+**Every check in this step was run on 2026-08-21 and passed, with the results given below.** They are here so you can confirm the code still behaves that way after transcription, not to discover it for the first time. If any result differs, the transcription is wrong, not the expectation.
+
+Two local-environment traps, both hit while writing this plan:
+
+- **The globally installed `ktsubuild` is likely stale.** It was 2.0.1 on the author's machine, which predates `test list` entirely and fails with `'test' was not matched`. Install the current tool to a scratch path and call it explicitly rather than relying on whatever is on `PATH`:
+
+```bash
+TOOLS="$(mktemp -d)/ktsubuild"
+dotnet tool install ktsu.KtsuBuild.Tool --tool-path "$TOOLS"
+KB="$TOOLS/ktsubuild"
+"$KB" --version   # must be 2.3.0 or later
+```
+
+- **`jq` is not installed on this Windows machine** and is not on `PATH` under Git Bash, though every GitHub runner has it. Fetch a standalone binary rather than installing anything:
+
+```bash
+JQ="$(mktemp -d)/jq.exe"
+curl -sL -o "$JQ" https://github.com/jqlang/jq/releases/latest/download/jq-windows-amd64.exe
+"$JQ" --version
+```
+
+Use `"$KB"` and `"$JQ"` in place of `ktsubuild` and `jq` in the commands below.
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+"$KB" test list --workspace . > /tmp/projects.json || echo "EXIT NONZERO"
+cat /tmp/projects.json | "$JQ" -c '
+  {
+    include: [
+      .[]
+      | . as $p
+      | {
+          neutral: ["ubuntu-latest", "windows-latest", "macos-latest"],
+          windows: ["windows-latest"],
+          ios: ["macos-latest"]
+        }[$p.platform][]
+      | {
+          os: .,
+          project: $p.project,
+          name: ($p.project | split("/") | last | rtrimstr(".csproj")),
+          slug: ($p.project | rtrimstr(".csproj") | gsub("[^A-Za-z0-9]"; "-"))
+        }
+    ]
+  }' | "$JQ" '.include | length'
+```
+
+Expected: `42`. ImGuiApp has 14 test projects and all are `neutral`, so 14 × 3 = 42. If you get 14, the platform expansion is not expanding. If you get 0, the lookup returned null.
+
+Then check the slugs are unique, which is what keeps artifact names from colliding:
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+"$KB" test list --workspace . | "$JQ" -r '.[] | .project | rtrimstr(".csproj") | gsub("[^A-Za-z0-9]"; "-")' | sort | uniq -d
+```
+
+Expected: no output. Any line printed is a duplicate slug and a real bug.
+
+Also exercise the empty case, because a repo with no test projects must produce an empty matrix rather than an error:
+
+```bash
+echo '[]' | "$JQ" -c '{include: [.[] | . as $p | {neutral: ["ubuntu-latest","windows-latest","macos-latest"], windows: ["windows-latest"], ios: ["macos-latest"]}[$p.platform][] | {os: ., project: $p.project, name: ($p.project | split("/") | last | rtrimstr(".csproj")), slug: ($p.project | rtrimstr(".csproj") | gsub("[^A-Za-z0-9]"; "-"))}]}'
+```
+
+Expected: `{"include":[]}`.
+
+And confirm the unknown-platform guard fires, which is the check that prevents a silently smaller matrix:
+
+```bash
+echo '[{"project":"tests/A/A.csproj","platform":"solaris"}]' | "$JQ" -r '[.[] | select(.platform as $p | ["neutral","windows","ios"] | index($p) | not) | .platform] | unique | join(", ")'
+```
+
+Expected: `solaris`. If this prints nothing, the guard does not discriminate and would let an unknown platform through.
+
+Then run the same guard against the real project list, which is the positive control that stops the check from being vacuous:
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+"$KB" test list --workspace . | "$JQ" -r '[.[] | select(.platform as $p | ["neutral","windows","ios"] | index($p) | not) | .platform] | unique | join(", ")'
+```
+
+Expected: empty. A guard that fires on `solaris` and stays silent on real input is discriminating. One that fires on both, or neither, is not.
+
+- [ ] **Step 4: Validate the YAML parses**
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+python -c "import yaml,sys; d=yaml.safe_load(open('.github/workflows/dotnet.yml')); print('jobs:', list(d['jobs'].keys()))"
+```
+
+Expected: `jobs: ['discover', 'build', 'winget', 'security']`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+git checkout .editorconfig
+git add .github/workflows/dotnet.yml
+git commit -m "ci: add a job that discovers test projects into a matrix [patch]"
+```
+
+---
+
+### Task 2: Replace the build job with the test matrix
+
+**Files:**
+- Modify: `.github/workflows/dotnet.yml`
+
+**Interfaces:**
+- Consumes: `needs.discover.outputs.matrix` and `needs.discover.outputs.has_tests` from Task 1, and `matrix.os`, `matrix.project`, `matrix.name`, `matrix.slug` within each cell.
+- Produces: artifacts named `coverage-<slug>-<os>`, each containing that cell's `coverage/` directory, so the artifact root holds `coverage.xml` and `TestResults/`. Task 3 downloads them with the pattern `coverage-*` and must not merge them, because every one contains a file named `coverage.xml`.
+
+- [ ] **Step 1: Add the test job**
+
+Insert after `discover` and before the existing `build` job.
+
+```yaml
+  test:
+    name: Test ${{ matrix.name }} (${{ matrix.os }})
+    needs: discover
+    if: needs.discover.outputs.has_tests == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    strategy:
+      # One platform's failure must not cancel the others. Knowing that a project fails on
+      # macOS only is the point of running the matrix at all.
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          lfs: true
+          submodules: recursive
+
+      - name: Setup .NET SDK ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}.x
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/Directory.Packages.props
+            **/global.json
+
+      - name: Install KtsuBuild
+        shell: bash
+        run: |
+          dotnet tool install ktsu.KtsuBuild.Tool --tool-path "${{ runner.temp }}/ktsubuild"
+          echo "${{ runner.temp }}/ktsubuild" >> "$GITHUB_PATH"
+
+      # One test project per invocation. Besides parallelizing the suite, this removes the
+      # condition behind a coverage-collector flake that KtsuBuild otherwise retries around:
+      # the instrumentation pipe drops during teardown when several assemblies run together.
+      - name: Run Tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          ktsubuild test run --project "${{ matrix.project }}" --workspace "$GITHUB_WORKSPACE" --verbose
+
+      - name: Upload Coverage
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage-${{ matrix.slug }}-${{ matrix.os }}
+          path: ./coverage/*
+          retention-days: 7
+          if-no-files-found: warn
+```
+
+- [ ] **Step 2: Delete the old build job**
+
+Remove the entire `build:` job, from its `build:` key through the end of its `Upload Coverage Report` step, leaving `winget:` and `security:` in place. Task 3 adds the `release` job that takes over its remaining responsibilities.
+
+At the end of this step the workflow is deliberately broken: `winget` and `security` still say `needs: build`. Task 3 fixes that. Do not attempt to run CI between these two tasks.
+
+- [ ] **Step 3: Validate the YAML parses and the references resolve**
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+python -c "import yaml; d=yaml.safe_load(open('.github/workflows/dotnet.yml')); print('jobs:', list(d['jobs'].keys()))"
+```
+
+Expected: `jobs: ['discover', 'test', 'winget', 'security']`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+git checkout .editorconfig
+git add .github/workflows/dotnet.yml
+git commit -m "ci: fan tests out across platform and project [minor]"
+```
+
+---
+
+### Task 3: Add the release job and repoint the dependent jobs
+
+**Files:**
+- Modify: `.github/workflows/dotnet.yml`
+
+**Interfaces:**
+- Consumes: the `coverage-*` artifacts from Task 2, and `needs.discover.outputs.has_tests` from Task 1.
+- Produces: job outputs `version`, `release_hash`, `should_release`, consumed by `winget` and `security`.
+
+- [ ] **Step 1: Add the release job**
+
+Insert after `test` and before `winget`. This job keeps `windows-latest`, which is what the deleted `build` job used. The spec's Revisions section explains why: `GetBuildableProjects` filters by host, so a Linux release job would build and publish fewer projects in any repo that has a Windows-tied target framework, and this file reaches sixty repos.
+
+The first eight steps are byte-identical to the deleted `build` job's, including the `Install KtsuBuild` step, which this job needs just as much as the matrix cells do. They are reproduced in full below rather than referenced, because a silently dropped setup step fails late and confusingly.
+
+```yaml
+  release:
+    name: Analyze & Release
+    needs: [discover, test]
+    # `always()` is required because `test` is skipped when a repo has no test projects, and a
+    # skipped dependency would otherwise skip this job too. The explicit result checks are what
+    # keep a genuine test failure from releasing anyway.
+    if: |
+      always()
+      && needs.discover.result == 'success'
+      && (needs.test.result == 'success' || needs.test.result == 'skipped')
+    runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write # For creating releases and committing metadata
+      packages: write # For publishing packages
+
+    outputs:
+      version: ${{ steps.pipeline.outputs.version }}
+      release_hash: ${{ steps.pipeline.outputs.release_hash }}
+      should_release: ${{ steps.pipeline.outputs.should_release }}
+
+    steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: "zulu" # Alternative distribution options are available.
+
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # Full history for versioning
+          fetch-tags: true
+          lfs: true
+          submodules: recursive
+          persist-credentials: true
+
+      - name: Setup .NET SDK ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}.x
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/Directory.Packages.props
+            **/global.json
+
+      # Ensure NuGet packages directory exists for caching (prevents error when pipeline exits early)
+      - name: Ensure NuGet cache directory exists
+        run: New-Item -Path "$env:USERPROFILE\.nuget\packages" -ItemType Directory -Force
+        shell: pwsh
+
+      - name: Cache SonarQube Cloud packages
+        if: ${{ env.SONAR_TOKEN != '' }}
+        uses: actions/cache@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache SonarQube Cloud scanner
+        if: ${{ env.SONAR_TOKEN != '' }}
+        id: cache-sonar-scanner
+        uses: actions/cache@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          path: .\.sonar\scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+
+      - name: Install SonarQube Cloud scanner
+        if: ${{ env.SONAR_TOKEN != '' && steps.cache-sonar-scanner.outputs.cache-hit != 'true' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: pwsh
+        run: |
+          New-Item -Path .\.sonar\scanner -ItemType Directory
+          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+
+      - name: Install KtsuBuild
+        shell: pwsh
+        run: |
+          dotnet tool install ktsu.KtsuBuild.Tool --tool-path "${{ runner.temp }}/ktsubuild"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "${{ runner.temp }}/ktsubuild" >> $env:GITHUB_PATH
+
+      # Every cell wrote a file named coverage.xml, so the downloads must stay in their own
+      # per-artifact directories. Merging them would leave one file and report the coverage of
+      # a single test project as though it were the whole repository's.
+      - name: Download Coverage
+        if: needs.discover.outputs.has_tests == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          pattern: coverage-*
+          path: coverage
+
+      - name: Begin SonarQube
+        if: ${{ env.SONAR_TOKEN != '' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: pwsh
+        run: |
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"${{ github.repository_owner }}_${{ github.event.repository.name }}" /o:"${{ github.repository_owner }}" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.projectBaseDir="${{ github.workspace }}" /d:sonar.cs.vscoveragexml.reportsPaths="coverage/**/coverage.xml" /d:sonar.coverage.exclusions="**/*Test*.cs,**/*.Tests.cs,**/*.Tests/**/*,**/obj/**/*,**/*.dll,**/NativeExports.cs" /d:sonar.cs.vstest.reportsPaths="coverage/**/*.trx" /d:sonar.exclusions="**/NativeExports.cs"
+
+      # `ci` rather than restore and build directly, because it is the only place that updates
+      # and commits the metadata files, updates the repository topics, applies the version gate
+      # behind `[skip ci]`, and writes the step outputs the winget and security jobs read.
+      # The tests already ran in the matrix, and the release waits for the quality gate below.
+      - name: Run KtsuBuild Pipeline
+        id: pipeline
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUGET_API_KEY: ${{ secrets.NUGET_KEY }}
+          KTSU_PACKAGE_KEY: ${{ secrets.KTSU_PACKAGE_KEY }}
+          EXPECTED_OWNER: ktsu-dev
+        run: |
+          $versionBump = "${{ github.event.inputs.version-bump }}"
+
+          $args = @("ci", "--workspace", "${{ github.workspace }}", "--no-test", "--no-release", "--verbose")
+          if (![string]::IsNullOrEmpty($versionBump) -and $versionBump -ne "auto") {
+            $args += @("--version-bump", $versionBump)
+          }
+
+          & ktsubuild @args
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: End SonarQube
+        if: env.SONAR_TOKEN != '' && steps.pipeline.outputs.build_skipped != 'true'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: pwsh
+        run: |
+          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="$env:SONAR_TOKEN"
+
+      # After the gate, not before. A failed quality gate fails the step above and this never
+      # runs, which is a deliberate change from the old shape where `ci` released first and
+      # Sonar reported afterward.
+      - name: Release
+        if: steps.pipeline.outputs.should_release == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUGET_API_KEY: ${{ secrets.NUGET_KEY }}
+          KTSU_PACKAGE_KEY: ${{ secrets.KTSU_PACKAGE_KEY }}
+          EXPECTED_OWNER: ktsu-dev
+        run: |
+          ktsubuild release --workspace "${{ github.workspace }}" --verbose
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage-report
+          path: |
+            ./coverage/*
+          retention-days: 7
+          if-no-files-found: ignore
+```
+
+- [ ] **Step 2: Repoint winget and security**
+
+In both jobs, change `needs: build` to `needs: release`, and change every `needs.build.outputs.` to `needs.release.outputs.`. There are two such references in each job: `should_release` in the `if:`, and `release_hash` in the checkout `ref:`.
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+grep -n "needs: build\|needs.build.outputs" .github/workflows/dotnet.yml
+```
+
+Expected before the edit: four lines. Expected after: no output.
+
+- [ ] **Step 3: Verify no reference to the deleted job survives**
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+grep -n "needs.build\|needs: build" .github/workflows/dotnet.yml && echo "STALE REFERENCE FOUND" || echo "clean"
+python -c "
+import yaml
+d = yaml.safe_load(open('.github/workflows/dotnet.yml'))
+jobs = d['jobs']
+print('jobs:', list(jobs.keys()))
+for name, job in jobs.items():
+    needs = job.get('needs')
+    print(' ', name, '<- needs:', needs)
+    for dep in ([needs] if isinstance(needs, str) else (needs or [])):
+        assert dep in jobs, f'{name} needs missing job {dep}'
+print('all needs resolve')
+"
+```
+
+Expected: `clean`, then the five jobs `discover`, `test`, `release`, `winget`, `security`, then `all needs resolve`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+git checkout .editorconfig
+git add .github/workflows/dotnet.yml
+git commit -m "ci: analyze and release after the matrix, gated on the quality gate [minor]"
+```
+
+---
+
+### Task 4: Validate on a branch
+
+The spec is explicit that CI changes cannot be proven by reasoning about YAML. This task is the proof, and it is the reason the plan exists in a repo rather than in a template.
+
+**Files:** none.
+
+- [ ] **Step 1: Push and start a run**
+
+The workflow's triggers are `push` on `main` and `develop`, and `pull_request`. A push to a feature branch fires neither, so opening the pull request is what starts the run.
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+git push -u origin feat/ci-parallel-test-matrix
+gh pr create --base main --head feat/ci-parallel-test-matrix \
+  --title "Fan CI tests out across platforms and projects" \
+  --body "Replaces the serial windows-latest test run with a discover, matrix, release shape. Validation results are recorded in the plan's task 4."
+```
+
+- [ ] **Step 2: Watch the run and record what happened**
+
+Capture the run id once and reuse it, since every check below needs it.
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+RUN_ID=$(gh run list --branch feat/ci-parallel-test-matrix --workflow ".NET Workflow" --limit 1 --json databaseId --jq '.[0].databaseId')
+echo "RUN_ID=$RUN_ID"
+gh run watch "$RUN_ID" --exit-status
+```
+
+`gh run watch` exits non-zero when the run fails. A failure here is information, not a reason to stop: read the failing job's log and fix the workflow, because that is what this task is for.
+
+- [ ] **Step 3: Confirm each of the spec's five validation claims, by evidence**
+
+Record the actual numbers. Each of these has a specific failure it is looking for.
+
+1. **The matrix expanded to the real projects.** Read the `discover` job's log and confirm it printed 42 cells for ImGuiApp (14 projects × 3 platforms). A count of 14 means the platform expansion failed. A count of 0 means discovery failed and the run is testing nothing.
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+gh run view "$RUN_ID" --log --job "$(gh run view "$RUN_ID" --json jobs --jq '.jobs[] | select(.name=="Discover Test Projects") | .databaseId')" | grep -E "Matrix has|Discovered"
+```
+
+2. **The reported test counts match what the projects produce locally.** This is the check the spec calls the design's most exposed failure. Pick three cells, including one `*.UITests` project, and compare the count in the CI log against a local run:
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+ktsubuild test run --project tests/ImGuiWidgetsDemo.UITests/ImGuiWidgetsDemo.UITests.csproj --workspace . 2>&1 | grep -E "total:|succeeded:"
+```
+
+A CI cell reporting `total: 0` while passing is the exact failure `--nologo` causes and the reason it is banned. If any cell reports zero tests, stop and investigate rather than accepting a green run.
+
+3. **SonarCloud received coverage from all three platforms.** Confirm the `End SonarQube` step logged the number of coverage files it imported, and that the SonarCloud project page reports a coverage figure comparable to the last `main` run. A figure far below the previous one means the fan-in globbed nothing and Sonar treated the unmatched files as uncovered.
+
+4. **The release job did not publish from a pull request.** Confirm `should_release` was `false` and the `Release` step was skipped, while `Begin`/`End SonarQube` still ran. A PR run must analyze without publishing.
+
+5. **Wall clock is under the cap with room to spare.** Record the total run duration and the slowest single cell.
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+gh run view "$RUN_ID" --json jobs --jq '.jobs[] | {name, startedAt, completedAt, conclusion}'
+```
+
+- [ ] **Step 4: Write the numbers into the spec**
+
+The spec's Sequence step 3 says to sync to the other repos "once the numbers from step 2 are known". Record them so that decision has evidence:
+
+Append a `## Measured` section to `docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md` giving the cell count, the total wall clock, the slowest cell, the SonarCloud coverage figure before and after, and the runner minutes consumed. State plainly whether the blast-radius trade the spec worried about looks acceptable for a small repo, since that is what gates the sync.
+
+```bash
+cd /c/dev/ktsu-dev/ImGuiApp
+git checkout .editorconfig
+git add docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
+git commit -m "docs: record the measured results of the parallel test matrix [patch]"
+git push
+```
+
+- [ ] **Step 5: Stop and report**
+
+Merging is the repository owner's call, and so is syncing this file to the other repos. Report the five validation results with their numbers, and say explicitly whether any of them fell short.
+
+---
+
+## Notes carried in from the KtsuBuild work
+
+- `ktsubuild test list` reports 14 test projects for ImGuiApp, not 15. `ImGui.App.iOS.SmokeTest` is a console executable with no test framework and is correctly excluded, and `ios.yml` runs it separately on a simulator.
+- `test run` passes the project path positionally to `dotnet test`. A path that does not exist reports zero tests rather than failing, which is why the matrix must come from `test list` rather than from hand-written paths.
+- `ci --no-test` does not suppress the iOS validation build, because that is a build rather than a test. The release job runs on Windows, where it reports the detected heads and skips.
+- NuGet has two indexes and they lag apart. Releasing 2.3.0, the package blob reached the flat container after 210 seconds but `dotnet tool install` could not resolve it for roughly another 30. An unpinned `dotnet tool install` picks up the latest resolvable version, which is what the workflow does today and should keep doing.

--- a/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
+++ b/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
@@ -134,3 +134,31 @@ Dropping the step outputs would have silently disabled the `winget` and `securit
 ## Out of scope
 
 The iOS workflow, the winget job, the dependabot-merge workflow, and any change to what `ktsubuild ci` does — it stays as it is for repos that haven't moved.
+
+## Measured
+
+Measured on PR #325, run 32577299711, the first green run of the restructured workflow. macOS is excluded from this matrix, see issue #327, so these figures cover Linux and Windows only.
+
+**Shape.** 14 test projects, 2 platforms, 28 cells. Discovery took 0.2 minutes. No failures.
+
+**Wall clock: 24.2 minutes, against 13.6 to 19.9 for the old serial job.** End to end the restructure is slower, not faster, and the reason is visible in the breakdown: the slowest cell is 15.8 minutes and the release job adds another 8.1 after the matrix finishes, where previously everything shared one 20 minute job.
+
+What the restructure did fix is the failure that prompted it. The old job died on its own `timeout-minutes: 20`. No cell now approaches its 30 minute limit, so runs stop being cancelled. That was the emergency. The wall clock improvement the design expected did not materialize.
+
+**One project dominates.** `ImGuiWidgetsDemo.UITests` takes 15.8 minutes on Windows by itself, and `ImGuiAppDemo.UITests` 14.5. The design's premise, that wall clock becomes the slowest single project rather than the sum, holds exactly. The constant is simply much larger than this document assumed when it estimated the five demo suites at roughly 9.6 minutes in total.
+
+**Build duplication is the bulk of the cost.** Every cell restores and builds before testing. On Windows the cheapest cell still costs several minutes while doing almost no testing, so most of the 84.5 Windows cell-minutes is the same tree being rebuilt 14 times.
+
+| Platform | Cells | Cell minutes | Billed, at GitHub's multipliers |
+| --- | --- | --- | --- |
+| ubuntu-latest | 14 | 24.4 | ~24 |
+| windows-latest | 14 | 84.5 | ~169 |
+| Total | 28 | 108.9 | ~193 |
+
+Against roughly 30 to 40 billed minutes for the old single Windows job, that is close to a fivefold increase with macOS already removed. The earlier run including macOS came to roughly 375 billed minutes, and its macOS cells failed within a minute, so a working macOS leg would cost far more than that figure suggests.
+
+**Coverage fan-in works.** SonarCloud parsed coverage from both platforms in equal numbers and imported 28 trx files for 28 cells, confirming the `coverage/**/coverage.xml` glob matches the per-artifact directory layout rather than collapsing to one file.
+
+**A pull request run analyzes without publishing.** `Begin SonarQube` and `End SonarQube` both ran, `Download Coverage` succeeded, and `Release` was correctly skipped. `End SonarQube` succeeded with `sonar.qualitygate.wait=true` now set, so the gate is genuinely being waited on rather than reported after the fact.
+
+**Conclusion on the blast-radius question this document raised.** The trade does not look good for a small repo on these numbers. A repo with two test projects would pay four builds and four runner starts to parallelize work that took two minutes serially, and would get slower end to end once job startup is counted, exactly as feared. Recommend not syncing this shape to the other repos until the build duplication is removed. The lever this document already described, building once per platform and having that platform's cells download the output, is what removes it, and it now has numbers behind it. That lever needs `ktsubuild test run` to grow a `--no-build` option first, because the command currently always builds and offers no pass-through for extra arguments.

--- a/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
+++ b/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
@@ -1,0 +1,92 @@
+# CI: parallel test matrix across platforms
+
+Restructures `.github/workflows/dotnet.yml` so tests fan out across platforms and projects instead of running serially on one Windows runner. The immediate reason is that CI already fails: two runs were cancelled at the 20-minute cap, including the merge of PR #322.
+
+This file is propagated to every ktsu repo by `ktsu sync`, so the design has to work for a repo with one test project as well as one with ten.
+
+## The problem
+
+`ktsubuild ci` runs restore, build, and every test project in sequence on `windows-latest`, inside a job capped at 20 minutes. Merging the five demo UI test projects added 107 headless tests. Measured against `ImGuiMarkdownDemo.UITests`, those cost about 5.4 seconds each — roughly 9.6 minutes of new work in a job that already ran 13.6 to 19.9 minutes.
+
+The cap can't simply be raised. It's the wrong shape: everything is serial, one platform is tested, and the budget is shared between building, testing, analysis, and release.
+
+## Decisions
+
+**Stop calling `ktsubuild ci`; call restore, build, and test directly.** `CiCommand` is a thin orchestrator — version, restore, build, test, release — with no way to skip or scope the test step. Calling the parts directly lets the workflow decide what runs where. `ktsubuild release` still handles pack, publish, and release, so no release automation is lost.
+
+**Fan out over platform × test project.** Each cell restores, builds, and runs one test project on one platform. This is what fixes the timeout: each cell carries its own budget, and the wall clock becomes the slowest single project rather than the sum of all of them.
+
+**Each cell is self-contained. No build artifacts move between jobs.** An earlier shape built once on Linux and shipped the output to every platform. It doesn't work: `dotnet test --no-build` reads `obj/project.assets.json`, which holds absolute paths into the NuGet cache, and `/home/runner/.nuget/packages` doesn't exist on a Windows runner. Working around that means either running assemblies directly or restoring on every leg, and both are more machinery than a rebuild is worth. A build costs a minute or two against nine minutes of UI tests.
+
+**Test on Linux, Windows, and macOS on every run.** Cost isn't the binding constraint — self-hosted runners are available if the minutes bite — so the matrix runs on every trigger rather than being gated to `main`. A dependabot bump that breaks only on Windows is caught by the bump, not by the merge.
+
+**One Sonar analysis, in the release job.** SonarCloud replaces the previous analysis for a project key rather than merging, so a Sonar block inside each cell would submit 15 competing analyses of the same project. Whichever finished last would win and report every project it didn't run as uncovered. Instead each cell uploads its coverage XML, and one job imports them all.
+
+**Sonar and release are one job.** Both need a build on Linux, so merging them saves one. Pack and push run after `sonarscanner end`, which means a failed quality gate stops the release — a change from today, where `ktsubuild ci` releases first and Sonar reports afterward. A release that fails the project's own quality bar is worth stopping, and nothing has consumed it at that point.
+
+## Job graph
+
+```
+discover (ubuntu)   list test projects -> matrix JSON
+
+test (matrix: {ubuntu, windows, macos} x N projects)
+                    restore -> build -> test one project
+                    upload coverage-<platform>-<project>.xml
+
+release (ubuntu, needs: test)
+                    sonar begin -> restore -> build -> sonar end (imports coverage)
+                    -> ktsubuild release   [only when the release condition holds]
+
+winget (windows, needs: release)    unchanged
+ios (separate workflow)             unchanged
+```
+
+With three platforms and N test projects the matrix runs 3N builds, plus one in the release job. For ImGuiApp that's 30 plus 1 rather than the single build today. Wall clock doesn't suffer, because they're parallel, but the runner minutes are real.
+
+The lever, if that cost bites before self-hosted runners land: build once per platform and have that platform's test cells download its output. The transfer is same-OS, so the `project.assets.json` paths still resolve and none of the cross-platform problems return. It trades 3N builds for 3 builds plus 3N artifact round-trips, and it reintroduces artifact machinery this design deliberately avoided. Not worth doing until the numbers say so.
+
+## Discovering the test projects
+
+The matrix can't be hardcoded, because this file lands in every ktsu repo. A `discover` job lists the projects in the solution and selects the test ones by the rules `KtsuBuild.DotNetService.IsTestProject` already uses: a file or directory name ending in `.Test` or `.Tests`, a directory named exactly `Test` or `Tests`, or project content containing `<IsTestProject>true</IsTestProject>`, `Sdk="Microsoft.NET.Sdk.Test"`, or an MSTest SDK reference.
+
+That last clause matters here: the five `*.UITests` projects match on content, not on name.
+
+**Two implementations of one rule is the failure this repo has already paid for.** The preferred fix is a `ktsubuild list-test-projects --json` command, so the workflow and the build tool share one definition. Until that exists, the discovery step reimplements the rule in PowerShell, and drift between the two is a recorded risk rather than a surprise.
+
+When the solution has no test projects, `discover` emits an empty matrix and the test job is skipped. The release job must not require a non-empty matrix.
+
+## Running the tests
+
+Each cell runs `dotnet test <project> --coverage --coverage-output-format xml`, scoped to a single project.
+
+**Do not pass `--nologo`.** It makes the runner report `total: 0` with exit code 5 while every test passes — verified on 2026-08-21 against `ImageGui.Core.Tests`, which reports 163 passing without the flag and zero with it. A CI step that passes it looks green and tests nothing.
+
+Fanning out also sidesteps a flake that `KtsuBuild` currently retries around: the Microsoft.CodeCoverage collector intermittently drops its instrumentation IPC pipe during teardown when several test assemblies run in one invocation, surfacing as exit code 7 despite every test passing. One assembly per invocation removes the condition rather than retrying it.
+
+## Risks
+
+**Rule drift in test discovery.** The workflow's PowerShell filter and `KtsuBuild.IsTestProject` must agree. If they diverge, a project silently stops being tested — the failure is invisible, because a skipped project reports nothing. Closing this properly means the `ktsubuild list-test-projects` command above.
+
+**Platform-tied projects can't build everywhere.** `GetBuildableProjects` exists because some projects are tied to a host: iOS needs macOS, `net10.0-windows` needs Windows. ImGuiApp has no Windows-tied targets, and its iOS targets are added conditionally on macOS hosts and covered by a separate workflow. Across sixty repos that won't hold universally.
+
+Handle it at discovery, not in the cell. The `discover` job classifies each test project the way `GetProjectPlatform` does — neutral, Windows, or iOS — and emits the platform pairs that can actually build, so a Windows-only test project produces one cell rather than three, two of which fail. A cell that skips its own work reports green while testing nothing, which is the failure mode this whole design is trying to remove.
+
+**Blast radius.** This restructure reaches every ktsu repo on the next `ktsu sync`. A repo with two test projects pays six builds and six runner starts to parallelize work that took two minutes serially, and gets slower in wall clock once job startup is counted. The shape is right for repos with heavy suites and mildly negative for small ones — which is most of them. Worth deciding whether that trade holds org-wide before syncing, rather than after.
+
+**Quality gate now blocks release.** Deliberate, and a behavior change. A SonarCloud outage would stop publishing; `continue-on-error` on the `end` step is the escape hatch if that ever happens.
+
+**macOS runner cost.** Billed at a premium relative to Linux. Named here so that moving the matrix to self-hosted runners is a planned response rather than a reaction to a bill.
+
+## Validating it
+
+CI changes can't be proven by reasoning about YAML. Before this syncs anywhere:
+
+- Run it on a branch in ImGuiApp and confirm the matrix expands to 3 platforms × the real test projects.
+- Confirm the reported test counts match what the projects produce locally. A step that runs no tests and exits zero is the specific failure this design is most exposed to.
+- Confirm SonarCloud receives coverage from all three platforms' uploads and reports a figure comparable to today's.
+- Confirm the release job runs `ktsubuild release` only under the existing release condition, and that a PR run analyses without publishing.
+- Confirm the wall clock is under the cap with room to spare, and record the number.
+
+## Out of scope
+
+The iOS workflow, the winget job, the dependabot-merge workflow, and any change to `KtsuBuild` beyond the `list-test-projects` command named above as the preferred fix for rule drift.

--- a/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
+++ b/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
@@ -22,7 +22,7 @@ The cap can't simply be raised. It's the wrong shape: everything is serial, one 
 
 **One Sonar analysis, in the release job.** SonarCloud replaces the previous analysis for a project key rather than merging, so a Sonar block inside each cell would submit 15 competing analyses of the same project. Whichever finished last would win and report every project it didn't run as uncovered. Instead each cell uploads its coverage XML, and one job imports them all.
 
-**Sonar and release are one job.** Both need a build on Linux, so merging them saves one. Pack and push run after `sonarscanner end`, which means a failed quality gate stops the release — a change from today, where `ktsubuild ci` releases first and Sonar reports afterward. A release that fails the project's own quality bar is worth stopping, and nothing has consumed it at that point.
+**Sonar and release are one job, and it stays on `windows-latest`.** (Revised 2026-08-21, see Revisions.) Both need a build, so merging them saves a job. Pack and push run after `sonarscanner end`, which means a failed quality gate stops the release — a change from today, where `ktsubuild ci` releases first and Sonar reports afterward. A release that fails the project's own quality bar is worth stopping, and nothing has consumed it at that point.
 
 ## Job graph
 
@@ -33,7 +33,7 @@ test (matrix: {ubuntu, windows, macos} x N projects)
                     restore -> build -> test one project
                     upload coverage-<platform>-<project>.xml
 
-release (ubuntu, needs: test)
+release (windows, needs: discover + test)
                     download every coverage artifact
                     sonar begin
                     -> ktsubuild ci --no-test --no-release
@@ -120,6 +120,8 @@ CI changes can't be proven by reasoning about YAML. Before this syncs anywhere:
 **2026-08-21, the release job.** The original decision to stop calling `ktsubuild ci` rested on the claim that "`ktsubuild release` still handles pack, publish, and release, so no release automation is lost." Reading `CiCommand` against `ReleaseCommand` showed that false. `ci` does five things `release` does not: update and commit the metadata files, update the repository topics from TAGS.md, gate the release on the version increment (which is how `[skip ci]` works), honor a forced version bump, and write the four step outputs. `ReleaseService.ExecuteReleaseAsync` packs, publishes, and creates the GitHub release unconditionally once called, gated only on `ShouldRelease`, which means "on main, untagged, official repo" and nothing about whether the version moved.
 
 Dropping the step outputs would have silently disabled the `winget` and `security` jobs, since both gate on `should_release`. That is the failure mode this design exists to remove, so `ci` stays and gained two skip flags instead. Shipped in `ktsu.KtsuBuild.Tool` 2.3.0.
+
+**2026-08-21, the release job's runner.** The original graph put it on ubuntu. Keeping it on `windows-latest`, which is what runs today, for two reasons. `GetBuildableProjects` filters by host, so a Linux release job would build and publish a smaller set of projects than today in any repo holding a Windows-tied target framework, and this file reaches sixty repos verbatim. ImGuiApp itself has none (its only host-tied projects are iOS ones, conditional on a macOS host), but the repos it syncs to were not surveyed. Staying on Windows also leaves the existing SonarCloud cache and scanner steps untouched, since they are written in PowerShell with Windows paths. The cost is one Windows runner instead of one Linux runner, against a 3N matrix where the test cells dominate.
 
 **2026-08-21, the `security` job.** The original job graph omitted it. It exists, it is `needs: build`, and it consumes the same two outputs `winget` does.
 

--- a/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
+++ b/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
@@ -45,19 +45,34 @@ With three platforms and N test projects the matrix runs 3N builds, plus one in 
 
 The lever, if that cost bites before self-hosted runners land: build once per platform and have that platform's test cells download its output. The transfer is same-OS, so the `project.assets.json` paths still resolve and none of the cross-platform problems return. It trades 3N builds for 3 builds plus 3N artifact round-trips, and it reintroduces artifact machinery this design deliberately avoided. Not worth doing until the numbers say so.
 
-## Discovering the test projects
+## Extending ktsubuild rather than working around it
 
-The matrix can't be hardcoded, because this file lands in every ktsu repo. A `discover` job lists the projects in the solution and selects the test ones by the rules `KtsuBuild.DotNetService.IsTestProject` already uses: a file or directory name ending in `.Test` or `.Tests`, a directory named exactly `Test` or `Tests`, or project content containing `<IsTestProject>true</IsTestProject>`, `Sdk="Microsoft.NET.Sdk.Test"`, or an MSTest SDK reference.
+The workflow needs three things `ktsubuild` doesn't expose yet. All three are already implemented inside it — they're just not reachable from a command line. Reimplementing them in the workflow would put a second copy of each rule in a YAML file, and the second copy is the one that goes stale.
 
-That last clause matters here: the five `*.UITests` projects match on content, not on name.
+**`ktsubuild test list --json`** emits the test projects with the platform each is tied to:
 
-**Two implementations of one rule is the failure this repo has already paid for.** The preferred fix is a `ktsubuild list-test-projects --json` command, so the workflow and the build tool share one definition. Until that exists, the discovery step reimplements the rule in PowerShell, and drift between the two is a recorded risk rather than a surprise.
+```json
+[
+  { "project": "tests/ImGui.Widgets.Tests/ImGui.Widgets.Tests.csproj", "platform": "neutral" },
+  { "project": "tests/ImGui.App.iOS.SmokeTest/ImGui.App.iOS.SmokeTest.csproj", "platform": "ios" }
+]
+```
 
-When the solution has no test projects, `discover` emits an empty matrix and the test job is skipped. The release job must not require a non-empty matrix.
+`DotNetService.IsTestProject` and `GetProjectPlatform` already produce both fields. The `discover` job turns this into the matrix, expanding neutral projects across all three platforms and platform-tied ones only onto hosts that can build them.
+
+Detection matters more than it looks: the five `*.UITests` projects don't end in `.Test` or `.Tests`, so they match only on project content. A name-based filter in YAML would silently drop all 107 tests — green, and testing nothing.
+
+**`ktsubuild test run --project <path>`** runs one project with the coverage flags the pipeline already uses, instead of the workflow assembling a `dotnet test` invocation of its own. `TestAsync` takes the project list already; this exposes a scoped call.
+
+**`ktsubuild build --no-test`** restores and builds without testing, for the release job, which needs a compilation between `sonarscanner begin` and `end` but runs no tests.
+
+Each is a thin command over existing service methods. None changes what `ci` does, so repos still on `ci` are unaffected.
+
+When a solution has no test projects, `test list` emits an empty array, the matrix is empty, and the test job is skipped. The release job must not require a non-empty matrix.
 
 ## Running the tests
 
-Each cell runs `dotnet test <project> --coverage --coverage-output-format xml`, scoped to a single project.
+Each cell runs `ktsubuild test run --project <path>`, which applies the same coverage flags the current pipeline uses.
 
 **Do not pass `--nologo`.** It makes the runner report `total: 0` with exit code 5 while every test passes — verified on 2026-08-21 against `ImageGui.Core.Tests`, which reports 163 passing without the flag and zero with it. A CI step that passes it looks green and tests nothing.
 
@@ -65,7 +80,7 @@ Fanning out also sidesteps a flake that `KtsuBuild` currently retries around: th
 
 ## Risks
 
-**Rule drift in test discovery.** The workflow's PowerShell filter and `KtsuBuild.IsTestProject` must agree. If they diverge, a project silently stops being tested — the failure is invisible, because a skipped project reports nothing. Closing this properly means the `ktsubuild list-test-projects` command above.
+**The workflow can't use commands that aren't published yet.** CI installs the tool with `dotnet tool install ktsu.KtsuBuild.Tool`, so the three new commands must be released to nuget.org before any repo's workflow calls them. That makes this a two-repo delivery in a fixed order: extend and release KtsuBuild, then restructure the workflow. A workflow synced ahead of the tool release fails everywhere at once.
 
 **Platform-tied projects can't build everywhere.** `GetBuildableProjects` exists because some projects are tied to a host: iOS needs macOS, `net10.0-windows` needs Windows. ImGuiApp has no Windows-tied targets, and its iOS targets are added conditionally on macOS hosts and covered by a separate workflow. Across sixty repos that won't hold universally.
 
@@ -87,6 +102,12 @@ CI changes can't be proven by reasoning about YAML. Before this syncs anywhere:
 - Confirm the release job runs `ktsubuild release` only under the existing release condition, and that a PR run analyses without publishing.
 - Confirm the wall clock is under the cap with room to spare, and record the number.
 
+## Sequence
+
+1. `KtsuBuild`: add `test list --json`, `test run --project`, and `build --no-test`. Release to nuget.org.
+2. `ImGuiApp`: restructure `dotnet.yml` against the released tool. Validate on a branch.
+3. Sync to the other repos once the numbers from step 2 are known.
+
 ## Out of scope
 
-The iOS workflow, the winget job, the dependabot-merge workflow, and any change to `KtsuBuild` beyond the `list-test-projects` command named above as the preferred fix for rule drift.
+The iOS workflow, the winget job, the dependabot-merge workflow, and any change to what `ktsubuild ci` does — it stays as it is for repos that haven't moved.

--- a/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
+++ b/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
@@ -12,7 +12,7 @@ The cap can't simply be raised. It's the wrong shape: everything is serial, one 
 
 ## Decisions
 
-**Stop calling `ktsubuild ci`; call restore, build, and test directly.** `CiCommand` is a thin orchestrator — version, restore, build, test, release — with no way to skip or scope the test step. Calling the parts directly lets the workflow decide what runs where. `ktsubuild release` still handles pack, publish, and release, so no release automation is lost.
+**Keep calling `ktsubuild ci`, with its two new skip flags.** (Revised 2026-08-21. The original decision was to stop calling `ci` and invoke restore, build, and test directly, on the grounds that `ktsubuild release` covered everything else. That was wrong, and the correction is recorded under Revisions.) The release job runs `ktsubuild ci --no-test --no-release` inside the SonarCloud begin and end window, then `ktsubuild release` after the gate passes. `ci` remains the only place that updates and commits the metadata files, updates the repository topics, applies the version gate that makes `[skip ci]` work, honors a forced version bump, and writes the `version`, `release_hash`, `should_release`, and `build_skipped` step outputs.
 
 **Fan out over platform × test project.** Each cell restores, builds, and runs one test project on one platform. This is what fixes the timeout: each cell carries its own budget, and the wall clock becomes the slowest single project rather than the sum of all of them.
 
@@ -34,12 +34,19 @@ test (matrix: {ubuntu, windows, macos} x N projects)
                     upload coverage-<platform>-<project>.xml
 
 release (ubuntu, needs: test)
-                    sonar begin -> restore -> build -> sonar end (imports coverage)
-                    -> ktsubuild release   [only when the release condition holds]
+                    download every coverage artifact
+                    sonar begin
+                    -> ktsubuild ci --no-test --no-release
+                       (metadata, topics, version gate, restore, build, step outputs)
+                    -> sonar end (imports the downloaded coverage)
+                    -> ktsubuild release   [if should_release == 'true']
 
-winget (windows, needs: release)    unchanged
-ios (separate workflow)             unchanged
+winget   (windows, needs: release)  unchanged apart from where it reads its outputs
+security (windows, needs: release)  unchanged apart from where it reads its outputs
+ios      (separate workflow)        unchanged
 ```
+
+`winget` and `security` both gate on `should_release` and both check out `release_hash`. Today they read those from the `build` job. They must be repointed at whichever job replaces it, or they stop running and report nothing.
 
 With three platforms and N test projects the matrix runs 3N builds, plus one in the release job. For ImGuiApp that's 30 plus 1 rather than the single build today. Wall clock doesn't suffer, because they're parallel, but the runner minutes are real.
 
@@ -64,7 +71,9 @@ Detection matters more than it looks: the five `*.UITests` projects don't end in
 
 **`ktsubuild test run --project <path>`** runs one project with the coverage flags the pipeline already uses, instead of the workflow assembling a `dotnet test` invocation of its own. `TestAsync` takes the project list already; this exposes a scoped call.
 
-**`ktsubuild build --no-test`** restores and builds without testing, for the release job, which needs a compilation between `sonarscanner begin` and `end` but runs no tests.
+**`ktsubuild build --no-test`** restores and builds without testing. Shipped in 2.2.0, and useful generally, though the release job uses `ci --no-test --no-release` instead so that it keeps the metadata, version-gate, and step-output behavior that lives only in `ci`.
+
+**`ktsubuild ci --no-test` and `ktsubuild ci --no-release`** run the full pipeline while suppressing one step each. `--no-release` suppresses this run's release without changing what the `should_release` output reports, because the job reading that output is the one performing the release. Shipped in 2.3.0.
 
 Each is a thin command over existing service methods. None changes what `ci` does, so repos still on `ci` are unaffected.
 
@@ -86,6 +95,10 @@ Fanning out also sidesteps a flake that `KtsuBuild` currently retries around: th
 
 Handle it at discovery, not in the cell. The `discover` job classifies each test project the way `GetProjectPlatform` does — neutral, Windows, or iOS — and emits the platform pairs that can actually build, so a Windows-only test project produces one cell rather than three, two of which fail. A cell that skips its own work reports green while testing nothing, which is the failure mode this whole design is trying to remove.
 
+**The synced file propagates verbatim.** `ktsu sync` hashes every copy of a filename across the tree and propagates whichever group is chosen, so the restructured workflow reaches sixty repos byte for byte. Nothing in it may be specific to ImGuiApp: no hardcoded project names, no hardcoded test counts, no repo name outside the expressions GitHub already substitutes. The matrix has to be discovered at runtime for correctness, not only for elegance.
+
+**NuGet has two indexes and they lag apart.** Verified on 2026-08-21 releasing 2.3.0: the package blob appeared in nuget.org's flat container 210 seconds after the GitHub release, but `dotnet tool install` still could not resolve it, and needed roughly another 30 seconds for the registration index the client reads. A workflow synced immediately after a tool release can fail to resolve a version whose release page already says published. The install step should tolerate that rather than fail the run outright.
+
 **Blast radius.** This restructure reaches every ktsu repo on the next `ktsu sync`. A repo with two test projects pays six builds and six runner starts to parallelize work that took two minutes serially, and gets slower in wall clock once job startup is counted. The shape is right for repos with heavy suites and mildly negative for small ones — which is most of them. Worth deciding whether that trade holds org-wide before syncing, rather than after.
 
 **Quality gate now blocks release.** Deliberate, and a behavior change. A SonarCloud outage would stop publishing; `continue-on-error` on the `end` step is the escape hatch if that ever happens.
@@ -101,6 +114,14 @@ CI changes can't be proven by reasoning about YAML. Before this syncs anywhere:
 - Confirm SonarCloud receives coverage from all three platforms' uploads and reports a figure comparable to today's.
 - Confirm the release job runs `ktsubuild release` only under the existing release condition, and that a PR run analyses without publishing.
 - Confirm the wall clock is under the cap with room to spare, and record the number.
+
+## Revisions
+
+**2026-08-21, the release job.** The original decision to stop calling `ktsubuild ci` rested on the claim that "`ktsubuild release` still handles pack, publish, and release, so no release automation is lost." Reading `CiCommand` against `ReleaseCommand` showed that false. `ci` does five things `release` does not: update and commit the metadata files, update the repository topics from TAGS.md, gate the release on the version increment (which is how `[skip ci]` works), honor a forced version bump, and write the four step outputs. `ReleaseService.ExecuteReleaseAsync` packs, publishes, and creates the GitHub release unconditionally once called, gated only on `ShouldRelease`, which means "on main, untagged, official repo" and nothing about whether the version moved.
+
+Dropping the step outputs would have silently disabled the `winget` and `security` jobs, since both gate on `should_release`. That is the failure mode this design exists to remove, so `ci` stays and gained two skip flags instead. Shipped in `ktsu.KtsuBuild.Tool` 2.3.0.
+
+**2026-08-21, the `security` job.** The original job graph omitted it. It exists, it is `needs: build`, and it consumes the same two outputs `winget` does.
 
 ## Sequence
 

--- a/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
+++ b/docs/superpowers/specs/2026-08-21-ci-parallel-test-matrix-design.md
@@ -49,7 +49,7 @@ The lever, if that cost bites before self-hosted runners land: build once per pl
 
 The workflow needs three things `ktsubuild` doesn't expose yet. All three are already implemented inside it — they're just not reachable from a command line. Reimplementing them in the workflow would put a second copy of each rule in a YAML file, and the second copy is the one that goes stale.
 
-**`ktsubuild test list --json`** emits the test projects with the platform each is tied to:
+**`ktsubuild test list`** emits the test projects with the platform each is tied to:
 
 ```json
 [
@@ -104,7 +104,7 @@ CI changes can't be proven by reasoning about YAML. Before this syncs anywhere:
 
 ## Sequence
 
-1. `KtsuBuild`: add `test list --json`, `test run --project`, and `build --no-test`. Release to nuget.org.
+1. `KtsuBuild`: add `test list`, `test run --project`, and `build --no-test`. Release to nuget.org.
 2. `ImGuiApp`: restructure `dotnet.yml` against the released tool. Validate on a branch.
 3. Sync to the other repos once the numbers from step 2 are known.
 


### PR DESCRIPTION
Replaces the serial windows-latest test run with a discover, matrix, release shape. Validation results are recorded in the plan's task 4.